### PR TITLE
Fixes bug with Merkle proof branch selection

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1518,7 +1518,7 @@ For each `deposit` in `block.body.deposits`:
 def verify_merkle_branch(leaf: Hash32, branch: [Hash32], depth: int, index: int, root: Hash32) -> bool:
     value = leaf
     for i in range(depth):
-        if index % 2:
+        if index // (2**i) % 2:
             value = hash(branch[i] + value)
         else:
             value = hash(value + branch[i])


### PR DESCRIPTION
This code determines the order in which the next branch element and the
current value should be hashed to produce the parent node in the Merkle tree.

The existing code fails to verify branches constructed in the standard way.

This patch fixes the spec code so that it works properly by using an appropriate
parity calculation.

Example code here to illustrate it working:
https://gist.github.com/ralexstokes/9d82e188bd3286ff74a1fa1dcb5068e0