### PR TITLE
Fix a type error with units of wei when determining ejection balance.

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1690,7 +1690,7 @@ def process_ejections(state: BeaconState) -> None:
     and eject active validators with balance below ``EJECTION_BALANCE``.
     """
     for index in active_validator_indices(state.validator_registry):
-        if state.validator_balances[index] < EJECTION_BALANCE:
+        if state.validator_balances[index] < EJECTION_BALANCE * GWEI_PER_ETH:
             update_validator_status(state, index, new_status=EXITED_WITHOUT_PENALTY)
 ```
 


### PR DESCRIPTION
`EJECTION_BALANCE` is in units of ETH.

`state.validator_balances[index]` is in units of Gwei.

For the ejection computation to work as desired, we need to convert the
`EJECTION_BALANCE` constant from ETH to Gwei.