### PR TITLE
Handle activations and exits separately for balance churn

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1450,15 +1450,15 @@ def get_changed_validators(validators: List[ValidatorRecord],
         MAX_DEPOSIT * GWEI_PER_ETH,
         total_balance // (2 * MAX_BALANCE_CHURN_QUOTIENT)
     )
-    
+
     # Activate validators within the allowable balance churn
     total_activated_balance = 0
     for i in range(len(validators)):
         if validators[i].status == PENDING_ACTIVATION:
-            validators[i].status = ACTIVE
             total_activated_balance += get_effective_balance(validators[i])
             if total_activated_balance >= max_balance_churn:
                 break
+            validators[i].status = ACTIVE
             validator_registry_delta_chain_tip = get_new_validator_registry_delta_chain_tip(
                 validator_registry_delta_chain_tip=validator_registry_delta_chain_tip,
                 index=i,
@@ -1466,14 +1466,14 @@ def get_changed_validators(validators: List[ValidatorRecord],
                 flag=ACTIVATION,
             )
 
-    # Exit valdiators within the allowable balance churn 
+    # Exit validators within the allowable balance churn 
     total_exited_balance = 0
     for i in range(len(validators)):
         if validators[i].status == EXITED_WITHOUT_PENALTY:
-            validators[i].latest_status_change_slot = current_slot
             total_exited_balance += get_effective_balance(validators[i])
             if total_exited_balance >= max_balance_churn:
                 break
+            validators[i].latest_status_change_slot = current_slot
             validator_registry_delta_chain_tip = get_new_validator_registry_delta_chain_tip(
                 validator_registry_delta_chain_tip=validator_registry_delta_chain_tip,
                 index=i,

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1461,7 +1461,7 @@ def get_changed_validators(validators: List[ValidatorRecord],
         if validators[i].status == PENDING_ACTIVATION and validators[i].balance >= MAX_DEPOSIT:
             # Check the balance churn would be within the allowance
             balance_churn += get_effective_balance(validators[i])
-            if balance_churn >= max_balance_churn:
+            if balance_churn > max_balance_churn:
                 break
 
             # Activate validator
@@ -1480,7 +1480,7 @@ def get_changed_validators(validators: List[ValidatorRecord],
         if validators[i].status == ACTIVE_PENDING_EXIT:
             # Check the balance churn would be within the allowance
             balance_churn += get_effective_balance(validators[i])
-            if balance_churn >= max_balance_churn:
+            if balance_churn > max_balance_churn:
                 break
 
             # Exit validator

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1452,12 +1452,15 @@ def get_changed_validators(validators: List[ValidatorRecord],
     )
 
     # Activate validators within the allowable balance churn
-    total_activated_balance = 0
+    balance_churn = 0
     for i in range(len(validators)):
         if validators[i].status == PENDING_ACTIVATION:
-            total_activated_balance += get_effective_balance(validators[i])
-            if total_activated_balance >= max_balance_churn:
+            # Check the balance churn would be within the allowance
+            balance_churn += get_effective_balance(validators[i])
+            if balance_churn >= max_balance_churn:
                 break
+
+            # Activate validator
             validators[i].status = ACTIVE
             validator_registry_delta_chain_tip = get_new_validator_registry_delta_chain_tip(
                 validator_registry_delta_chain_tip=validator_registry_delta_chain_tip,
@@ -1467,12 +1470,15 @@ def get_changed_validators(validators: List[ValidatorRecord],
             )
 
     # Exit validators within the allowable balance churn 
-    total_exited_balance = 0
+    balance_churn = 0
     for i in range(len(validators)):
         if validators[i].status == EXITED_WITHOUT_PENALTY:
-            total_exited_balance += get_effective_balance(validators[i])
-            if total_exited_balance >= max_balance_churn:
+            # Check the balance churn would be within the allowance
+            balance_churn += get_effective_balance(validators[i])
+            if balance_churn >= max_balance_churn:
                 break
+
+            # Exit validator
             validators[i].latest_status_change_slot = current_slot
             validator_registry_delta_chain_tip = get_new_validator_registry_delta_chain_tip(
                 validator_registry_delta_chain_tip=validator_registry_delta_chain_tip,


### PR DESCRIPTION
This change is to avoid deposits from fully consuming the allowable balance churn, preventing exits from being processed. And vice versa with deposits/exits swapped.