### PR TITLE
First pass cleanup of bls_verify.md

### DIFF
--- a/specs/bls_verify.md
+++ b/specs/bls_verify.md
@@ -101,7 +101,7 @@ Let `bls_verify(pubkey: uint384, message: bytes32, signature: [uint384], domain:
 
 * Verify that `pubkey` is a valid G1 point.
 * Verify that `signature` is a valid G2 point.
-* Verify `e(pubkey, hash_to_G2(message, domain)) == e(g, signature)`.
+* Verify that `e(pubkey, hash_to_G2(message, domain)) == e(g, signature)`.
 
 ### `bls_verify_multiple`
 

--- a/specs/bls_verify.md
+++ b/specs/bls_verify.md
@@ -40,20 +40,20 @@ We require:
 
 * `x < q`
 * `c_flag == 1`
-* if `b_flag == 1` then `a_flag == x == 0` and `z` is the point at infinity
-* if `b_flag == 0` then `z` is the point `(x, y)` where `y` is the valid coordinate such that `(y * 2) // q == a_flag`
+* if `b_flag == 1` then `a_flag == x == 0` and `z` represents the point at infinity
+* if `b_flag == 0` then `z` represents the point `(x, y)` where `y` is the valid coordinate such that `(y * 2) // q == a_flag`
 
 ### G2 points
 
-A point in G2 is represented as a pair of 384-bit integers `(z1, z2)`. We decompose `z1` and `z2` as above into `x1`, `a_flag1`, `b_flag1`, `c_flag1` and `x2`, `a_flag2`, `b_flag2`, `c_flag2`.
+A point in G2 is represented as a pair of 384-bit integers `(z1, z2)`. We decompose `z1` as above into `x1`, `a_flag1`, `b_flag1`, `c_flag1` and `z2` into `x2`, `a_flag2`, `b_flag2`, `c_flag2`.
 
 We require:
 
 * `x1 < q` and `x2 < q`
 * `a_flag2 == b_flag2 == c_flag2 == 0`
 * `c_flag1 == 1`
-* if `b_flag1 == 1` then `a_flag1 == x1 == x2 == 0` and `(z1, z2)` is the point at infinity
-* if `b_flag1 == 0` then `(z1, z2)` is the point `(x1 * i + x2, y)` where `y` is the valid coordinate such that the imaginary part `y_im` of `y` satisfies `(y_im * 2) // q == a_flag1`
+* if `b_flag1 == 1` then `a_flag1 == x1 == x2 == 0` and `(z1, z2)` represents the point at infinity
+* if `b_flag1 == 0` then `(z1, z2)` represents the point `(x1 * i + x2, y)` where `y` is the valid coordinate such that the imaginary part `y_im` of `y` satisfies `(y_im * 2) // q == a_flag1`
 
 ## Helpers
 
@@ -79,6 +79,8 @@ def hash_to_G2(message, domain):
 
 ### `modular_squareroot`
 
+`modular_squareroot(x)` returns the value `y` such that `y**2 % field_modulus == x`, and `None` if this is not possible. In cases where there are two solutions, the value with higher imaginary component is favored; if both solutions have equal imaginary component the value with higher real component is favored. Here is an implementation.
+
 ```python
 qmod = q ** 2 - 1
 eighth_roots_of_unity = [FQ2([1,1]) ** ((qmod * k) // 8) for k in range(8)]
@@ -87,7 +89,9 @@ def modular_squareroot(value):
     candidate_squareroot = value ** ((qmod + 8) // 16)
     check = candidate_squareroot ** 2 / value
     if check in eighth_roots_of_unity[::2]:
-        return candidate_squareroot / eighth_roots_of_unity[eighth_roots_of_unity.index(check) // 2]
+        x1 = candidate_squareroot / eighth_roots_of_unity[eighth_roots_of_unity.index(check) // 2]
+        x2 = -x1
+        return x1 if (x1.coeffs[1].n, x1.coeffs[0].n) > (x2.coeffs[1].n, x2.coeffs[0].n) else x2
     return None
 ```
 

--- a/specs/bls_verify.md
+++ b/specs/bls_verify.md
@@ -53,7 +53,7 @@ We require:
 * `a_flag2 == b_flag2 == c_flag2 == 0`
 * `c_flag1 == 1`
 * if `b_flag1 == 1` then `a_flag1 == x1 == x2 == 0` and `(z1, z2)` is the point at infinity
-* if `b_flag1 == 0` then `(z1, z2)` is the point `(x1 * i + x2, y)` where `y` is the valid coordinate such that the imaginary part `y_im` of `y` satisfies `(y_im * 2) // q == a_flag1`.
+* if `b_flag1 == 0` then `(z1, z2)` is the point `(x1 * i + x2, y)` where `y` is the valid coordinate such that the imaginary part `y_im` of `y` satisfies `(y_im * 2) // q == a_flag1`
 
 ## Helpers
 

