### PR TITLE
Implementation of alternate withdrawal mechanism (issue #91)

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -828,7 +828,7 @@ Additionally, verify and update the RANDAO reveal. This is done as follows:
 * Verify that `repeat_hash(block.randao_reveal, (block.slot - V.randao_last_change) // RANDAO_SLOTS_PER_LAYER + 1) == V.randao_commitment`
 * Set `state.randao_mix = xor(state.randao_mix, block.randao_reveal)`, `V.randao_commitment = block.randao_reveal`, `V.randao_last_change = block.slot`
 
-Finally, if `block.candidate_pow_hash_chain_tip = crystallized_state.candidate_pow_hash_chain_tip`, set `crystallized_state.candidate_hash_chain_tip_votes += 1`.
+Finally, if `block.candidate_pow_hash_chain_tip = state.candidate_pow_hash_chain_tip`, set `state.candidate_hash_chain_tip_votes += 1`.
 
 ### Process penalties, logouts and other special objects
 
@@ -965,9 +965,9 @@ For every shard number `shard` for which a crosslink committee exists in the cyc
 
 If `last_state_recalculation_slot % POW_HASH_VOTING_PERIOD == 0`, then:
 
-* If `crystallized_state.candidate_hash_chain_tip_votes * 3 >= POW_HASH_VOTING_PERIOD * 2`, set `crystallized_state.hash_chain_tip = crystallized_state.candidate_hash_chain_tip`
-* Set `crystallized_state.candidate_hash_chain_tip = block.candidate_pow_hash_chain_tip`
-* Set `crystallized_state.candidate_hash_chain_tip_votes = 0`
+* If `state.candidate_hash_chain_tip_votes * 3 >= POW_HASH_VOTING_PERIOD * 2`, set `state.hash_chain_tip = state.candidate_hash_chain_tip`
+* Set `state.candidate_hash_chain_tip = block.candidate_pow_hash_chain_tip`
+* Set `state.candidate_hash_chain_tip_votes = 0`
 
 ### Validator set change
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -628,6 +628,7 @@ def on_startup(initial_validator_entries: List[Any], genesis_time: uint64, pow_h
         deposits_penalized_in_period=[],
         next_shuffling_seed=b'\x00'*32,
         validator_set_delta_hash_chain=bytes([0] * 32),  # stub
+        current_exit_seq=0,
         genesis_time=genesis_time,
         known_pow_hash_chain_tip=pow_hash_chain_tip,
         processed_pow_hash_chain_tip=pow_hash_chain_tip,

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -707,8 +707,8 @@ def add_validator(validators: List[ValidatorRecord],
 def exit_validator(index, state, penalize, current_slot):
     validator = state.validators[index]
     validator.exit_slot = current_slot
-    validator.exit_seq = crystallized_state.current_exit_seq
-    crystallized_state.current_exit_seq += 1
+    validator.exit_seq = state.current_exit_seq
+    state.current_exit_seq += 1
     if penalize:
         validator.status = PENALIZED
         state.deposits_penalized_in_period[current_slot // COLLECTIVE_PENALTY_CALCULATION_PERIOD] += validator.balance


### PR DESCRIPTION
See https://github.com/ethereum/eth2.0-specs/issues/91 for description, and https://ethresear.ch/t/suggested-average-case-improvements-to-reduce-capital-costs-of-being-a-casper-validator/3844 for more theoretical discussion.

Possible alternatives: make `WITHDRAWALS_PER_CYCLE` a function of deposits, proportional linearly or to the square root.

Some more numbers on how long it would take X ETH to withdraw assuming no one else is withdrawing:

* 32 ETH: 65536 sec ~= 18 hours
* 16384 ETH: 65536 sec ~= 18 hours
* 100k ETH: 400k sec ~= 3 days
* 1m ETH: 4m sec ~= 44 days