### PR TITLE
Move to a per-slot state transition function

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1222,8 +1222,9 @@ If there is a block from the proposer for `state.slot`, we process that incoming
 If there is not a block from the proposer for `state.slot`, a "skip block" is inserted into the beacon chain:
 * Let `block` be a skip block defined by `get_skip_block(state.slot, parent, parent_hash)`.
 
-Set `state.latest_block_hashes` to `state.latest_block_hashes + [parent_hash]`. (The output of `get_block_hash` should not change, except that it will no longer throw for `state.slot - 1`.)
-Also, check that the `block.ancestor_hashes` equals `get_updated_ancestor_hashes(parent, parent_hash)`.
+Verify that `block.ancestor_hashes` equals `get_updated_ancestor_hashes(parent, parent_hash)`.
+
+Set `state.latest_block_hashes = state.latest_block_hashes + [parent_hash]`. (The output of `get_block_hash` should not change, except that it will no longer throw for `state.slot - 1`).
 
 ### Proposer signature
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -857,7 +857,7 @@ def get_block_hash(state: BeaconState,
 #### `get_beacon_proposer_index`
 
 ```python
-def get_beacon_proposer_index(state:BeaconState,
+def get_beacon_proposer_index(state: BeaconState,
                               slot: int) -> int:
     """
     Returns the beacon proposer index for the ``slot``.

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1185,7 +1185,16 @@ def exit_validator(index: int,
 
 ## Per-slot processing
 
-Below are the processing steps that happen at every slot. Denote by `block` the associated block, possibly a skip block.
+Below are the processing steps that happen at every slot. If there is no block from the proposer for a given slot a "skip block" is inserted into the beacon chain. The skip block is a `BeaconBlock` where the non-zero fields are:
+
+* `parent_hash`: the hash of the previous block (which may itself be a skip block)
+* `slot`: the current slot
+* `state_root`: the state root at the current slot
+
+```python
+
+```
+Denote by `block` the associated block, possibly a skip block.
 
 * Let `parent_hash` be the hash of the immediate previous beacon slot (i.e. equal to `block.ancestor_hashes[0]`).
 * Let `parent` be the beacon slot with the hash `parent_hash`.

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1422,14 +1422,14 @@ If `state.slot % POW_RECEIPT_ROOT_VOTING_PERIOD == 0`:
 
 * Set `state.previous_justified_slot = state.justified_slot`.
 * Set `state.justification_bitfield = (state.justification_bitfield * 2) % 2**64`.
-* Set `state.justification_bitfield &= 2` and `state.justified_slot = s - EPOCH_LENGTH` if `3 * previous_epoch_boundary_attesting_balance >= 2 * total_balance`.
-* Set `state.justification_bitfield &= 1` and `state.justified_slot = s` if `3 * this_epoch_boundary_attesting_balance >= 2 * total_balance`.
+* Set `state.justification_bitfield |= 2` and `state.justified_slot = s - EPOCH_LENGTH` if `3 * previous_epoch_boundary_attesting_balance >= 2 * total_balance`.
+* Set `state.justification_bitfield |= 1` and `state.justified_slot = s` if `3 * this_epoch_boundary_attesting_balance >= 2 * total_balance`.
 
-### Finalization
+# Finalization
 
-* Set `state.finalized_slot = state.justified_slot` if `state.justified_slot == s - 1 * EPOCH_LENGTH and state.justification_bitfield % 4 == 3`.
-* Set `state.finalized_slot = state.justified_slot` if `state.justified_slot == s - 2 * EPOCH_LENGTH and state.justification_bitfield % 8 == 7`.
-* Set `state.finalized_slot = state.justified_slot` If `state.justified_slot == s - 3 * EPOCH_LENGTH and state.justification_bitfield % 16 in (15, 14)`.
+* Set `state.finalized_slot = state.justified_slot - EPOCH_LENGTH` if `state.justified_slot == s and state.justification_bitfield % 4 == 3`.
+* Set `state.finalized_slot = state.justified_slot - EPOCH_LENGTH` if `state.justified_slot == s - EPOCH_LENGTH and state.justification_bitfield % 8 == 7`.
+* Set `state.finalized_slot = state.justified_slot - EPOCH_LENGTH` if `state.justified_slot == s - 2 * EPOCH_LENGTH and state.justification_bitfield % 16 in (15, 14)`.
 
 ### Crosslinks
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1242,7 +1242,7 @@ For each `attestation` in `block.attestations`:
 * Verify that `attestation.data.slot <= state.slot - MIN_ATTESTATION_INCLUSION_DELAY`.
 * Verify that `attestation.data.slot >= max(parent.slot - EPOCH_LENGTH + 1, 0)`.
 * Verify that `attestation.data.justified_slot` is equal to `state.justified_slot if attestation.data.slot >= state.slot - (state.slot % EPOCH_LENGTH) else state.previous_justified_slot`.
-* Verify that `attestation.data.justified_block_hash` is equal to `get_block_hash(state, block, attestation.data.justified_slot)`.
+* Verify that `attestation.data.justified_block_hash` is equal to `get_block_hash(state, attestation.data.justified_slot)`.
 * Verify that either `attestation.data.latest_crosslink_hash` or `attestation.data.shard_block_hash` equals `state.crosslinks[shard].shard_block_hash`.
 * `aggregate_signature` verification:
     * Let `participants = get_attestation_participants(state, attestation.data, attestation.participation_bitfield)`.
@@ -1372,14 +1372,14 @@ All [validators](#dfn-validator):
 [Validators](#dfn-Validator) justifying the epoch boundary block at the start of the current epoch:
 
 * Let `this_epoch_attestations = [a for a in state.latest_attestations if s <= a.data.slot < s + EPOCH_LENGTH]`. (Note: this is the set of attestations of slots in the epoch `s...s+EPOCH_LENGTH-1`, _not_ attestations that got included in the chain during the epoch `s...s+EPOCH_LENGTH-1`.)
-* Let `this_epoch_boundary_attestations = [a for a in this_epoch_attestations if a.data.epoch_boundary_hash == get_block_hash(state, block, s) and a.justified_slot == state.justified_slot]`.
+* Let `this_epoch_boundary_attestations = [a for a in this_epoch_attestations if a.data.epoch_boundary_hash == get_block_hash(state, s) and a.justified_slot == state.justified_slot]`.
 * Let `this_epoch_boundary_attesters` be the union of the [validator](#dfn-validator) index sets given by `[get_attestation_participants(state, a.data, a.participation_bitfield) for a in this_epoch_boundary_attestations]`.
 * Let `this_epoch_boundary_attesting_balance = sum([get_effective_balance(v) for v in this_epoch_boundary_attesters])`.
 
 [Validators](#dfn-Validator) justifying the epoch boundary block at the start of the previous epoch:
 
 * Let `previous_epoch_attestations = [a for a in state.latest_attestations if s - EPOCH_LENGTH <= a.slot < s]`.
-* Let `previous_epoch_boundary_attestations = [a for a in this_epoch_attestations + previous_epoch_attestations if a.epoch_boundary_hash == get_block_hash(state, block, s - EPOCH_LENGTH) and a.justified_slot == state.previous_justified_slot]`.
+* Let `previous_epoch_boundary_attestations = [a for a in this_epoch_attestations + previous_epoch_attestations if a.epoch_boundary_hash == get_block_hash(state, s - EPOCH_LENGTH) and a.justified_slot == state.previous_justified_slot]`.
 * Let `previous_epoch_boundary_attesters` be the union of the validator index sets given by `[get_attestation_participants(state, a.data, a.participation_bitfield) for a in previous_epoch_boundary_attestations]`.
 * Let `previous_epoch_boundary_attesting_balance = sum([get_effective_balance(v) for v in previous_epoch_boundary_attesters])`.
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1425,11 +1425,11 @@ If `state.slot % POW_RECEIPT_ROOT_VOTING_PERIOD == 0`:
 * Set `state.justification_bitfield |= 2` and `state.justified_slot = s - EPOCH_LENGTH` if `3 * previous_epoch_boundary_attesting_balance >= 2 * total_balance`.
 * Set `state.justification_bitfield |= 1` and `state.justified_slot = s` if `3 * this_epoch_boundary_attesting_balance >= 2 * total_balance`.
 
-# Finalization
+### Finalization
 
-* Set `state.finalized_slot = state.justified_slot - EPOCH_LENGTH` if `state.justified_slot == s and state.justification_bitfield % 4 == 3`.
-* Set `state.finalized_slot = state.justified_slot - EPOCH_LENGTH` if `state.justified_slot == s - EPOCH_LENGTH and state.justification_bitfield % 8 == 7`.
-* Set `state.finalized_slot = state.justified_slot - EPOCH_LENGTH` if `state.justified_slot == s - 2 * EPOCH_LENGTH and state.justification_bitfield % 16 in (15, 14)`.
+* Set `state.finalized_slot = state.previous_justified_slot` if `state.previous_justified_slot == s - 1 * EPOCH_LENGTH and state.justification_bitfield % 4 == 3`.
+* Set `state.finalized_slot = state.previous_justified_slot` if `state.previous_justified_slot == s - 2 * EPOCH_LENGTH and state.justification_bitfield % 8 == 7`.
+* Set `state.finalized_slot = state.previous_justified_slot` if `state.previous_justified_slot == s - 3 * EPOCH_LENGTH and state.justification_bitfield % 16 in (15, 14)`.
 
 ### Crosslinks
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -90,6 +90,7 @@
         - [Validator registry](#validator-registry)
         - [Proposer reshuffling](#proposer-reshuffling)
         - [Final updates](#final-updates)
+    - [State root processing](#state-root-processing)
 - [Appendix](#appendix)
     - [Appendix A - Hash function](#appendix-a---hash-function)
 - [References](#references)
@@ -1602,6 +1603,14 @@ while len(state.persistent_committee_reassignments) > 0 and state.persistent_com
 * Remove any `attestation` in `state.latest_attestations` such that `attestation.data.slot < s`.
 * Run `exit_validator(i, state, penalize=False, current_slot=state.slot)` for indices `i` such that `state.validator_registry[i].status = ACTIVE and state.validator_registry[i].balance < MIN_BALANCE`.
 * Set `state.latest_block_hashes = state.latest_block_hashes[EPOCH_LENGTH:]`.
+
+## State root processing
+
+If `block` is not a skip block:
+* Verify `block.state_root == hash(state)`
+
+If `block` is a skip block:
+* Set `block.state_root = hash(state)`
 
 # Appendix
 ## Appendix A - Hash function


### PR DESCRIPTION
Migrate to a per-block state transition function:

* Add `slot` to the state
* Introduce skip blocks if there is no block from the proposer
* Deemphasize `latest_state_recalculation_slot` (can probably be removed altogether)
* Per-epoch processing simply happens at exact epoch boundaries, without queuing
* Rely on `state.slot` instead of `current_state` or `block.state` where appropriate
* Initial cleanups in the "Per-slot processing" and "Per-epoch processing"
     * Review the table of content titles
     * Cleaner sub-sections
     * Misc cleanups