### PR TITLE
Remove MIN_BALANCE definition

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -34,7 +34,6 @@ The primary source of load on the beacon chain are "attestations". Attestations 
 | --- | --- | :---: | - |
 | `SHARD_COUNT` | 2**10 (= 1,024)| shards |
 | `DEPOSIT_SIZE` | 2**5 (= 32) | ETH |
-| `MIN_BALANCE` | 2**4 (= 16) | ETH |
 | `MIN_ONLINE_DEPOSIT_SIZE` | 2**4 (= 16) | ETH |
 | `GWEI_PER_ETH` | 10**9 | Gwei/ETH |
 | `TARGET_COMMITTEE_SIZE` | 2**8 (= 256) | validators |


### PR DESCRIPTION
`MIN_BALANCE` is not used - I'm guessing it was replaced by `MIN_ONLINE_DEPOSIT_SIZE`.