### PR TITLE
add assertion to integer_squareroot() to prevent negative results.

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1097,6 +1097,7 @@ def integer_squareroot(n: int) -> int:
     """
     The largest integer ``x`` such that ``x**2`` is less than ``n``.
     """
+    assert n >= 0
     x = n
     y = (x + 1) // 2
     while y < x:


### PR DESCRIPTION
- resolves #425 ~by setting `x=int(n)`~  
- added an assertion that `n >= 0` to prevent negative results.