### PR TITLE
Fix for Issue #416

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -922,7 +922,7 @@ def get_shard_committees_at_slot(state: BeaconState,
     """
     earliest_slot_in_array = state.slot - (state.slot % EPOCH_LENGTH) - EPOCH_LENGTH
     assert earliest_slot_in_array <= slot < earliest_slot_in_array + EPOCH_LENGTH * 2
-    return state.shard_committees_at_slots[slot - earliest_slot_in_array]
+    return state.shard_committees_at_slots[max(slot, slot - earliest_slot_in_array)]
 ```
 
 #### `get_block_root`


### PR DESCRIPTION
Issue #416 allows the value of the array `slot - earliest_slot_in_array` for pass below zero before being used as an index in `return state.shard_committees_at_slots[slot - earliest_slot_in_array]`. 

I added a `max(slot, slot - earliest_slot_in_array)` to keep the value from passing below 0.