### PR TITLE
Remove line repeat in activate_validator & initiate_validator_exit

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1338,7 +1338,6 @@ def initiate_validator_exit(state: BeaconState,
     if validator.status != ACTIVE:
         return
 
-    validator = state.validator_registry[index]
     validator.status = ACTIVE_PENDING_EXIT
     validator.latest_status_change_slot = state.slot
 ```

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1317,7 +1317,6 @@ def activate_validator(state: BeaconState,
     if validator.status != PENDING_ACTIVATION:
         return
 
-    validator = state.validator_registry[index]
     validator.status = ACTIVE
     validator.latest_status_change_slot = state.slot
     state.validator_registry_delta_chain_tip = get_new_validator_registry_delta_chain_tip(


### PR DESCRIPTION
`    validator = state.validator_registry[index]` is assigned twice in `activate_validator` and `initiate_validator_exit`; the repeat assignments aren't necessary.