### PR TITLE
First/sample reference

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1,6 +1,6 @@
 # Ethereum 2.0 Phase 0 -- The Beacon Chain
 
-**NOTICE**: This document is a work-in-progress for researchers and implementers. It reflects recent spec changes and takes precedence over the [Python proof-of-concept implementation](https://github.com/ethereum/beacon_chain).
+**NOTICE**: This document is a work-in-progress for researchers and implementers. It reflects recent spec changes and takes precedence over the Python proof-of-concept implementation [[python-poc]]](#ref-python-poc).
 
 ## Table of contents
 * [Ethereum 2.0 Phase 0 -- The Beacon Chain](#ethereum-20-phase-0----the-beacon-chain)
@@ -1395,6 +1395,8 @@ This section is divided into Normative and Informative references.  Normative re
 ## Normative
 
 ## Informative
+<a id="ref-python-poc"></a> _**python-poc**_  
+ &nbsp; _Python proof-of-concept implementation_. Ethereum Foundation. URL: https://github.com/ethereum/beacon_chain
 
 # Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1,6 +1,6 @@
 # Ethereum 2.0 Phase 0 -- The Beacon Chain
 
-**NOTICE**: This document is a work-in-progress for researchers and implementers. It reflects recent spec changes and takes precedence over the Python proof-of-concept implementation [[python-poc]]](#ref-python-poc).
+**NOTICE**: This document is a work-in-progress for researchers and implementers. It reflects recent spec changes and takes precedence over the Python proof-of-concept implementation [[python-poc]](#ref-python-poc).
 
 ## Table of contents
 * [Ethereum 2.0 Phase 0 -- The Beacon Chain](#ethereum-20-phase-0----the-beacon-chain)


### PR DESCRIPTION
This PR takes the very first external reference in the doc and moves it to the References section to show how this will work. (See #203)  If people can live with this referencing mechanism/syntax, then I will go through the doc and propose Reference-section moves for each of the other external links in the doc.

We may want to change the expected content for the items in the References section over time to match/follow a particular style, but for now I just want to get something in there that is lightweight enough that people will use it.

Note that there are two blank spaces after the first of the two text lines that make up a reference (not visible in GitHub).  This causes a line break to be inserted between the two lines.  In practice I expect most people will copy/paste to insert new references, which will automatically pick up the two blank spaces.  Welcome to the joys of (any kind of) styling in Markdown.
