### PR TITLE
Clarify TreeHash treatment of integers > 256bit

### DIFF
--- a/specs/simple-serialize.md
+++ b/specs/simple-serialize.md
@@ -394,11 +394,11 @@ The below `SSZTreeHash` algorithm is defined recursively in the case of lists an
 
 We define `hash(x)` as `BLAKE2b-512(x)[0:32]`.
 
-#### `uintN`, `bool`, `address`, `hash32`
+#### `uint8`..`uint256`, `bool`, `address`, `hash1`..`hash32`
 
 Return the serialization of the value.
 
-#### `bytes`, `hashN`
+#### `uint264`..`uintN`, `bytes`, `hash33`..`hashN`
 
 Return the hash of the serialization of the value.
 


### PR DESCRIPTION
Also clarify treatment of hashes < 32bytes