### PR TITLE
validator status cleanup

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -71,9 +71,11 @@
             - [`bytes1`, `bytes2`, ...](#bytes1-bytes2-)
             - [`get_effective_balance`](#get_effective_balance)
             - [`get_new_validator_registry_delta_chain_tip`](#get_new_validator_registry_delta_chain_tip)
+            - [`get_fork_version`](#get_fork_version)
             - [`get_domain`](#get_domain)
             - [`verify_casper_votes`](#verify_casper_votes)
             - [`integer_squareroot`](#integer_squareroot)
+            - [`BLSVerify`](#blsverify)
         - [On startup](#on-startup)
         - [Routine for activating a validator](#routine-for-activating-a-validator)
         - [Routine for exiting a validator](#routine-for-exiting-a-validator)
@@ -959,6 +961,17 @@ def get_new_validator_registry_delta_chain_tip(current_validator_registry_delta_
     )
 ```
 
+#### `get_fork_version`
+
+```python
+def get_fork_version(fork_data: ForkData,
+                     slot: int) -> int:
+    if slot < fork_data.fork_slot:
+        return fork_data.pre_fork_version
+    else:
+        return fork_data.post_fork_version
+```
+
 #### `get_domain`
 
 ```python
@@ -997,6 +1010,10 @@ def integer_squareroot(n: int) -> int:
         y = (x + n // x) // 2
     return x
 ```
+
+#### `BLSVerify`
+
+`BLSVerify` is a function for verifying a BLS12-381 signature, defined in the [BLS12-381 spec](https://github.com/ethereum/eth2.0-specs/blob/master/specs/bls_verify.md).
 
 ### On startup
 
@@ -1094,9 +1111,7 @@ def on_startup(initial_validator_entries: List[Any],
 
 ### Routine for processing deposits
 
-These logs should be processed in the order in which they are emitted by Ethereum 1.0.
-
-First, some helper functions:
+First, a helper function:
 
 ```python
 def min_empty_validator_index(validators: List[ValidatorRecord], current_slot: int) -> int:
@@ -1104,17 +1119,9 @@ def min_empty_validator_index(validators: List[ValidatorRecord], current_slot: i
         if v.balance == 0 and v.latest_status_change_slot + ZERO_BALANCE_VALIDATOR_TTL <= current_slot:
             return i
     return None
-
-def get_fork_version(fork_data: ForkData,
-                     slot: int) -> int:
-    if slot < fork_data.fork_slot:
-        return fork_data.pre_fork_version
-    else:
-        return fork_data.post_fork_version
 ```
 
-`BLSVerify` is a function for verifying a BLS12-381 signature, defined in the [BLS12-381 spec](https://github.com/ethereum/eth2.0-specs/blob/master/specs/bls_verify.md).
-Now, to add a [validator](#dfn-validator) or top up an existing [validator](#dfn-validator)'s balance:
+Now, to add a [validator](#dfn-validator) or top up an existing [validator](#dfn-validator)'s balance by some `deposit` amount:
 
 ```python
 def process_deposit(state: BeaconState,
@@ -1352,6 +1359,8 @@ For each `attestation` in `block.body.attestations`:
 #### Deposits
 
 Verify that `len(block.body.deposits) <= MAX_DEPOSITS`.
+
+[TODO: add logic to ensure that deposits from 1.0 chain are processed in order:]
 
 For each `deposit` in `block.body.deposits`:
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1210,7 +1210,7 @@ def activate_validator(index: int,
     validator.latest_status_change_slot = state.slot
     state.validator_registry_delta_chain_tip = get_new_validator_registry_delta_chain_tip(
         validator_registry_delta_chain_tip=validator_registry_delta_chain_tip,
-        index=i,
+        index=index,
         pubkey=validator.pubkey,
         flag=ACTIVATION,
     )
@@ -1360,7 +1360,7 @@ For each `attestation` in `block.body.attestations`:
 
 Verify that `len(block.body.deposits) <= MAX_DEPOSITS`.
 
-[TODO: add logic to ensure that deposits from 1.0 chain are processed in order:]
+[TODO: add logic to ensure that deposits from 1.0 chain are processed in order]
 
 For each `deposit` in `block.body.deposits`:
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -77,8 +77,8 @@
             - [`integer_squareroot`](#integer_squareroot)
             - [`BLSVerify`](#blsverify)
         - [On startup](#on-startup)
-        - [Routine for activating a validator](#routine-for-activating-a-validator)
-        - [Routine for exiting a validator](#routine-for-exiting-a-validator)
+        - [Routine for processing deposits](#routine-for-processing-deposits)
+        - [Routine for updating validator status](#routine-for-updating-validator-status)
     - [Per-slot processing](#per-slot-processing)
         - [Proposer signature](#proposer-signature)
         - [RANDAO](#randao)
@@ -1177,7 +1177,7 @@ def process_deposit(state: BeaconState,
     return index
 ```
 
-### Routines for updating validator status
+### Routine for updating validator status
 
 ```python
 def update_validator_status(index: int,
@@ -1550,7 +1550,7 @@ def update_validator_registry(state: BeaconState) -> None:
 
     # Activate validators within the allowable balance churn
     balance_churn = 0
-    for i, validator in enumerate(state.validator_registry):
+    for index, validator in enumerate(state.validator_registry):
         if validator.status == PENDING_ACTIVATION and validator.balance >= MAX_DEPOSIT:
             # Check the balance churn would be within the allowance
             balance_churn += get_effective_balance(validator)
@@ -1558,11 +1558,11 @@ def update_validator_registry(state: BeaconState) -> None:
                 break
 
             # Activate validator
-            update_validator_status(i, state, new_status=ACTIVE)
+            update_validator_status(index, state, new_status=ACTIVE)
 
     # Exit validators within the allowable balance churn 
     balance_churn = 0
-    for i, validator in enumerate(state.validator_registry):
+    for index, validator in enumerate(state.validator_registry):
         if validator.status == ACTIVE_PENDING_EXIT:
             # Check the balance churn would be within the allowance
             balance_churn += get_effective_balance(validator)
@@ -1570,7 +1570,7 @@ def update_validator_registry(state: BeaconState) -> None:
                 break
 
             # Exit validator
-            update_validator_status(i, state, new_status=EXITED_WITHOUT_PENALTY)
+            update_validator_status(index, state, new_status=EXITED_WITHOUT_PENALTY)
 
 
     # Calculate the total ETH that has been penalized in the last ~2-3 withdrawal periods

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1238,10 +1238,10 @@ def exit_validator(index: int,
         whistleblower.balance += whistleblower_reward
         validator.balance -= whistleblower_reward
 
-    if prev_status != ACTIVE:
+    if prev_status in [EXITED_WITH_PENALTY, EXITED_WITHOUT_PENALTY]
         return
 
-    # The following updates only occur if previously ACTIVE
+    # The following updates only occur if not previous exited
     state.validator_registry_exit_count += 1
     validator.exit_count = state.validator_registry_exit_count
     state.validator_registry_delta_chain_tip = get_new_validator_registry_delta_chain_tip(

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1195,6 +1195,8 @@ def update_validator_status(index: int,
         exit_validator(index, state, new_status)
 ```
 
+The following are helpers and should only be called via `update_validator_status`:
+
 ```python
 def activate_validator(index: int,
                        state: BeaconState) -> None:
@@ -1321,7 +1323,7 @@ For each `proposer_slashing` in `block.body.proposer_slashings`:
 * Verify that `proposer_slashing.proposal_data_1.shard == proposer_slashing.proposal_data_2.shard`.
 * Verify that `proposer_slashing.proposal_data_1.block_hash != proposer_slashing.proposal_data_2.block_hash`.
 * Verify that `proposer.status != EXITED_WITH_PENALTY`.
-* Run `exit_validator(proposer_slashing.proposer_index, state, new_status=EXITED_WITH_PENALTY)`.
+* Run `update_validator_status(proposer_slashing.proposer_index, state, new_status=EXITED_WITH_PENALTY)`.
 
 #### Casper slashings
 
@@ -1336,7 +1338,7 @@ For each `casper_slashing` in `block.body.casper_slashings`:
 * Let `intersection = [x for x in indices(casper_slashing.votes_1) if x in indices(casper_slashing.votes_2)]`.
 * Verify that `len(intersection) >= 1`.
 * Verify that `casper_slashing.votes_1.data.justified_slot + 1 < casper_slashing.votes_2.data.justified_slot + 1 == casper_slashing.votes_2.data.slot < casper_slashing.votes_1.data.slot` or `casper_slashing.votes_1.data.slot == casper_slashing.votes_2.data.slot`.
-* For each [validator](#dfn-validator) index `i` in `intersection`, if `state.validator_registry[i].status` does not equal `EXITED_WITH_PENALTY`, then run `exit_validator(i, state, new_status=EXITED_WITH_PENALTY)`
+* For each [validator](#dfn-validator) index `i` in `intersection`, if `state.validator_registry[i].status` does not equal `EXITED_WITH_PENALTY`, then run `update_validator_status(i, state, new_status=EXITED_WITH_PENALTY)`
 
 #### Attestations
 
@@ -1403,7 +1405,7 @@ For each `exit` in `block.body.exits`:
 * Verify that `validator.status == ACTIVE`.
 * Verify that `state.slot >= exit.slot`.
 * Verify that `state.slot >= validator.latest_status_change_slot + SHARD_PERSISTENT_COMMITTEE_CHANGE_PERIOD`.
-* Run `exit_validator(validator_index, state, new_status=ACTIVE_PENDING_EXIT)`.
+* Run `update_validator_status(validator_index, state, new_status=ACTIVE_PENDING_EXIT)`.
 
 ### Ejections
 
@@ -1415,9 +1417,9 @@ def process_ejections(state: BeaconState) -> None:
     Iterate through the validator registry
     and eject active validators with balance below ``EJECTION_BALANCE``.
     """
-    for i, v in enumerate(state.validator_registry):
-        if is_active_validator(v) and v.balance < EJECTION_BALANCE:
-            exit_validator(i, state, new_status=EXITED_WITHOUT_PENALTY)
+    for index, validator in enumerate(state.validator_registry):
+        if is_active_validator(validor) and validator.balance < EJECTION_BALANCE:
+            update_validator_status(index, state, new_status=EXITED_WITHOUT_PENALTY)
 ```
 
 ## Per-epoch processing

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1013,7 +1013,7 @@ def integer_squareroot(n: int) -> int:
 
 #### `BLSVerify`
 
-`BLSVerify` is a function for verifying a BLS12-381 signature, defined in the [BLS12-381 spec](https://github.com/ethereum/eth2.0-specs/blob/master/specs/bls_verify.md).
+`BLSVerify` is a function for verifying a BLS12-381 signature, defined in the [BLS Verification spec](https://github.com/ethereum/eth2.0-specs/blob/master/specs/bls_verify.md).
 
 ### On startup
 


### PR DESCRIPTION
addresses #274 and #268 

* Setup initial validators via `process_deposit` and normal activation to better reuse code and ensure that the `validator_registry_delta_chain` is built
* handle all validator status updates via `update_validator_status`
* `exit_validator` is no longer used for changing `ACTIVE` -> `ACTIVE_PENDING_EXIT`
* `exit_validator` only removes validator from `persistent_committees` and updates `validator_registry_delta_chain` if not previously already exited
    * _note_: This protects against doing repeated actions when slashing a validator that has already exited to status `EXIT_WITHOUT_PENALTY

Not addressed but worth noting here:
* There was language around the definition of `process_deposit` that said deposits from 1.0 should be processed in order as they were submit in the 1.0 chain, but there is no mechanism in "per-slot - deposits" to ensure this validity when processing a block. This needs to be considered more and handled in another PR. the `Deposit` object might need a `source` field (to distinguish 1.0 vs 2.0 deposits) and the `BeaconState` might need to remember the last deposit hash processed from the 1.0 chain.
