### PR TITLE
Get rid of redundant recent_block_hashes entry

### DIFF
--- a/specs/beacon-chain.md
+++ b/specs/beacon-chain.md
@@ -157,8 +157,6 @@ The `ActiveState` has the following fields:
 
 ```python
 {
-    # Most recent 2 * CYCLE_LENGTH block hashes, oldest to newest
-    'recent_block_hashes': ['hash32'],
     # Attestations not yet processed
     'pending_attestations': [AttestationRecord],
     # Specials not yet been processed


### PR DESCRIPTION
### What's fixed
A tiny fix that removes duplicated `recent_block_hashes` in `ActiveState` structure description. 

Should be compatible with https://github.com/ethereum/eth2.0-specs/pull/44.