### PR TITLE
Update VRC contract for Vyper v0.1.0-beta.6

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -621,7 +621,7 @@ When sufficiently many full deposits have been made the deposit contract emits t
 ### Vyper code
 
 ```python
-## compiled with v0.1.0-beta.4 ##
+## compiled with v0.1.0-beta.6 ##
 
 MIN_DEPOSIT: constant(uint256) = 1  # ETH
 MAX_DEPOSIT: constant(uint256) = 32  # ETH
@@ -634,7 +634,7 @@ SECONDS_PER_DAY: constant(uint256) = 86400
 Eth1Deposit: event({previous_receipt_root: bytes32, data: bytes[2064], deposit_count: uint256})
 ChainStart: event({receipt_root: bytes32, time: bytes[8]})
 
-receipt_tree: bytes32[uint256]
+receipt_tree: map(uint256, bytes32)
 deposit_count: uint256
 full_deposit_count: uint256
 


### PR DESCRIPTION
[Issue #221](https://github.com/ethereum/eth2.0-specs/issues/221) required that the Validator Registration Contract be compiled in Vyper v0.1.0-beta.4 instead of  Vyper v0.1.0-beta.5 due to a bug in contract compilation. The issue has been resolved in the latest  Vyper v0.1.0-beta.6. Contract has been updated to reflect the latest syntax and compiler version annotation has been updated.