### PR TITLE
Remove remaining usage of dynasty

### DIFF
--- a/specs/beacon-chain.md
+++ b/specs/beacon-chain.md
@@ -492,6 +492,7 @@ def on_startup(initial_validator_entries: List[Any]) -> Tuple[CrystallizedState,
         for i in range(SHARD_COUNT)
     ]
     crystallized_state = CrystallizedState(
+        validator_set_change_slot=0,
         validators=validators,
         crosslinks=crosslinks,
         last_state_recalculation_slot=0,

--- a/specs/beacon-chain.md
+++ b/specs/beacon-chain.md
@@ -492,9 +492,6 @@ def on_startup(initial_validator_entries: List[Any]) -> Tuple[CrystallizedState,
         for i in range(SHARD_COUNT)
     ]
     crystallized_state = CrystallizedState(
-        dynasty=1,
-        dynasty_seed=bytes([0] * 32),  # stub
-        dynasty_start_slot=0,
         validators=validators,
         crosslinks=crosslinks,
         last_state_recalculation_slot=0,


### PR DESCRIPTION
Looks like it was accidentally brought back in after it was removed in an earlier commit.