### PR TITLE
Don't need slot # for get_active_validator_indices

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -660,7 +660,7 @@ The beacon chain fork choice rule is a hybrid that combines justification and fi
 def lmd_ghost(store, start):
     validators = start.state.validator_registry
     active_validators = [validators[i] for i in
-                         get_active_validator_indices(validators, start.slot)]
+                         get_active_validator_indices(validators)]
     attestation_targets = [get_latest_attestation_target(store, validator)
                            for validator in active_validators]
     def get_vote_count(block):


### PR DESCRIPTION
get_active_validator_indices doesn't have a second argument for slot number, I'm fixing that for `get_active_validator_indices` under `lmd_ghost` function