### PR TITLE
Fix deserialize uint bounds logic

### DIFF
--- a/specs/simple-serialize.md
+++ b/specs/simple-serialize.md
@@ -248,10 +248,10 @@ size as the integer length. (e.g. ``uint16 == 2 bytes``)
 All integers are interpreted as **big endian**.
 
 ```python
-assert(len(rawbytes) >= current_index + int_size)
 byte_length = int_size / 8
-new_index = current_index + int_size
-return int.from_bytes(rawbytes[current_index:current_index+int_size], 'big'), new_index
+new_index = current_index + byte_length
+assert(len(rawbytes) >= new_index)
+return int.from_bytes(rawbytes[current_index:new_index], 'big'), new_index
 ```
 
 #### Bool

--- a/specs/simple-serialize.md
+++ b/specs/simple-serialize.md
@@ -251,7 +251,7 @@ All integers are interpreted as **big endian**.
 byte_length = int_size / 8
 new_index = current_index + byte_length
 assert(len(rawbytes) >= new_index)
-return int.from_bytes(rawbytes[current_index:new_index], 'big'), new_index
+return int.from_bytes(rawbytes[current_index:current_index+byte_length], 'big'), new_index
 ```
 
 #### Bool


### PR DESCRIPTION
I believe the array accesses should be relative to uint byte length, not bit length.