### PR TITLE
concatenation for hash function

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1529,9 +1529,9 @@ def verify_merkle_branch(leaf: Hash32, branch: [Hash32], depth: int, index: int,
     value = leaf
     for i in range(depth):
         if index % 2:
-            value = hash(branch[i], value)
+            value = hash(branch[i] + value)
         else:
-            value = hash(value, branch[i])
+            value = hash(value + branch[i])
     return value == root
 ```
 


### PR DESCRIPTION
I don't think `hash` takes 2 arguments, we are missing a `+` in the middle