### PR TITLE
simplify merkle tree chunking

### DIFF
--- a/specs/simple-serialize.md
+++ b/specs/simple-serialize.md
@@ -427,7 +427,7 @@ def merkle_hash(lst):
         chunkz = [hash(chunkz[i] + chunkz[i+1]) for i in range(0, len(chunkz), 2)]
 
     # Return hash of root and length data
-    return hash((chunkz[0] + datalen)
+    return hash(chunkz[0] + datalen)
 ```
 
 To `tree_hash` a list, we simply do:


### PR DESCRIPTION
* pack small items tightly to fit more items in single chunk, decreasing
the number of hash operations needed
* remove chunk padding - hash algorithm will pad to its own block size
anyway
* express data length in number of items instead of binary bytes at leaf
level (equivalent)