### PR TITLE
extend ssz hash type to arbitrary lengths

### DIFF
--- a/specs/simple-serialize.md
+++ b/specs/simple-serialize.md
@@ -117,7 +117,7 @@ return value
 |:---------------------------------------|:---------------------|
 | Length in bytes is correct for `hashN` | ``len(value) == N``  |
 
-##### Example for arbitrary hashN
+##### HashN
 
 ```python
 assert(len(value) == N)
@@ -297,7 +297,6 @@ return rawbytes[current_index:current_index+20], new_index
 ```
 
 #### Hash
-
 
 ##### HashN
 

--- a/specs/simple-serialize.md
+++ b/specs/simple-serialize.md
@@ -298,6 +298,17 @@ return rawbytes[current_index:current_index+20], new_index
 
 #### Hash
 
+
+##### HashN
+
+Return the N bytes.
+
+```python
+assert(len(rawbytes) >= current_index + N)
+new_index = current_index + N
+return rawbytes[current_index:current_index+N], new_index
+```
+
 ##### Hash32
 
 Return the 32 bytes.

--- a/specs/simple-serialize.md
+++ b/specs/simple-serialize.md
@@ -16,9 +16,6 @@ deserializing objects and data types.
       - [uint: 8/16/24/32/64/256](#uint-816243264256)
       - [Address](#address)
       - [Hash](#hash)
-         * [Hash32](#hash32)
-         * [Hash96](#hash96)
-         * [Hash97](#hash97)
       - [Bytes](#bytes)
       - [List/Vectors](#listvectors)
       - [Container](#container)
@@ -26,9 +23,6 @@ deserializing objects and data types.
       - [uint: 8/16/24/32/64/256](#uint-816243264256-1)
       - [Address](#address-1)
       - [Hash](#hash-1)
-         * [Hash32](#hash32-1)
-         * [Hash96](#hash96-1)
-         * [Hash97](#hash97-1)
       - [Bytes](#bytes-1)
       - [List/Vectors](#listvectors-1)
       - [Container](#container-1)
@@ -116,26 +110,17 @@ return value
 |  `hash32` | Hash size of ``keccak`` or `blake2b[0.. < 32]`. |
 |  `hash96` | BLS Public Key Size.                            |
 |  `hash97` | BLS Public Key Size with recovery bit.          |
+|  `hashN`  | Hash of arbitrary length N                      |
 
 
-| Checks to perform                   | Code                 |
-|:-----------------------------------|:---------------------|
-| Length is correct (32) if `hash32` | ``len(value) == 32`` |
-| Length is correct (96) if `hash96` | ``len(value) == 96`` |
-| Length is correct (97) if `hash97` | ``len(value) == 97`` |
+| Checks to perform                      | Code                 |
+|:---------------------------------------|:---------------------|
+| Length in bytes is correct for `hashN` | ``len(value) == N``  |
 
-
-**Example all together**
+##### Example for arbitrary hashN
 
 ```python
-if (type(value) == 'hash32'):
-   assert(len(value) == 32)
-elif (type(value) == 'hash96'):
-   assert(len(value) == 96)
-elif (type(value) == 'hash97'):
-   assert(len(value) == 97)
-else:
-   raise TypeError('Invalid hash type supplied')
+assert(len(value) == N)
 
 return value
 ```

--- a/specs/simple-serialize.md
+++ b/specs/simple-serialize.md
@@ -91,7 +91,7 @@ return b'\x01' if value is True else b'\x00'
 
 #### Address
 
-The address should already come as a hash/byte format. Ensure that length is
+The `address` should already come as a hash/byte format. Ensure that length is
 **20**.
 
 | Check to perform       | Code                 |
@@ -107,17 +107,14 @@ return value
 
 | Hash Type | Usage                                           |
 |:---------:|:------------------------------------------------|
-|  `hash32` | Hash size of ``keccak`` or `blake2b[0.. < 32]`. |
-|  `hash96` | BLS Public Key Size.                            |
-|  `hash97` | BLS Public Key Size with recovery bit.          |
-|  `hashN`  | Hash of arbitrary byte length, N                |
+|  `hashN`  | Hash of arbitrary byte length `N`.              |
 
 
 | Checks to perform                      | Code                 |
 |:---------------------------------------|:---------------------|
 | Length in bytes is correct for `hashN` | ``len(value) == N``  |
 
-##### HashN
+##### hashN
 
 ```python
 assert(len(value) == N)
@@ -125,36 +122,9 @@ assert(len(value) == N)
 return value
 ```
 
-##### Hash32
-
-Ensure 32 byte length and return the bytes.
-
-```python
-assert(len(value) == 32)
-return value
-```
-
-##### Hash96
-
-Ensure 96 byte length and return the bytes.
-
-```python
-assert(len(value) == 96)
-return value
-```
-
-##### Hash97
-
-Ensure 97 byte length and return the bytes.
-
-```python
-assert(len(value) == 97)
-return value
-```
-
 #### Bytes
 
-For general `byte` type:
+For general `bytes` type:
 1. Get the length/number of bytes; Encode into a `4-byte` integer.
 2. Append the value to the length and return: ``[ length_bytes ] + [
    value_bytes ]``
@@ -298,46 +268,15 @@ return rawbytes[current_index:current_index+20], new_index
 
 #### Hash
 
-##### HashN
+##### hashN
 
-Return the N bytes.
+Return the `N` bytes.
 
 ```python
 assert(len(rawbytes) >= current_index + N)
 new_index = current_index + N
 return rawbytes[current_index:current_index+N], new_index
 ```
-
-##### Hash32
-
-Return the 32 bytes.
-
-```python
-assert(len(rawbytes) >= current_index + 32)
-new_index = current_index + 32
-return rawbytes[current_index:current_index+32], new_index
-```
-
-##### Hash96
-
-Return the 96 bytes.
-
-```python
-assert(len(rawbytes) >= current_index + 96)
-new_index = current_index + 96
-return rawbytes[current_index:current_index+96], new_index
-```
-
-##### Hash97
-
-Return the 97 bytes.
-
-```python
-assert(len(rawbytes) >= current_index + 97)
-new_index = current_index + 97
-return rawbytes[current_index:current_index+97], new_index
-```
-
 
 #### Bytes
 


### PR DESCRIPTION
addresses #50 
Make the hash type in SSZ allow for arbitrary byte length, `N`, for `hashN`


I left the examples of hash32, hash96, and hash97. I can pull them out if we think it's overkill