### PR TITLE
Fix 'validator_index': 'uint64' -> 'uint24'

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -379,7 +379,7 @@ Unless otherwise indicated, code appearing in `this style` is to be interpreted 
     # Minimum slot for processing exit
     'slot': 'uint64',
     # Index of the exiting validator
-    'validator_index': 'uint64',
+    'validator_index': 'uint24',
     # Validator signature
     'signature': '[uint384]',
 }


### PR DESCRIPTION
Use `uint24` for the validator indices.