### PR TITLE
Fixes typo in `sorted` function.

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1729,7 +1729,7 @@ def process_penalties_and_exits(state: BeaconState) -> None:
 
     all_indices = list(range(len(state.validator_registry)))
     eligible_indices = filter(eligible, all_indices)
-    sorted_indices = sorted(eligible_indices, filter=lambda index: state.validator_registry[index].exit_count)
+    sorted_indices = sorted(eligible_indices, key=lambda index: state.validator_registry[index].exit_count)
     withdrawn_so_far = 0
     for index in sorted_indices:
         validator = state.validator_registry[index]


### PR DESCRIPTION
In keeping with the rest of the code in this document we adhere to valid Python
where possible.

The custom comparator keyword argument for `sorted` in Python3 is `key` so this commit
updates its usage when sorting validators by exit order.