--- a/specs/bls_verify.md
+++ b/specs/bls_verify.md
@@ -70,15 +70,15 @@ def hash_to_G2(message, domain):
     # Initial candidate x coordinate
     x_re = int.from_bytes(hash(bytes8(domain) + b'\x01' + message), 'big')
     x_im = int.from_bytes(hash(bytes8(domain) + b'\x02' + message), 'big')
-    x_coordinate = FQ2([x_re, x_im])  # x = x_re + i * x_im
+    x_coordinate = Fq2([x_re, x_im])  # x = x_re + i * x_im
     
     # Test candidate y coordinates until a one is found
     while 1:
-        y_coordinate_squared = x_coordinate ** 3 + FQ2([4, 4])  # The curve is y^2 = x^3 + 4(i + 1)
+        y_coordinate_squared = x_coordinate ** 3 + Fq2([4, 4])  # The curve is y^2 = x^3 + 4(i + 1)
         y_coordinate = modular_squareroot(y_coordinate_squared)
         if y_coordinate is not None:  # Check if quadratic residue found
             return multiply_in_G2((x_coordinate, y_coordinate), G2_cofactor)
-        x_coordinate += FQ2([1, 0])  # Add 1 and try again
+        x_coordinate += Fq2([1, 0])  # Add 1 and try again
 ```
 
 ### `modular_squareroot`
@@ -87,7 +87,7 @@ def hash_to_G2(message, domain):
 
 ```python
 qmod = q ** 2 - 1
