### PR TITLE
clarified language around start_up

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -85,8 +85,8 @@
     - [Per-slot processing](#per-slot-processing)
         - [Misc counters](#misc-counters)
         - [Block roots](#block-roots)
-    - [Per-block processing](#per-block-processing)  
-        - [Slot](#slot)  
+    - [Per-block processing](#per-block-processing)
+        - [Slot](#slot)
         - [Proposer signature](#proposer-signature)
         - [RANDAO](#randao)
         - [PoW receipt root](#pow-receipt-root)
@@ -592,7 +592,7 @@ Every deposit, of size between `MIN_DEPOSIT` and `MAX_DEPOSIT`, emits an `Eth1De
 
 ### `ChainStart` log
 
-When sufficiently many full deposits have been made the deposit contract emits the `ChainStart` log. The beacon chain may then be initialized by calling the `on_startup` function (defined below) where:
+When sufficiently many full deposits have been made the deposit contract emits the `ChainStart` log. The beacon chain may then be initialized by calling the `get_initial_beacon_state` function (defined below) where:
 
 * `genesis_time` equals `time` in the `ChainStart` log
 * `processed_pow_receipt_root` equals `receipt_root` in the `ChainStart` log
@@ -1060,10 +1060,10 @@ A valid block with slot `INITIAL_SLOT_NUMBER` (a "genesis block") has the follow
 }
 ```
 
-`STARTUP_STATE_ROOT` is the root of the initial state, computed by running the following code:
+`STARTUP_STATE_ROOT` (in the above "genesis block") is generated from the `get_initial_beacon_state` function below. When enough full deposits have been made to the deposit contract and the `ChainStart` log has been emitted, `get_initial_beacon_state` will execute to compute the `ssz_tree_hash` of `BeaconState`.
 
 ```python
-def on_startup(initial_validator_deposits: List[Deposit],
+def get_initial_beacon_state(initial_validator_deposits: List[Deposit],
                genesis_time: int,
                processed_pow_receipt_root: Hash32) -> BeaconState:
     state = BeaconState(
@@ -1267,7 +1267,7 @@ def exit_validator(state: BeaconState,
     prev_status = validator.status
 
     if prev_status == EXITED_WITH_PENALTY:
-        return 
+        return
 
     validator.status = new_status
     validator.latest_status_change_slot = state.slot

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -592,7 +592,7 @@ Every deposit, of size between `MIN_DEPOSIT` and `MAX_DEPOSIT`, emits an `Eth1De
 
 ### `ChainStart` log
 
-When sufficiently many full deposits have been made the deposit contract emits the `ChainStart` log. The beacon chain may then be initialized by calling the `get_initial_beacon_state` function (defined below) where:
+When sufficiently many full deposits have been made the deposit contract emits the `ChainStart` log. The beacon chain state may then be initialized by calling the `get_initial_beacon_state` function (defined below) where:
 
 * `genesis_time` equals `time` in the `ChainStart` log
 * `processed_pow_receipt_root` equals `receipt_root` in the `ChainStart` log
@@ -1064,8 +1064,8 @@ A valid block with slot `INITIAL_SLOT_NUMBER` (a "genesis block") has the follow
 
 ```python
 def get_initial_beacon_state(initial_validator_deposits: List[Deposit],
-               genesis_time: int,
-               processed_pow_receipt_root: Hash32) -> BeaconState:
+                             genesis_time: int,
+                             processed_pow_receipt_root: Hash32) -> BeaconState:
     state = BeaconState(
         # Misc
         slot=INITIAL_SLOT_NUMBER,


### PR DESCRIPTION
Renamed `on_startup` to `get_initial_beacon_state` and clarified language around the `get_initial_beacon_state ` functionality.