### PR TITLE
Potential typo for crosslinks?

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1648,9 +1648,9 @@ Set `state.finalized_slot = state.previous_justified_slot` if any of the followi
 
 ### Crosslinks
 
-For every `shard_committee` in `state.shard_committees_at_slots`:
+For every `shard_committee_at_slot` in `state.shard_committees_at_slots` and for every `shard_committee`in `shard_committee_at_slot`:
 
-* Set `state.latest_crosslinks[shard] = CrosslinkRecord(slot=state.slot, block_root=winning_root(shard_committee))` if `3 * total_attesting_balance(shard_committee) >= 2 * total_balance(shard_committee)`.
+* Set `state.latest_crosslinks[shard_committee.shard] = CrosslinkRecord(slot=state.slot, block_root=winning_root(shard_committee))` if `3 * total_attesting_balance(shard_committee) >= 2 * total_balance(shard_committee)`.
 
 ### Rewards and penalties
 


### PR DESCRIPTION
Let me know if these changes make sense, `state.shard_committees_at_slots` is a nested array first packed by slot then packed by shard, I think we need to unpack it again after `shard_committee`

I also changed `latest_crosslinks[shard]` to `latest_crosslinks[shard_committee.shard]`