### PR TITLE
Cleanups part 2

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -790,7 +790,7 @@ def get_new_shuffling(seed: Hash32,
 
         shard_id_start = crosslinking_start_shard + slot * committees_per_slot
 
-        shards_and_committees_for_slot = [
+        shard_committees = [
             ShardCommittee(
                 shard=(shard_id_start + shard_position) % SHARD_COUNT,
                 committee=indices,
@@ -811,7 +811,7 @@ Here's a diagram of what is going on:
 
 ```python
 def get_shard_committees_at_slot(state: BeaconState,
-                                      slot: int) -> List[ShardCommittee]:
+                                 slot: int) -> List[ShardCommittee]:
     """
     Returns the ``ShardCommittee`` for the ``slot``.
     """


### PR DESCRIPTION
Changelog (nothing major):

* Clean up constants
   * Add to table of contents
   * Rename a few
   * Split into more categories (e.g. "Deposit contract"  and "Initial values")
   * Replaced `SQRT_E_DROP_TIME ` by `INACTIVITY_PENALTY_QUOTIENT`
* Put all the data structures in "Data structures", including specials
* Move deposit contract after "Data structures"
* `ShardAndCommittee` => `ShardCommittee` (and related changes)
* `aggregate_sig` => `aggregate_signature`
* `justified_slot_bitfield` => `justification_bitfield`
* Use double-ticks everywhere in Python docstrings
* Clean up deposit contract a bit