### PR TITLE
Refactor code and fix `on_startup`

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1118,7 +1118,7 @@ def change_validators(validators: List[ValidatorRecord], current_slot: int) -> N
             validators[i].status = PENDING_WITHDRAW
             validators[i].last_status_change_slot = current_slot
             total_changed += validators[i].balance
-            state.validator_set_delta_hash_chain = calcuate_validator_set_delta_hash_chain(
+            state.validator_set_delta_hash_chain = get_new_validator_set_delta_hash_chain(
                 validator_set_delta_hash_chain=state.validator_set_delta_hash_chain,
                 index=i,
                 pubkey=validators[i].pubkey,


### PR DESCRIPTION
1. IMO it's better to decrease passing `BeaconState` between functions so that we can have a clear view of function boundary, but indeed it makes a long parameter list. :|
2. Fix `on_startup`
    * The previous `on_startup` function calls `add_validator(validators, ...)`, but `add_validator` was changed to taking `BeaconState` instead of `List[ValidatorRecord]` as the first parameter. So I added `get_new_validators(current_validators: List[ValidatorRecord], pre_fork_version: int, post_fork_version: int, fork_slot_number: int... )` that returns a new `List[ValidatorRecord]`.
    * Remove `withdrawal_shard` leftover in message.
3. Update `add_validator_set_change_record(state: BeaconState, index: int, pubkey: int, flag: int) -> None` to pure function `get_new_validator_set_delta_hash_chain(current_validator_set_delta_hash_chain: Hash32,  index: int,  pubkey: int, flag: int) -> Hash32`.
