### PR TITLE
Only require crosslinks from current epoch

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1658,7 +1658,7 @@ def process_ejections(state: BeaconState) -> None:
 If the following are satisfied:
 
 * `state.finalized_slot > state.validator_registry_latest_change_slot`
-* `state.latest_crosslinks[shard].slot > state.validator_registry_latest_change_slot` for every shard number `shard` in `shard_committee` from `shard_committee_at_slot` in `state.shard_committees_at_slots`
+* `state.latest_crosslinks[shard].slot > state.validator_registry_latest_change_slot` for every shard number `shard` in `shard_committee` from each `shard_committee_at_slot` in `state.shard_committees_at_slots[EPOCH_LENGTH:]`
 
 update the validator registry and associated fields by running
 


### PR DESCRIPTION
# Issue
We were requiring crosslinks from both the previous epoch's crosslink_committees and the current for a validator registry change to occur. Depending on the number of validators and the configuration, this could prevent validator registry changes indefinitely.

# solution
only require crosslinks from the latter half of the `crosslink_committees_at_slots` array.