### PR TITLE
Changed crosslink mechanics

### DIFF
--- a/specs/beacon-chain.md
+++ b/specs/beacon-chain.md
@@ -824,8 +824,8 @@ def change_validators(validators: List[ValidatorRecord]) -> None:
 
 * Set `shard_and_committee_for_slots[:CYCLE_LENGTH] = shard_and_committee_for_slots[CYCLE_LENGTH:]`
 * Let `time_since_finality = block.slot - crystallized_state.validator_set_change_slot`
-* Let `next_start_shard = (shard_and_committee_for_slots[-1][-1].shard + 1) % SHARD_COUNT`
-* If `time_since_finality * CYCLE_LENGTH <= MIN_VALIDATOR_SET_CHANGE_INTERVAL` or `time_since_finality` is an exact power of 2, set `shard_and_committee_for_slots[CYCLE_LENGTH:] = get_new_shuffling(crystallized_state.next_shuffling_seed, validators, next_start_shard)` and set `crystallized_state.next_shuffling_seed = active_state.randao_mix`. Do NOT update `next_start_shard`.
+* Let `start_shard = shard_and_committee_for_slots[0][0].shard`
+* If `time_since_finality * CYCLE_LENGTH <= MIN_VALIDATOR_SET_CHANGE_INTERVAL` or `time_since_finality` is an exact power of 2, set `shard_and_committee_for_slots[CYCLE_LENGTH:] = get_new_shuffling(crystallized_state.next_shuffling_seed, validators, start_shard)` and set `crystallized_state.next_shuffling_seed = active_state.randao_mix`. Note that `start_shard` is not changed from last cycle.
 
 #### Finally...
 


### PR DESCRIPTION
Makes the following changes:

* Multiple crosslinks for one shard can happen between validator set transitions.
* Validator reshuffling now only happens at all in three cases: (i) during a validator set transition, (ii) during the 4 cycles after a validator set transition, (iii) after an exact power of 2 of cycles after a validator set transition.

This ensures that (i) no committee that is selected has an infinite amount of time to coordinate on an attack, as eventually the next power of 2 is reached, and (ii) every committee must process the shard chain at most twice as fast as the shard chain's progress, as if it is selected at time T + 2^k then it has the 2^k-sized backlog to process from [T...T+2^k] as well as the new data from [T+2^k....T+2^(k+1)] before its deadline at time T + 2^(k+1).