### PR TITLE
Add getter to Vyper contract for Merkle branches

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -694,9 +694,9 @@ def get_deposit_root() -> bytes32:
 
 @public
 @constant
-def get_merkle_branch(index: uint256) -> bytes32[32]: # size is DEPOSIT_CONTRACT_TREE_DEPTH (symbolic const not supported)
+def get_merkle_branch(deposit_count: uint256) -> bytes32[32]: # size is DEPOSIT_CONTRACT_TREE_DEPTH (symbolic const not supported)
     branch: bytes32[32] # size is DEPOSIT_CONTRACT_TREE_DEPTH
-    index = index + TWO_TO_POWER_OF_TREE_DEPTH
+    index: uint256 = deposit_count + TWO_TO_POWER_OF_TREE_DEPTH
     for i in range(DEPOSIT_CONTRACT_TREE_DEPTH):
         branch[i] = self.deposit_tree[bitwise_xor(index, 1)]
         index /= 2

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -692,6 +692,18 @@ def deposit(deposit_input: bytes[2048]):
 def get_deposit_root() -> bytes32:
     return self.deposit_tree[1]
 
+@public
+@constant
+def get_merkle_branch(index: uint256) -> bytes32[32]: # size is DEPOSIT_CONTRACT_TREE_DEPTH (symbolic const not supported)
+    idx: uint256 = index + TWO_TO_POWER_OF_TREE_DEPTH
+    ret: bytes32[32] # size is DEPOSIT_CONTRACT_TREE_DEPTH
+    for i in range(DEPOSIT_CONTRACT_TREE_DEPTH):
+        if idx % 2 == 1:
+            ret[i] = self.deposit_tree[idx - 1]
+        else:
+            ret[i] = self.deposit_tree[idx + 1]
+        idx /= 2
+    return ret
 ```
 
 ## Beacon chain processing

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -698,10 +698,7 @@ def get_merkle_branch(index: uint256) -> bytes32[32]: # size is DEPOSIT_CONTRACT
     idx: uint256 = index + TWO_TO_POWER_OF_TREE_DEPTH
     ret: bytes32[32] # size is DEPOSIT_CONTRACT_TREE_DEPTH
     for i in range(DEPOSIT_CONTRACT_TREE_DEPTH):
-        if idx % 2 == 1:
-            ret[i] = self.deposit_tree[idx - 1]
-        else:
-            ret[i] = self.deposit_tree[idx + 1]
+        ret[i] = self.deposit_tree[bitwise_xor(idx,1)]
         idx /= 2
     return ret
 ```

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -694,9 +694,9 @@ def get_deposit_root() -> bytes32:
 
 @public
 @constant
-def get_merkle_branch(deposit_count: uint256) -> bytes32[32]: # size is DEPOSIT_CONTRACT_TREE_DEPTH (symbolic const not supported)
+def get_branch(leaf: uint256) -> bytes32[32]: # size is DEPOSIT_CONTRACT_TREE_DEPTH (symbolic const not supported)
     branch: bytes32[32] # size is DEPOSIT_CONTRACT_TREE_DEPTH
-    index: uint256 = deposit_count + TWO_TO_POWER_OF_TREE_DEPTH
+    index: uint256 = leaf + TWO_TO_POWER_OF_TREE_DEPTH
     for i in range(DEPOSIT_CONTRACT_TREE_DEPTH):
         branch[i] = self.deposit_tree[bitwise_xor(index, 1)]
         index /= 2

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -695,8 +695,8 @@ def get_deposit_root() -> bytes32:
 @public
 @constant
 def get_merkle_branch(index: uint256) -> bytes32[32]: # size is DEPOSIT_CONTRACT_TREE_DEPTH (symbolic const not supported)
-    index = index + TWO_TO_POWER_OF_TREE_DEPTH
     branch: bytes32[32] # size is DEPOSIT_CONTRACT_TREE_DEPTH
+    index = index + TWO_TO_POWER_OF_TREE_DEPTH
     for i in range(DEPOSIT_CONTRACT_TREE_DEPTH):
         branch[i] = self.deposit_tree[bitwise_xor(index, 1)]
         index /= 2

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -695,12 +695,12 @@ def get_deposit_root() -> bytes32:
 @public
 @constant
 def get_merkle_branch(index: uint256) -> bytes32[32]: # size is DEPOSIT_CONTRACT_TREE_DEPTH (symbolic const not supported)
-    idx: uint256 = index + TWO_TO_POWER_OF_TREE_DEPTH
-    ret: bytes32[32] # size is DEPOSIT_CONTRACT_TREE_DEPTH
+    index = index + TWO_TO_POWER_OF_TREE_DEPTH
+    branch: bytes32[32] # size is DEPOSIT_CONTRACT_TREE_DEPTH
     for i in range(DEPOSIT_CONTRACT_TREE_DEPTH):
-        ret[i] = self.deposit_tree[bitwise_xor(idx,1)]
-        idx /= 2
-    return ret
+        branch[i] = self.deposit_tree[bitwise_xor(index, 1)]
+        index /= 2
+    return branch
 ```
 
 ## Beacon chain processing


### PR DESCRIPTION
Returns the Merkle branch for the leaf at index `index`. This getter provides an alternative way for beacon chain proposers to access the Merkle tree of deposits, rather than being Ethereum 1.0 light clients. The method can be called on a trusted Ethereum 1.0 archive node at specific past block numbers via RPC/IPC to retrieve the Merkle branch needed to register a validator.