### PR TITLE
fix slashing conditons

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1080,7 +1080,9 @@ def is_double_vote(attestation_data_1: AttestationData,
     Returns True if the provided ``AttestationData`` are slashable
     due to a 'double vote'.
     """
-    return attestation_data_1.slot == attestation_data_2.slot
+    target_epoch_1 = attestation_data_1.slot // EPOCH_LENGTH
+    target_epoch_2 = attestation_data_2.slot // EPOCH_LENGTH
+    return target_epoch_1 == target_epoch_2
 ```
 
 #### `is_surround_vote`
@@ -1095,10 +1097,14 @@ def is_surround_vote(attestation_data_1: AttestationData,
     Note: parameter order matters as this function only checks
     that ``attestation_data_1`` surrounds ``attestation_data_2``.
     """
+    source_epoch_1 = attestation_data_1.justified_slot // EPOCH_LENGTH
+    source_epoch_2 = attestation_data_2.justified_slot // EPOCH_LENGTH
+    target_epoch_1 = attestation_data_1.slot // EPOCH_LENGTH
+    target_epoch_2 = attestation_data_2.slot // EPOCH_LENGTH
     return (
-        (attestation_data_1.justified_slot < attestation_data_2.justified_slot) and
-        (attestation_data_2.justified_slot + 1 == attestation_data_2.slot) and
-        (attestation_data_2.slot < attestation_data_1.slot)
+        (source_epoch_1 < source_epoch_2) and
+        (source_epoch_2 + 1 == target_epoch_2) and
+        (target_epoch_2 < target_epoch_1)
     )
 ```
 


### PR DESCRIPTION
There were bugs in both `is_surround_vote` and `is_double_vote`. Bugs were fixed by doing all checks wrt epoch number rather than slot number.

* addresses #362 
* addresses bug in `is_surround`
  * `attestation_data_2.justified_slot + 1 == attestation_data_2.slot` was not correctly checking if `attestation_data_2` could have been a finality vote because `justified_slot + 1` would never equal `sot`

_Note/question_:
We could do the same thing for the proposer slashings and only allow a proposer to make one block per epoch. I don't think this is strictly required, but this would prevent them from opportunistically following two shufflings and proposing on both if they happened to be selected to propose in both within one epoch. That said, it is unlikely that a proposer would be selected to propose in the same epoch in two alternate shufflings.
