### PR TITLE
Remove multiple slots per committee option

### DIFF
--- a/specs/beacon-chain.md
+++ b/specs/beacon-chain.md
@@ -378,8 +378,6 @@ def clamp(minval: int, maxval: int, x: int) -> int:
         return maxval
     else:
         return x
-def clamp(minval, maxval, x):
-    return minval if x < minval else maxval if x > maxval else x
 ```
 
 Now, our combined helper method:


### PR DESCRIPTION
As discussed last week.

Rationale is that the `slots_per_committee > 1` case only appears when the validator count is less than 8192, or ETH deposited is less than 262144; in these cases, having smaller committees is not a big deal as the system is going to not be extremely secure in any case.