### PR TITLE
docs(*): change eth2.0 to ethereum serenity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
-# Ethereum 2.0 Specifications
+# Ethereum Serenity Specifications
 
-This repo hosts the current eth2.0 specifications. Discussions about design rationale and proposed changes can be brought up and discussed as issues. Solidified, agreed upon changes to spec can be made through pull requests. 
+This repo hosts the current Ethereum Serenity specifications. Discussions about design rationale and proposed changes can be brought up and discussed as issues. Solidified, agreed upon changes to spec can be made through pull requests.
+
+### Table of Contents
+
+- [Beacon Chain](specs/beacon-chain.md)
+- [Simple Serialize](specs/simple-serialize.md)
+- [Test Format](specs/test-format.md)
+

--- a/specs/beacon-chain.md
+++ b/specs/beacon-chain.md
@@ -1,12 +1,12 @@
-# Ethereum 2.0 spec—Casper and sharding
+# Ethereum Serenity spec—Casper and sharding
 
-###### tags: `spec`, `eth2.0`, `casper`, `sharding`
+###### tags: `spec`, `eth2.0`, `serenity`, `casper`, `sharding`
 
 **NOTICE**: This document is a work-in-progress for researchers and implementers. It reflects recent spec changes and takes precedence over the [Python proof-of-concept implementation](https://github.com/ethereum/beacon_chain).
 
 ### Introduction
 
-At the center of Ethereum 2.0 is a system chain called the "beacon chain". The beacon chain stores and manages the set of active proof-of-stake validators. In the initial deployment phases of Ethereum 2.0 the only mechanism to become a validator is to make a fixed-size one-way ETH deposit to a registration contract on the Ethereum 1.0 PoW chain. Induction as a validator happens after registration transaction receipts are processed by the beacon chain and after a queuing process. Deregistration is either voluntary or done forcibly as a penalty for misbehavior.
+At the center of Ethereum Serenity is a system chain called the "beacon chain". The beacon chain stores and manages the set of active proof-of-stake validators. In the initial deployment phases of Ethereum Serenity the only mechanism to become a validator is to make a fixed-size one-way ETH deposit to a registration contract on the Ethereum 1.0 PoW chain. Induction as a validator happens after registration transaction receipts are processed by the beacon chain and after a queuing process. Deregistration is either voluntary or done forcibly as a penalty for misbehavior.
 
 The primary source of load on the beacon chain are "attestations". Attestations simultaneously attest to a shard block and a corresponding beacon chain block. A sufficient number of attestations for the same shard block create a "crosslink", confirming the shard segment up to that shard block into the beacon chain. Crosslinks also serve as infrastructure for asynchronous cross-shard communication.
 
@@ -82,7 +82,7 @@ The primary source of load on the beacon chain are "attestations". Attestations 
 
 ### PoW chain registration contract
 
-The initial deployment phases of Ethereum 2.0 are implemented without consensus changes to the PoW chain. A registration contract is added to the PoW chain to deposit ETH. This contract has a `registration` function which takes as arguments `pubkey`, `withdrawal_shard`, `withdrawal_address`, `randao_commitment` as defined in a `ValidatorRecord` below. A BLS `proof_of_possession` of types `bytes` is given as a final argument.
+The initial deployment phases of Ethereum Serenity are implemented without consensus changes to the PoW chain. A registration contract is added to the PoW chain to deposit ETH. This contract has a `registration` function which takes as arguments `pubkey`, `withdrawal_shard`, `withdrawal_address`, `randao_commitment` as defined in a `ValidatorRecord` below. A BLS `proof_of_possession` of types `bytes` is given as a final argument.
 
 The registration contract emits a log with the various arguments for consumption by the beacon chain. It does not do validation, pushing the registration logic to the beacon chain. In particular, the proof of possession (based on the BLS12-381 curve) is not verified by the registration contract.
 

--- a/specs/simple-serialize.md
+++ b/specs/simple-serialize.md
@@ -1,7 +1,7 @@
 # [WIP] SimpleSerialize (SSZ) Spec
 
 This is the **work in progress** document to describe `simpleserialize`, the
-current selected serialization method for Ethereum 2.0 using the Beacon Chain.
+current selected serialization method for Ethereum Serenity using the Beacon Chain.
 
 This document specifies the general information for serializing and
 deserializing objects and data types.

--- a/specs/test-format.md
+++ b/specs/test-format.md
@@ -1,6 +1,6 @@
 # General test format [WIP]
 
-This document defines the general YAML format to which all tests should conform. Testing specifications in Eth2.0 are still a work in progress. _Expect breaking changes_
+This document defines the general YAML format to which all tests should conform. Testing specifications in Ethereum Serenity are still a work in progress. _Expect breaking changes_
 
 ## ToC
 
@@ -9,7 +9,7 @@ This document defines the general YAML format to which all tests should conform.
 * [Example test suite](#example-test-suite)
 
 ## About
-Ethereum 2.0 uses YAML as the format for all cross client tests. This document describes at a high level the general format to which all test files should conform.
+Ethereum Serenity uses YAML as the format for all cross client tests. This document describes at a high level the general format to which all test files should conform.
 
 The particular formats of specific types of tests (test suites) are defined in separate documents.
 


### PR DESCRIPTION
```gherkin
Scenario: Table of contents on opening page
   When I open the repo
   Then I see a table of contents to spec pages

Scenario: Specification uses Ethereum Serenity as the name
   When I read the docs
   Then I see the project is referenced as "Ethereum Serenity"
```

### NOTES

- It was announced at Devcon4 that Eth2.0 is no longer to be referred to as Shasper. Sorry Mr ShasperMcShardface

### CUTE ANIMAL PICTURE
![hyena-prelena-soma-owen-elephant-plains-sabie1](https://user-images.githubusercontent.com/183140/47813962-c8beca80-dd4c-11e8-88d8-1bfd05c4b1ee.jpg)
