### PR TITLE
Removes naming conflict in get_shuffling.

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -885,11 +885,11 @@ def get_shuffling(seed: Hash32,
     validators_per_slot = split(shuffled_active_validator_indices, EPOCH_LENGTH)
 
     output = []
-    for slot_num, slot_indices in enumerate(validators_per_slot):
+    for slot_position, slot_indices in enumerate(validators_per_slot):
         # Split the shuffled list into committees_per_slot pieces
         shard_indices = split(slot_indices, committees_per_slot)
 
-        shard_id_start = crosslinking_start_shard + slot_num * committees_per_slot
+        shard_id_start = crosslinking_start_shard + slot_position * committees_per_slot
 
         shard_committees = [
             ShardCommittee(

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -885,11 +885,11 @@ def get_shuffling(seed: Hash32,
     validators_per_slot = split(shuffled_active_validator_indices, EPOCH_LENGTH)
 
     output = []
-    for slot, slot_indices in enumerate(validators_per_slot):
+    for slot_num, slot_indices in enumerate(validators_per_slot):
         # Split the shuffled list into committees_per_slot pieces
         shard_indices = split(slot_indices, committees_per_slot)
 
-        shard_id_start = crosslinking_start_shard + slot * committees_per_slot
+        shard_id_start = crosslinking_start_shard + slot_num * committees_per_slot
 
         shard_committees = [
             ShardCommittee(


### PR DESCRIPTION
The variable name 'slot' in the for-loop in 'get_shuffling' conflicts with the get_shuffling argument name 'slot'. Renames 'slot' in for-loop to 'slot_num'.