### PR TITLE
deposit contract: reduce on-chain computation

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -608,6 +608,7 @@ MAX_DEPOSIT: constant(uint256) = 32  # ETH
 GWEI_PER_ETH: constant(uint256) = 1000000000  # 10**9
 CHAIN_START_FULL_DEPOSIT_THRESHOLD: constant(uint256) = 16384  # 2**14
 DEPOSIT_CONTRACT_TREE_DEPTH: constant(uint256) = 32
+TWO_TO_POWER_OF_TREE_DEPTH: constant(uint256) = 4294967296  # 2**32
 SECONDS_PER_DAY: constant(uint256) = 86400
 
 Eth1Deposit: event({previous_receipt_root: bytes32, data: bytes[2064], deposit_count: uint256})
@@ -623,7 +624,7 @@ def deposit(deposit_parameters: bytes[2048]):
     assert msg.value >= as_wei_value(MIN_DEPOSIT, "ether")
     assert msg.value <= as_wei_value(MAX_DEPOSIT, "ether")
 
-    index: uint256 = self.deposit_count + 2**DEPOSIT_CONTRACT_TREE_DEPTH
+    index: uint256 = self.deposit_count + TWO_TO_POWER_OF_TREE_DEPTH
     msg_gwei_bytes8: bytes[8] = slice(concat("", convert(msg.value / GWEI_PER_ETH, bytes32)), start=24, len=8)
     timestamp_bytes8: bytes[8] = slice(concat("", convert(block.timestamp, bytes32)), start=24, len=8)
     deposit_data: bytes[2064] = concat(msg_gwei_bytes8, timestamp_bytes8, deposit_parameters)

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -85,8 +85,8 @@
     - [Per-slot processing](#per-slot-processing)
         - [Misc counters](#misc-counters)
         - [Block roots](#block-roots)
-    - [Per-block processing](#per-block-processing)  
-        - [Slot](#slot)  
+    - [Per-block processing](#per-block-processing)
+        - [Slot](#slot)
         - [Proposer signature](#proposer-signature)
         - [RANDAO](#randao)
         - [PoW receipt root](#pow-receipt-root)
@@ -723,7 +723,7 @@ The hash function is denoted by `hash`. In Phase 0 the beacon chain is deployed 
 Note: We aim to migrate to a S[T/N]ARK-friendly hash function in a future Ethereum 2.0 deployment phase.
 
 #### `is_active_validator`
- ```python
+```python
 def is_active_validator(validator: ValidatorRecord) -> bool:
     """
     Checks if ``validator`` is active.
@@ -1449,7 +1449,7 @@ For each `exit` in `block.body.exits`:
 
 * Run `process_ejections(state)`.
 
- ```python
+```python
 def process_ejections(state: BeaconState) -> None:
     """
     Iterate through the validator registry


### PR DESCRIPTION
There's a `2**32` computation in `deposit()` function. Reduce on-chain computation by defining the constant variable `TWO_TO_POWER_OF_TREE_DEPTH: constant(uint256) = 4294967296`.