### PR TITLE
Replace numeric constant with symbolic in Vyper contract

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -675,7 +675,7 @@ def deposit(deposit_input: bytes[2048]):
 
     # add deposit to merkle tree
     self.deposit_tree[index] = sha3(deposit_data)
-    for i in range(32):  # DEPOSIT_CONTRACT_TREE_DEPTH (range of constant var not yet supported)
+    for i in range(DEPOSIT_CONTRACT_TREE_DEPTH):
         index /= 2
         self.deposit_tree[index] = sha3(concat(self.deposit_tree[index * 2], self.deposit_tree[index * 2 + 1]))
 


### PR DESCRIPTION
Vyper v0.1.0-beta.6 supports ranges with symbolic constants.