### PR TITLE
Bug in update_ancestor_hashes?

### DIFF
--- a/specs/beacon-chain.md
+++ b/specs/beacon-chain.md
@@ -587,7 +587,7 @@ def update_ancestor_hashes(parent_ancestor_hashes: List[Hash32],
                            parent_hash: Hash32) -> List[Hash32]:
     new_ancestor_hashes = copy.copy(parent_ancestor_hashes)
     for i in range(32):
-        if parent_slot_number % 2**i == 0:
+        if parent_slot_number == 2**i:
             new_ancestor_hashes[i] = parent_hash
     return new_ancestor_hashes
 ```


### PR DESCRIPTION
Not sure if this is a bug. 

By checking `parent_slot_number % 2**i == 0`, all the parent hashes before i gets updated as well.

**For example:**
parent_slot_number: 32, parent_hash: 0xA
ancestor_hashes[0], [1], [2], [3], [4] will all have 0xA