### PR TITLE
Rename `pow_receipt_` to `deposit_`

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -420,7 +420,7 @@ Unless otherwise indicated, code appearing in `this style` is to be interpreted 
     'parent_root': 'hash32',
     'state_root': 'hash32',
     'randao_reveal': 'hash32',
-    'deposit_root_vote': 'hash32',
+    'deposit_root': 'hash32',
     'signature': ['uint384'],
 
     ## Body ##
@@ -559,7 +559,7 @@ Unless otherwise indicated, code appearing in `this style` is to be interpreted 
 ```python
 {
     # Deposit root
-    'deposit_root_vote': 'hash32',
+    'deposit_root': 'hash32',
     # Vote count
     'vote_count': 'uint64',
 }
@@ -1131,7 +1131,7 @@ A valid block with slot `INITIAL_SLOT_NUMBER` (a "genesis block") has the follow
     parent_root=ZERO_HASH,
     state_root=STARTUP_STATE_ROOT,
     randao_reveal=ZERO_HASH,
-    deposit_root_vote=ZERO_HASH,
+    deposit_root=ZERO_HASH,
     signature=EMPTY_SIGNATURE,
     body=BeaconBlockBody(
         proposer_slashings=[],
@@ -1453,8 +1453,8 @@ Below are the processing steps that happen at every `block`.
 
 ### Deposit root
 
-* If `block.deposit_root_vote` is `x.deposit_root_vote` for some `x` in `state.deposit_root_votes`, set `x.vote_count += 1`.
-* Otherwise, append to `state.deposit_root_votes` a new `DepositRootVote(deposit_root_vote=block.deposit_root_vote, vote_count=1)`.
+* If `block.deposit_root` is `deposit_root_vote.deposit_root` for some `deposit_root_vote` in `state.deposit_root_votes`, set `deposit_root_vote.vote_count += 1`.
+* Otherwise, append to `state.deposit_root_votes` a new `DepositRootVote(deposit_root=block.deposit_root, vote_count=1)`.
 
 ### Operations
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -623,7 +623,7 @@ The private key corresponding to `withdrawal_pubkey` will be required to initiat
 
 ### `Deposit` logs
 
-Every Ethereum 1.0 deposit, of size between `MIN_DEPOSIT` and `MAX_DEPOSIT`, emits an `Deposit` log for consumption by the beacon chain. The deposit contract does little validation, pushing most of the validator onboarding logic to the beacon chain. In particular, the proof of possession (a BLS12-381 signature) is not verified by the deposit contract.
+Every Ethereum 1.0 deposit, of size between `MIN_DEPOSIT` and `MAX_DEPOSIT`, emits a `Deposit` log for consumption by the beacon chain. The deposit contract does little validation, pushing most of the validator onboarding logic to the beacon chain. In particular, the proof of possession (a BLS12-381 signature) is not verified by the deposit contract.
 
 ### `ChainStart` log
 
@@ -701,7 +701,7 @@ For a beacon chain block, `block`, to be processed by a node, the following cond
 
 * The parent block with root `block.parent_root` has been processed and accepted.
 * The node has processed its `state` up to slot, `block.slot - 1`.
-* A Ethereum 1.0 block pointed to by the `state.latest_deposit_root` has been processed and accepted.
+* An Ethereum 1.0 block pointed to by the `state.latest_deposit_root` has been processed and accepted.
 * The node's local clock time is greater than or equal to `state.genesis_time + block.slot * SLOT_DURATION`.
 
 If these conditions are not met, the client should delay processing the beacon block until the conditions are all satisfied.


### PR DESCRIPTION
1. Per #358 item (3) - `pow_receipt_` to `deposit_`
    - `POW_RECEIPT_ROOT_VOTING_PERIOD` => `DEPOSIT_ROOT_VOTING_PERIOD`
    - `CandidatePoWReceiptRootRecord` => `DepositRootVote`
    - `candidate_pow_receipt_root` => `deposit_root_vote`
    - `processed_pow_receipt_root` => `processed_deposit_root`
2. Refactor `### Deposit roots` a little.
3. Also update #358 item (7). Misc shortenings in state - `candidate_pow_receipt_roots` => `deposit_root_votes` 