### PR TITLE
Add proofs of custody

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -877,7 +877,7 @@ Verify that there are at most `MAX_SPECIALS_PER_BLOCK` objects in `block.special
 
 For each `SpecialRecord` `obj` in `block.specials`, verify that its `kind` is one of the below values, and that `obj.data` deserializes according to the format for the given `kind`, then process it. The word "verify" when used below means that if the given verification check fails, the block containing that `SpecialRecord` is invalid.
 
-We define the following object `SpecialAttestationData` and helper `verify_special_attesation_data`:
+We define the following object `SpecialAttestationData` and helper `verify_special_attestation_data`:
 
 ```python
 {
@@ -889,7 +889,7 @@ We define the following object `SpecialAttestationData` and helper `verify_speci
 ```
 
 ```python
-def verify_special_attesation_data(state: State, obj: SpecialAttestationData) -> bool:
+def verify_special_attestation_data(state: State, obj: SpecialAttestationData) -> bool:
     pubs = [aggregate_pubkey([validators[i].pubkey for i in obj.aggregate_sig_poc_0_indices]),
             aggregate_pubkey([validators[i].pubkey for i in obj.aggregate_sig_poc_1_indices])]
     assert obj.voteproof_of_custody_hash_mod_2 == False
@@ -926,11 +926,11 @@ Perform the following checks:
 
 * Run and check `verify_special_attestation_data` on both votes.
 * Verify that `vote1.data != vote2.data`.
-* Let `indices(vote) = vote.aggregate_sig_poc_0_indices + vote.aggregate_sig_poc_1_indices`
+* Let `indices(vote) = vote.aggregate_sig_poc_0_indices + vote.aggregate_sig_poc_1_indices`.
 * Let `intersection = [x for x in indices(vote1) if x in indices(vote2)]`. Verify that `len(intersection) >= 1`.
-* Verify that either `vote1.data.justified_slot + 1 < vote2.data.justified_slot + 1 == vote2.data.slot < vote1.data.slot` or `vote1.data.slot == vote2.data.slot`
+* Verify that either `vote1.data.justified_slot + 1 < vote2.data.justified_slot + 1 == vote2.data.slot < vote1.data.slot` or `vote1.data.slot == vote2.data.slot`.
 
-For each validator index `v` in `intersection`, if `state.validators[v].status` does not equal `PENALIZED`, then run `exit_validator(v, state, penalize=True, current_slot=block.slot)`
+For each validator index `v` in `intersection`, if `state.validators[v].status` does not equal `PENALIZED`, then run `exit_validator(v, state, penalize=True, current_slot=block.slot)`.
 
 #### DEPOSIT_PROOF
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -328,7 +328,7 @@ A `ProofOfCustodyChallenge` has the following fields:
     # Expiry date
     'expiry_slot': 'uint64',
     # Who is challenging
-    'challenger_indexz': 'uint64',
+    'challenger_index': 'uint64',
     # Proof of custody bit
     'bit': 'bool'
 }
@@ -1225,7 +1225,7 @@ Note: This spec is ~65% complete.
 * [ ] Specify the deposit contract on the PoW chain in Vyper
 * [ ] Specify the beacon chain genesis rules ([issue 58](https://github.com/ethereum/eth2.0-specs/issues/58))
 * [ ] Specify the logic for proofs of custody, including slashing conditions
-* [ ] Specify BLSVerify and rework the spec for BLS12-381 throughout
+* [ ] Specify BLSVerify, BLSMultiVerify, BLSAddPubkeys and rework the spec for BLS12-381 throughout
 * [ ] Specify the constraints for `SpecialRecord`s ([issue 43](https://github.com/ethereum/eth2.0-specs/issues/43))
 * [ ] Specify the calculation and validation of `BeaconBlock.state_root`
 * [ ] Undergo peer review, security audits and formal verification

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -43,7 +43,7 @@ The primary source of load on the beacon chain are "attestations". Attestations 
 | `CYCLE_LENGTH` | 2**6 (= 64) | slots | ~6 minutes |
 | `MIN_VALIDATOR_SET_CHANGE_INTERVAL` | 2**8 (= 256) | slots | ~25 minutes |
 | `SHARD_PERSISTENT_COMMITTEE_CHANGE_PERIOD` | 2**17 (= 131,072) | slots | ~9 days |
-| `PROOF_OF_CUSTODY_MIN_CHANGE_PERIOD` | 2**18 | (= 65,536) | slots | ~18 days |
+| `PROOF_OF_CUSTODY_MIN_CHANGE_PERIOD` | 2**17 | (= 65,536) | slots | ~9 days |
 | `PROOF_OF_CUSTODY_RESPONSE_DEADLINE` | 2**20 (= 524,288) | slots | ~73 days |
 | `MIN_ATTESTATION_INCLUSION_DELAY` | 2**2 (= 4) | slots | ~24 seconds |
 | `RANDAO_SLOTS_PER_LAYER` | 2**12 (= 4096) | slots | ~7 hours |

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -966,7 +966,7 @@ For each `AttestationRecord` object `obj`:
 * `aggregate_sig` verification:
     * Let `bit_0_participants = get_attestation_participants(state, obj.data, obj.attester_bitfield, obj.poc_bitfield, 0)` and `bit_1_participants = get_attestation_participants(state, obj.data, obj.attester_bitfield, obj.poc_bitfield, 1)`
     * Let `group_public_key_0 = BLSAddPubkeys([state.validators[v].pubkey for v in bit_0_participants])` and `group_public_key_1 = BLSAddPubkeys([state.validators[v].pubkey for v in bit_1_participants])`
-    * Check `BLSMultiVerify(pubkeys=[group_public_key_0, group_public_key_1], msgs=[hash(obj.data)+bytes1(0), hash(obj.data)+bytes1(1)], sig=aggregate_sig, domain=get_domain(state.fork_data, slot, DOMAIN_ATTESTATION))`.
+    * Check `BLSMultiVerify(pubkeys=[group_public_key_0, group_public_key_1], msgs=[SSZTreeHash(obj.data)+bytes1(0), SSZTreeHash(obj.data)+bytes1(1)], sig=aggregate_sig, domain=get_domain(state.fork_data, slot, DOMAIN_ATTESTATION))`.
 * [TO BE REMOVED IN PHASE 1] Verify that `shard_block_hash == bytes([0] * 32)`.
 * Append `ProcessedAttestation(data=obj.data, attester_bitfield=obj.attester_bitfield, poc_bitfield=obj.poc_bitfield, slot_included=block.slot)` to `state.pending_attestations`.
 
@@ -1018,7 +1018,7 @@ We define the following object `SpecialAttestationData` and helper `verify_speci
 def verify_special_attestation_data(state: State, obj: SpecialAttestationData) -> bool:
     pubs = [aggregate_pubkey([state.validators[i].pubkey for i in obj.aggregate_sig_poc_0_indices]),
             aggregate_pubkey([state.validators[i].pubkey for i in obj.aggregate_sig_poc_1_indices])]
-    return BLSMultiVerify(pubkeys=pubs, msgs=[hash(obj)+bytes1(0), hash(obj)+bytes1(1), sig=aggregate_sig)`
+    return BLSMultiVerify(pubkeys=pubs, msgs=[SSZTreeHash(obj)+bytes1(0), SSZTreeHash(obj)+bytes1(1), sig=aggregate_sig)`
 ```
 
 #### LOGOUT
@@ -1066,7 +1066,7 @@ For each validator index `v` in `intersection`, if `state.validators[v].status` 
     'proposal1_signature': '[uint384]',
 }
 ```
-For each `proposal_signature`, verify that `BLSVerify(pubkey=validators[proposer_index].pubkey, msg=hash(proposal_data), sig=proposal_signature, domain=get_domain(state.fork_data, proposal_data.slot, DOMAIN_PROPOSAL))` passes. Verify that `proposal1_data.slot == proposal2_data.slot` but `proposal1 != proposal2`. If `state.validators[proposer_index].status` does not equal `PENALIZED`, then run `exit_validator(proposer_index, state, penalize=True, current_slot=block.slot)`
+For each `proposal_signature`, verify that `BLSVerify(pubkey=validators[proposer_index].pubkey, msg=SSZTreeHash(proposal_data), sig=proposal_signature, domain=get_domain(state.fork_data, proposal_data.slot, DOMAIN_PROPOSAL))` passes. Verify that `proposal1_data.slot == proposal2_data.slot` but `proposal1 != proposal2`. If `state.validators[proposer_index].status` does not equal `PENALIZED`, then run `exit_validator(proposer_index, state, penalize=True, current_slot=block.slot)`
 
 #### DEPOSIT_PROOF
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1382,11 +1382,6 @@ def get_changed_validators(validators: List[ValidatorRecord],
         if total_changed >= max_allowable_change:
             break
 
-    # Penalize validators that have not responded to proof of custody challenges long enough
-    while len(state.proof_of_custody_challenges) and current_slot > state.proof_of_custody_challenges[0].expiry_slot:
-        exit_validator(state.proof_of_custody_challenges[0].responder_index, state, True, current_slot)
-        state.proof_of_custody_challenges.pop(0)
-
     # Calculate the total ETH that has been penalized in the last ~2-3 withdrawal periods
     period_index = current_slot // COLLECTIVE_PENALTY_CALCULATION_PERIOD
     total_penalties = (

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1111,9 +1111,9 @@ def change_validators(state: State, current_slot: int) -> None:
             break
 
     # Penalize validators that have not responded to proof of custody challenges long enough
-    while len(state.challenges) and current_slot > state.challenges[0].expiry_slot:
-        exit_validator(state.challenges[0].responder_index, state, True, current_slot)
-        state.challenges.pop(0)
+    while len(state.proof_of_custody_challenges) and current_slot > state.proof_of_custody_challenges[0].expiry_slot:
+        exit_validator(state.proof_of_custody_challenges[0].responder_index, state, True, current_slot)
+        state.proof_of_custody_challenges.pop(0)
 
     # Calculate the total ETH that has been penalized in the last ~2-3 withdrawal periods
     period_index = current_slot // WITHDRAWAL_PERIOD
@@ -1127,7 +1127,7 @@ def change_validators(state: State, current_slot: int) -> None:
     for i in range(len(validators)):
         if validators[i].status in (PENDING_WITHDRAW, PENALIZED) and \
                 current_slot >= validators[i].exit_slot + WITHDRAWAL_PERIOD and \
-                len([c in state.challenges if c.responder_index == i]) == 0:
+                len([c in state.proof_of_custody_challenges if c.responder_index == i]) == 0:
             if validators[i].status == PENALIZED:
                 validators[i].balance -= validators[i].balance * min(total_penalties * 3, total_balance) // total_balance
             validators[i].status = WITHDRAWN

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -84,9 +84,6 @@ The primary source of load on the beacon chain are "attestations". Attestations 
 | `CASPER_SLASHING` | `1` | `16` |
 | `PROPOSER_SLASHING` | `2` | `16` |
 | `DEPOSIT_PROOF` | `3` | `16` |
-| `PROOF_OF_CUSTODY_SEED_CHANGE` | `4` | `16` |
-| `PROOF_OF_CUSTODY_CHALLENGE` | `5` | `16` |
-| `PROOF_OF_CUSTODY_RESPONSE` | `6` | `16` |
 
 **Validator set delta flags**
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1142,7 +1142,6 @@ For each `special` in `block.specials`, perform the appropriate check based on i
 
 #### `VOLUNTARY_EXIT`
 
-
 ```python
 {
     'slot': 'unit64',

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -135,7 +135,7 @@ An `AttestationRecord` has the following fields:
     # Slot number
     'slot': 'uint64',
     # Shard number
-    'shard': 'uint16',
+    'shard': 'uint64',
     # Beacon block hashes not part of the current chain, oldest to newest
     'oblique_parent_hashes': ['hash32'],
     # Shard block hash being attested to
@@ -294,7 +294,7 @@ A `ShardAndCommittee` object has the following fields:
 ```python
 {
     # Shard number
-    'shard': 'uint16',
+    'shard': 'uint64',
     # Validator indices
     'committee': ['uint24']
 }
@@ -307,7 +307,7 @@ A `ShardReassignmentRecord` object has the following fields:
     # Which validator to reassign
     'validator_index': 'uint24',
     # To which shard
-    'shard': 'uint16',
+    'shard': 'uint64',
     # When
     'slot': 'uint64'
 }

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -232,7 +232,7 @@ The `BeaconState` has the following fields:
     # Persistent shard committees
     'persistent_committees': [['uint24']],
     'persistent_committee_reassignments': [ShardReassignmentRecord],
-    # Open proof of custody challenges
+    # Open proof of custody challenges; NOTE: must remain empty in phase 0
     'proof_of_custody_challenges': [ProofOfCustodyChallenge],
     # Randao seed used for next shuffling
     'next_shuffling_seed': 'hash32',
@@ -326,29 +326,6 @@ A `ShardReassignmentRecord` object has the following fields:
     'shard': 'uint64',
     # When
     'slot': 'uint64'
-}
-```
-
-A `ProofOfCustodyChallenge` has the following fields:
-
-```python
-{
-    # Which validator is responding
-    'responder_index': 'uint64',
-    # Seed hash
-    'seed_hash': 'hash32',
-    # Depth
-    'depth': 'uint64',
-    # Index in tree
-    'data_index': 'uint64',
-    # Expiry date
-    'expiry_slot': 'uint64',
-    # Who is challenging
-    'challenger_index': 'uint64',
-    # Data root
-    'data_root': 'hash32',
-    # Proof of custody bit
-    'bit': 'bool'
 }
 ```
 

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -222,3 +222,21 @@ Perform the following checks:
 * Verify that `uint256(root) % 2 == challenge.bit`.
 
 Remove `challenge` from `state.proof_of_custody_challenges` (note: if a block has multiple `PROOF_OF_CUSTODY_RESPONSE` objects , later objects' `challenge_index` values will need to take removals from earlier objects into account).
+
+#### Add withdrawals
+
+Add to `exit_validators`
+
+```python
+    # Separate loop to withdraw validators that have been logged out for long enough, and
+    # calculate their penalties if they were slashed
+    # Do not allow validators to leave if they have unanswered PoC challenges, unless the
+    # validator voluntarily "surrenders" by slashing themselves
+    def withdrawable(v):
+        return (
+            v.status in (PENDING_WITHDRAW, PENALIZED) and \
+            current_slot >= v.exit_slot + MIN_WITHDRAWAL_PERIOD and \
+            (v.status == PENALIZED or len([c in state.proof_of_custody_challenges if c.responder_index == i]) == 0)
+        )    
+        
+```

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -18,7 +18,7 @@ Phase 1 depends upon all of the constants defined in [Phase 0](0_beacon-chain.md
 
 | Constant               | Value           | Unit  | Approximation |
 |------------------------|-----------------|-------|---------------|
-| `CHUNK_SIZE`           | 2**8 (= 256)    | bytes |               |
+| `SHARD_CHUNK_SIZE`     | 2**8 (= 256)    | bytes |               |
 | `SHARD_BLOCK_SIZE`     | 2**14 (= 16384) | bytes |               |
 | `PROOF_OF_CUSTODY_MIN_CHANGE_PERIOD` | 2**17 | (= 65,536) | slots | ~9 days |
 | `PROOF_OF_CUSTODY_RESPONSE_DEADLINE` | 2**20 (= 524,288) | slots | ~73 days |

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -197,7 +197,8 @@ Perform the following checks:
 * Let `FULL_PROOF_OF_CUSTODY_VALCOUNT = TARGET_COMMITEE_SIZE * SHARD_COUNT`, and `target = 2**256 * attestation.total_validator_count // FULL_PROOF_OF_CUSTODY_VALCOUNT`.
 * Verify that `check_value <= target`.
 
-Let `seed_hash = state.validators[index].proof_of_custody_commitment if attestation.slot > state.validators[index].proof_of_custody_last_change else hash(state.validators[index].proof_of_custody_commitment)`. Append to `state.proof_of_custody_challenges` the object `ProofOfCustodyChallenge(responder_index=validator_index, seed_hash=seed_hash, depth=attestation.proof_of_custody_depth, data_root=attestation.data.shard_block_hash, data_index=data_index, expiry_slot=block.slot+PROOF_OF_CUSTODY_RESPONSE_DEADLINE, challenger_index=get_proposer(state, block), bit=bit)`.
+* Let `seed_hash = state.validators[index].proof_of_custody_commitment if attestation.slot > state.validators[index].proof_of_custody_last_change else hash(state.validators[index].proof_of_custody_commitment)`.
+* Append to `state.proof_of_custody_challenges` the object `ProofOfCustodyChallenge(responder_index=validator_index, seed_hash=seed_hash, depth=attestation.proof_of_custody_depth, data_root=attestation.data.shard_block_hash, data_index=data_index, expiry_slot=block.slot+PROOF_OF_CUSTODY_RESPONSE_DEADLINE, challenger_index=get_proposer(state, block), bit=bit)`.
 
 A block can have maximum one proof of custody challenge, and it must appear before all `PROOF_OF_CUSTODY_SEED_CHANGE` objects.
 

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -136,7 +136,7 @@ The fork choice rule for any shard is LMD GHOST using the validators currently a
 
 Change to attestation verification:
 
-* Let `expected_depth = log2(SHARD_BLOCK_SIZE // SHARD_CHUNK_SIZE * next_power_of_2(slot - last_crosslink_slot))`. For each integer `i = 0, 1`, let `messages[i]` be `AttestationSignedData(slot, shard, parent_hashes, shard_block_hash, i == 1, expected_depth, attestation_indices.total_validator_count, justified_slot)`.
+* Let `expected_depth = log2(SHARD_BLOCK_SIZE // SHARD_CHUNK_SIZE * next_power_of_2(slot - last_crosslink_slot))`. For each integer `i = 0, 1`, let `messages[i]` be `AttestationData(slot, shard, parent_hashes, shard_block_hash, expected_depth, attestation_indices.total_validator_count, justified_slot)`.
 
 A `ProofOfCustodyChallenge` has the following fields:
 

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -131,6 +131,31 @@ Change to attestation verification:
 
 * Let `expected_depth = log2(SHARD_BLOCK_SIZE // SHARD_CHUNK_SIZE * next_power_of_2(slot - last_crosslink_slot))`. For each integer `i = 0, 1`, let `messages[i]` be `AttestationSignedData(slot, shard, parent_hashes, shard_block_hash, i == 1, expected_depth, attestation_indices.total_validator_count, justified_slot)`.
 
+A `ProofOfCustodyChallenge` has the following fields:
+
+```python
+{
+    # Which validator is responding
+    'responder_index': 'uint64',
+    # Seed hash
+    'seed_hash': 'hash32',
+    # Depth
+    'depth': 'uint64',
+    # Index in tree
+    'data_index': 'uint64',
+    # Expiry date
+    'expiry_slot': 'uint64',
+    # Who is challenging
+    'challenger_index': 'uint64',
+    # Data root
+    'data_root': 'hash32',
+    # Proof of custody bit
+    'bit': 'bool'
+}
+```
+
+
+
 Three new types of `SpecialObject` records:
 
 #### PROOF_OF_CUSTODY_SEED_CHANGE

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -19,7 +19,16 @@ Phase 1 depends upon all of the constants defined in [Phase 0](0_beacon-chain.md
 | Constant               | Value           | Unit  | Approximation |
 |------------------------|-----------------|-------|---------------|
 | `CHUNK_SIZE`           | 2**8 (= 256)    | bytes |               |
-| `MAX_SHARD_BLOCK_SIZE` | 2**15 (= 32768) | bytes |               |
+| `SHARD_BLOCK_SIZE`     | 2**14 (= 16384) | bytes |               |
+| `PROOF_OF_CUSTODY_MIN_CHANGE_PERIOD` | 2**17 | (= 65,536) | slots | ~9 days |
+| `PROOF_OF_CUSTODY_RESPONSE_DEADLINE` | 2**20 (= 524,288) | slots | ~73 days |
+
+### Flags, domains, etc.
+
+| Constant               | Value           |
+|------------------------|-----------------|
+| `SHARD_PROPOSER_DOMAIN`| 129             |
+| `SHARD_ATTESTER_DOMAIN`| 130             |
 
 ## Data Structures
 
@@ -43,9 +52,11 @@ A `ShardBlock` object has the following fields:
     'data_root': 'hash32'
     # State root (placeholder for now)
     'state_root': 'hash32',
-    # Attestation (including block signature)
+    # Block signature
+    'signature': ['uint384'],
+    # Attestation
     'attester_bitfield': 'bytes',
-    'aggregate_sig': ['uint256'],
+    'aggregate_sig': ['uint384'],
 }
 ```
 
@@ -61,31 +72,27 @@ To validate a block header on shard `shard_id`, compute as follows:
 * Verify that `beacon_chain_ref` is the hash of a block in the beacon chain with slot less than or equal to `slot`. Verify that `beacon_chain_ref` is equal to or a descendant of the `beacon_chain_ref` specified in the `ShardBlock` pointed to by `parent_hash`.
 * Let `state` be the state of the beacon chain block referred to by `beacon_chain_ref`. Let `validators` be `[validators[i] for i in state.current_persistent_committees[shard_id]]`.
 * Assert `len(attester_bitfield) == ceil_div8(len(validators))`
-* Let `curblock_proposer_index = hash(state.randao_mix + bytes8(shard_id) + bytes8(slot)) % len(validators)`. Let `parent_proposer_index` be the same value calculated for the parent block.
-* Make sure that the `parent_proposer_index`'th bit in the `attester_bitfield` is set to 1.
-* Generate the group public key by adding the public keys of all the validators for whom the corresponding position in the bitfield is set to 1. Verify the `aggregate_sig` using this as the pubkey and the `parent_hash` as the message.
+* Let `proposer_index = hash(state.randao_mix + bytes8(shard_id) + bytes8(slot)) % len(validators)`. Let `msg` be the block but with the `block.signature` set to `[0, 0]`. Verify that `BLSVerify(pub=validators[proposer_index].pubkey, msg=hash(msg), sig=block.signature, domain=get_domain(state, slot, SHARD_PROPOSER_DOMAIN))` passes.
+* Generate the `group_public_key` by adding the public keys of all the validators for whom the corresponding position in the bitfield is set to 1. Verify that `BLSVerify(pub=group_public_key, msg=parent_hash, sig=block.aggregate_sig, domain=get_domain(state, slot, SHARD_ATTESTER_DOMAIN))` passes.
+
+### Block Merklization helper
+
+```python
+def merkle_root(block_body):
+    assert len(block_body) == SHARD_BLOCK_SIZE
+    chunks = SHARD_BLOCK_SIZE // CHUNK_SIZE
+    o = [0] * chunks + [block_body[i * CHUNK_SIZE: (i+1) * CHUNK_SIZE] for i in range(chunks)]
+    for i in range(chunks-1, 0, -1):
+        o[i] = hash(o[i*2] + o[i*2+1])
+    return o[1]
+```
 
 ### Verifying shard block data
 
-At network layer, we expect a shard block header to be broadcast along with its `block_body`. First, we define a helper function that takes as input beacon chain state and outputs the max block size in bytes:
+At network layer, we expect a shard block header to be broadcast along with its `block_body`.
 
-```python
-def shard_block_maxbytes(state):
-    max_grains = MAX_SHARD_BLOCK_SIZE // CHUNK_SIZE
-    validators_at_target_committee_size = SHARD_COUNT * TARGET_COMMITTEE_SIZE
-
-    # number of grains per block is proportional to the number of validators
-    # up until `validators_at_target_committee_size`
-    grains = min(
-        len(get_active_validator_indices(state.validators)) * max_grains // validators_at_target_committee_size,
-        max_grains
-    )
-
-    return CHUNK_SIZE * grains
-```
-
-* Verify that `len(block_body) == shard_block_maxbytes(state)`
-* Define `filler_bytes = next_power_of_2(len(block_body)) - len(block_body)`. Compute a simple binary Merkle tree of `block_body + bytes([0] * filler_bytes)` and verify that the root equals the `data_root` in the header.
+* Verify that `len(block_body) == SHARD_BLOCK_SIZE`
+* Verify that `merkle_root(block_body)` equals the `data_root` in the header.
 
 ### Verifying a crosslink
 
@@ -93,23 +100,13 @@ A node should sign a crosslink only if the following conditions hold. **If a nod
 
 First, the conditions must recursively apply to the crosslink referenced in `last_crosslink_hash` for the same shard (unless `last_crosslink_hash` equals zero, in which case we are at the genesis).
 
-Second, we verify the `shard_block_combined_data_root`. Let `h` be the slot _immediately after_ the slot of the shard block included by the last crosslink, and `h+n-1` be the slot number of the block directly referenced by the current `shard_block_hash`. Let `B[i]` be the block at slot `h+i` in the shard chain. Let `bodies[0] .... bodies[n-1]` be the bodies of these blocks and `roots[0] ... roots[n-1]` the data roots. If there is a missing slot in the shard chain at position `h+i`, then `bodies[i] == b'\x00' * shard_block_maxbytes(state[i])` and `roots[i]` be the Merkle root of the empty data. Define `compute_merkle_root` be a simple Merkle root calculating function that takes as input a list of objects, where the list's length must be an exact power of two. Let `state[i]` be the beacon chain state at height `h+i` (if the beacon chain is missing a block at some slot, the state is unchanged), and `depths[i]` be equal to `log2(next_power_of_2(shard_block_maxbytes(state[i]) // CHUNK_SIZE))` (ie. the expected depth of the i'th data tree). We define the function for computing the combined data root as follows:
+Second, we verify the `shard_block_combined_data_root`. Let `h` be the slot _immediately after_ the slot of the shard block included by the last crosslink, and `h+n-1` be the slot number of the block directly referenced by the current `shard_block_hash`. Let `B[i]` be the block at slot `h+i` in the shard chain. Let `bodies[0] .... bodies[n-1]` be the bodies of these blocks and `roots[0] ... roots[n-1]` the data roots. If there is a missing slot in the shard chain at position `h+i`, then `bodies[i] == b'\x00' * shard_block_maxbytes(state[i])` and `roots[i]` be the Merkle root of the empty data. Define `compute_merkle_root` be a simple Merkle root calculating function that takes as input a list of objects, where the list's length must be an exact power of two. We define the function for computing the combined data root as follows:
 
 ```python
-def get_zeroroot_at_depth(n):
-    o = b'\x00' * CHUNK_SIZE
-    for i in range(n):
-        o = hash(o + o)
-    return o
+ZERO_ROOT = merkle_root(bytes([0] * SHARD_BLOCK_SIZE))
 
-def mk_combined_data_root(depths, roots):
-    default_value = get_zeroroot_at_depth(max(depths))
-    data = [default_value for _ in range(next_power_of_2(len(roots)))]
-    for i, (depth, root) in enumerate(zip(depths, roots)):
-        value = root
-        for j in range(depth, max(depths)):
-            value = hash(value, get_zeroroot_at_depth(depth + j))
-        data[i] = value
+def mk_combined_data_root(roots):
+    data = roots + [ZERO_ROOT for _ in range(len(roots), next_power_of_2(len(roots)))]
     return compute_merkle_root(data)
 ```
 
@@ -117,12 +114,7 @@ This outputs the root of a tree of the data roots, with the data roots all adjus
 
 ```python
 def mk_combined_data_root(depths, bodies):
-    default_value = get_zeroroot_at_depth(max(depths))
-    padded_body_length = max([CHUNK_SIZE * 2**d for d in depths])
-    data = b''
-    for body in bodies:
-        padded_body = body + bytes([0] * (padded_body_length - len(body)))
-        data += padded_body
+    data = b''.join(bodies)
     data += bytes([0] * (next_power_of_2(len(data)) - len(data))
     return compute_merkle_root([data[pos:pos+CHUNK_SIZE] for pos in range(0, len(data), CHUNK_SIZE)])
 ```
@@ -132,3 +124,69 @@ Verify that the `shard_block_combined_data_root` is the output of these function
 ### Shard block fork choice rule
 
 The fork choice rule for any shard is LMD GHOST using the validators currently assigned to that shard, but instead of being rooted in the genesis it is rooted in the block referenced in the most recent accepted crosslink (ie. `state.crosslinks[shard].shard_block_hash`). Only blocks whose `beacon_chain_ref` is the block in the main beacon chain at the specified `slot` should be considered (if the beacon chain skips a slot, then the block at that slot is considered to be the block in the beacon chain at the highest slot lower than a slot).
+
+## Changes to beacon chain
+
+Change to attestation verification:
+
+* Let `expected_depth = log2(SHARD_BLOCK_SIZE // SHARD_CHUNK_SIZE * next_power_of_2(slot - last_crosslink_slot))`. For each integer `i = 0, 1`, let `messages[i]` be `AttestationSignedData(slot, shard, parent_hashes, shard_block_hash, i == 1, expected_depth, attestation_indices.total_validator_count, justified_slot)`.
+
+Three new types of `SpecialObject` records:
+
+#### PROOF_OF_CUSTODY_SEED_CHANGE
+
+```python
+{
+    'index': 'uint64',
+    'new_commitment': 'hash32',
+    'signature': ['uint256']
+}
+```
+
+Let `signed_data = bytes8(fork_version) + new_commitment`. Verify that `BLSVerify(pub=state.validators[index].pubkey, msg=hash(signed_data), sig=signature)` passes. Verify that `hash(new_commitment) = state.validators[index].proof_of_custody_commitment`, and the `block.slot >= state.validators[index].proof_of_custody_last_change + PROOF_OF_CUSTODY_MIN_CHANGE_PERIOD`. Set `state.validators[index].proof_of_custody_second_last_change = state.validators[index].proof_of_custody_last_change` and `state.validators[index].proof_of_custody_last_change = block.slot`.
+
+#### PROOF_OF_CUSTODY_CHALLENGE
+
+```
+{
+    'attestation': SpecialAttestationData,
+    'validator_index': 'uint64',
+    'data_index': 'uint64',
+}
+```
+
+Perform the following checks:
+
+* Verify that the attestation is valid.
+* Verify that `attestation.slot > state.validators[index].proof_of_custody_second_last_change`.
+* Verify that `validator_index in attestation.aggregate_sig_poc_0_indices` or `validator_index in attestation.aggregate_sig_poc_1_indices`; if the former, let `bit = False`, else `bit = True`.
+* Verify that `state.validators[index].status == ACTIVE` or `state.validators[index].status == PENDING_EXIT` and `block.slot < state.validators[index].exit_slot + PROOF_OF_CUSTODY_MIN_CHANGE_PERIOD`
+* Let `check_value = as_uint256(hash(as_bytes8(validator_index) + as_bytes8(attestation.slot) + as_bytes8(attestation.shard_id)))`.
+* Let `FULL_PROOF_OF_CUSTODY_VALCOUNT = TARGET_COMMITEE_SIZE * SHARD_COUNT`, and `target = 2**256 * attestation.total_validator_count // FULL_PROOF_OF_CUSTODY_VALCOUNT`.
+* Verify that `check_value <= target`.
+
+Let `seed_hash = state.validators[index].proof_of_custody_commitment if attestation.slot > state.validators[index].proof_of_custody_last_change else hash(state.validators[index].proof_of_custody_commitment)`. Append to `state.proof_of_custody_challenges` the object `ProofOfCustodyChallenge(responder_index=validator_index, seed_hash=seed_hash, depth=attestation.proof_of_custody_depth, data_root=attestation.data.shard_block_hash, data_index=data_index, expiry_slot=block.slot+PROOF_OF_CUSTODY_RESPONSE_DEADLINE, challenger_index=get_proposer(state, block), bit=bit)`.
+
+A block can have maximum one proof of custody challenge, and it must appear before all `PROOF_OF_CUSTODY_SEED_CHANGE` objects.
+
+#### PROOF_OF_CUSTODY_RESPONSE
+```
+{
+    'challenge_index': 'uint64',
+    'leaf': 'hash32',
+    'root': 'hash32',
+    'seed': 'hash32',
+    'data_merkle_branch': '[hash32]',
+    'poc_merkle_branch': '[hash32]',
+}
+```
+Perform the following checks:
+
+* Verify `challenge_index < len(state.proof_of_custody_challenges)`.
+* Let`challenge = state.proof_of_custody_challenges[challenge_index]`.
+* Verify that `hash(seed) = challenge.seed_hash`
+* Verify that `verify_merkle_branch(leaf, data_merkle_branch, challenge.depth, challenge.data_index, root)` passes.
+* Verify that `verify_merkle_branch(leaf, poc_merkle_branch, challenge.depth, challenge.data_index, xor(root, seed))` passes.
+* Verify that `uint256(root) % 2 == challenge.bit`.
+
+Remove `challenge` from `state.proof_of_custody_challenges` (note: if a block has multiple `PROOF_OF_CUSTODY_RESPONSE` objects , later objects' `challenge_index` values will need to take removals from earlier objects into account).

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -30,6 +30,13 @@ Phase 1 depends upon all of the constants defined in [Phase 0](0_beacon-chain.md
 | `SHARD_PROPOSER_DOMAIN`| 129             |
 | `SHARD_ATTESTER_DOMAIN`| 130             |
 
+**Special record types**
+
+| Name | Value | Maximum count |
+| `PROOF_OF_CUSTODY_SEED_CHANGE` | `4` | `16` |
+| `PROOF_OF_CUSTODY_CHALLENGE` | `5` | `16` |
+| `PROOF_OF_CUSTODY_RESPONSE` | `6` | `16` |
+
 ## Data Structures
 
 ### Shard chain blocks

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -215,7 +215,7 @@ A block can have maximum one proof of custody challenge, and it must appear befo
 ```
 Perform the following checks:
 
-* Verify `challenge_index < len(state.proof_of_custody_challenges)`.
+* Verify that `challenge_index < len(state.proof_of_custody_challenges)`.
 * Let`challenge = state.proof_of_custody_challenges[challenge_index]`.
 * Verify that `hash(seed) = challenge.seed_hash`
 * Verify that `verify_merkle_branch(leaf, data_merkle_branch, challenge.depth, challenge.data_index, root)` passes.

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -175,7 +175,12 @@ Three new types of `SpecialObject` records:
 }
 ```
 
-Let `signed_data = bytes8(fork_version) + new_commitment`. Verify that `BLSVerify(pub=state.validators[index].pubkey, msg=hash(signed_data), sig=signature)` passes. Verify that `hash(new_commitment) = state.validators[index].proof_of_custody_commitment`, and the `block.slot >= state.validators[index].proof_of_custody_last_change + PROOF_OF_CUSTODY_MIN_CHANGE_PERIOD`. Set `state.validators[index].proof_of_custody_second_last_change = state.validators[index].proof_of_custody_last_change` and `state.validators[index].proof_of_custody_last_change = block.slot`.
+* Let `signed_data` be `bytes8(fork_version) + new_commitment`.
+* Verify that `BLSVerify(pub=state.validators[index].pubkey, msg=hash(signed_data), sig=signature)` passes.
+* Verify that `hash(new_commitment) = state.validators[index].proof_of_custody_commitment`.
+* Verify that `block.slot >= state.validators[index].proof_of_custody_last_change + PROOF_OF_CUSTODY_MIN_CHANGE_PERIOD`.
+* Set `state.validators[index].proof_of_custody_second_last_change` to `state.validators[index].proof_of_custody_last_change`.
+* Set `state.validators[index].proof_of_custody_last_change` to `block.slot`.
 
 #### PROOF_OF_CUSTODY_CHALLENGE
 


### PR DESCRIPTION
Introduces the following major changes:

* The bitfield now has 2 bits per validator; the second bit is a proof of custody bit
* Three new special objects, one for updating a validator's proof of custody seed, one for making a challenge, one for responding to a challenge
* If a validator fails to respond on time (~3 months) they get kicked out and penalized.