### PR TITLE
Edit latest_block_roots in place instead of as a queue

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1337,7 +1337,7 @@ Below are the processing steps that happen at every slot.
 ### Block roots
 
 * Let `previous_block_root` be the `tree_hash_root` of the previous beacon block processed in the chain.
-* Set `state.latest_block_roots = state.latest_block_roots[1:] + [previous_block_root]`.
+* Set `state.latest_block_roots[(state.slot - 1) % LATEST_BLOCK_ROOTS_LENGTH] = previous_block_root`.
 * If `state.slot % LATEST_BLOCK_ROOTS_LENGTH == 0` append `merkle_root(state.latest_block_roots)` to `state.batched_block_roots`.
 
 ## Per-block processing


### PR DESCRIPTION
Faster editing that way; otherwise every block will require completely reconstructing a 8192-sized Merkle tree.