-eighth_roots_of_unity = [FQ2([1,1]) ** ((qmod * k) // 8) for k in range(8)]
+eighth_roots_of_unity = [Fq2([1,1]) ** ((qmod * k) // 8) for k in range(8)]
 
 def modular_squareroot(value):
     candidate_squareroot = value ** ((qmod + 8) // 16)
@@ -101,7 +101,13 @@ def modular_squareroot(value):
 
 ## Signature verification
 
-In the following `e` is the pairing function and `g` is the generator in G1.
+In the following `e` is the pairing function and `g` is the G1 generator with the following coordinates (see [here](https://github.com/zkcrypto/pairing/tree/master/src/bls12_381#g1)):
+
+```python
+g_x = 3685416753713387016781088315183077757961620795782546409894578378688607592378376318836054947676345821548104185464507
+g_y = 1339506544944476473020471379941921221584933875938349620426543736416511423956333506472724655353366534992391756441569
+g = Fq2(g_x, g_y)
+```
 
 ### `bls_verify`
 

--- a/specs/bls_verify.md
+++ b/specs/bls_verify.md
@@ -66,7 +66,7 @@ def hash_to_G2(message, domain):
     x2 = hash(bytes8(domain) + b'\x02' + message)
     x_coordinate = FQ2([x1, x2]) # x1 + x2 * i
     while 1:
-        x_cubed_plus_b2 = x_coordinate ** 3 + FQ2([4,4])
+        x_cubed_plus_b2 = x_coordinate ** 3 + FQ2([4, 4])
         y_coordinate = modular_square_root(x_cubed_plus_b2)
         if y_coordinate is not None:
             break
@@ -91,7 +91,7 @@ def modular_square_root(value):
 
 ## Signature verification
 
-In the following `e` is the pairing function and `id_G1` the identity in G1.
+In the following `e` is the pairing function and `g` is the generator in G1.
 
 ### `bls_verify`
 
@@ -99,7 +99,7 @@ In the following `e` is the pairing function and `id_G1` the identity in G1.
 
 * Verify that `pubkey` is a valid G1 point.
 * Verify that `signature` is a valid G2 point.
-* Verify `e(pubkey, hash_to_G2(message, domain)) == e(id_G1, sig)`.
+* Verify `e(pubkey, hash_to_G2(message, domain)) == e(g, sig)`.
 
 ### `bls_verify_multiple`
 
@@ -108,4 +108,4 @@ In the following `e` is the pairing function and `id_G1` the identity in G1.
 * Verify that each `pubkey` in `pubkeys` is a valid G1 point.
 * Verify that `signature` is a valid G2 point.
 * Verify that `len(pubkeys)` equals `len(messages)` and denote the length `L`.
-* Verify that `e(pubkeys[0], hash_to_G2(messages[0], domain)) * ... * e(pubkeys[L-1], hash_to_G2(messages[L-1], domain)) == e(id_G1, sig)`.
+* Verify that `e(pubkeys[0], hash_to_G2(messages[0], domain)) * ... * e(pubkeys[L-1], hash_to_G2(messages[L-1], domain)) == e(g, sig)`.

--- a/specs/bls_verify.md
+++ b/specs/bls_verify.md
@@ -86,11 +86,11 @@ def hash_to_G2(message: bytes32, domain: uint64) -> [uint384]:
 `modular_squareroot(x)` returns a solution `y` to `y**2 % q == x`, and `None` if none exists. If there are two solutions the one with higher imaginary component is favored; if both solutions have equal imaginary component the one with higher real component is favored.
 
 ```python
-qmod = q ** 2 - 1
-eighth_roots_of_unity = [Fq2([1,1]) ** ((qmod * k) // 8) for k in range(8)]
+Fq2_order = q ** 2 - 1
+eighth_roots_of_unity = [Fq2([1,1]) ** ((Fq2_order * k) // 8) for k in range(8)]
 
 def modular_squareroot(value: int) -> int:
-    candidate_squareroot = value ** ((qmod + 8) // 16)
+    candidate_squareroot = value ** ((Fq2_order + 8) // 16)
     check = candidate_squareroot ** 2 / value
     if check in eighth_roots_of_unity[::2]:
         x1 = candidate_squareroot / eighth_roots_of_unity[eighth_roots_of_unity.index(check) // 2]

--- a/specs/bls_verify.md
+++ b/specs/bls_verify.md
@@ -105,7 +105,7 @@ Let `bls_verify(pubkey: uint384, message: bytes32, signature: [uint384], domain:
 
 ### `bls_verify_multiple`
 
-Let `BLSMultiVerify(pubkeys: [uint384], messages: [bytes32], signature: [uint384], domain: uint64) -> bool`:
+Let `bls_verify_multiple(pubkeys: [uint384], messages: [bytes32], signature: [uint384], domain: uint64) -> bool`:
 
 * Verify that each `pubkey` in `pubkeys` is a valid G1 point.
 * Verify that `signature` is a valid G2 point.

--- a/specs/bls_verify.md
+++ b/specs/bls_verify.md
@@ -7,6 +7,7 @@
 
 - [BLS signature verification](#bls-signature-verification)
     - [Table of contents](#table-of-contents)
+    - [Curve parameters](#curve-parameters)
     - [Point representations](#point-representations)
         - [G1 points](#g1-points)
         - [G2 points](#g2-points)
@@ -19,7 +20,7 @@
 
 <!-- /TOC -->
 
-## Curve 
+## Curve parameters
 
 The BLS12-381 curve parameters are defined [here](https://z.cash/blog/new-snark-curve).
 

--- a/specs/bls_verify.md
+++ b/specs/bls_verify.md
@@ -64,9 +64,9 @@ We require:
 
 ```python
 G2_cofactor = 305502333931268344200999753193121504214466019254188142667664032982267604182971884026507427359259977847832272839041616661285803823378372096355777062779109
-q = 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab
+q = 4002409555221667393417789825735904156556882819939007885332058136124031650490837864442687629129015664037894272559787
 
-def hash_to_G2(message, domain):
+def hash_to_G2(message: bytes32, domain: uint64) -> [uint384]:
     # Initial candidate x coordinate
     x_re = int.from_bytes(hash(bytes8(domain) + b'\x01' + message), 'big')
     x_im = int.from_bytes(hash(bytes8(domain) + b'\x02' + message), 'big')
@@ -89,7 +89,7 @@ def hash_to_G2(message, domain):
 qmod = q ** 2 - 1
 eighth_roots_of_unity = [Fq2([1,1]) ** ((qmod * k) // 8) for k in range(8)]
 
-def modular_squareroot(value):
+def modular_squareroot(value: int) -> int:
     candidate_squareroot = value ** ((qmod + 8) // 16)
     check = candidate_squareroot ** 2 / value
     if check in eighth_roots_of_unity[::2]:


### PR DESCRIPTION
Misc cleanups:

* (typo) `highflag` => `highflag1`
* (typo) `lowflag = x = 0` => `lowflag == x == 0`
* Add structure and table of contents
* Describe more notation in words (e.g. `i`)
* Make sure flags are 1-bit
* Clarify and polish presentation

Example notation cleanups:

* `G1` => `g` (to avoid confusing with the group G1)
* `field_modulus` => `q` (avoid using two names for same thing)
* `BLSVerify` => `bls_verify` (respect notation for functions in main document)
* `sig` => `signature` (avoid abbreviations as in main document)

TODO:

* Define argument and returned value types for `hash_to_G2`, `modular_squareroot`
* Describe/define `FQ2`, `b2`, `is_on_curve`, `multiply`, `g`
* Clarify where the value for `G2_cofactor` came from
* Make the naming changes around `bls_verify` in the main document
* Fix any bugs introduced by the cleanup