### PR TITLE
Fix typo with initial generation of `latest_penalized_exit_balances`

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1182,7 +1182,7 @@ def get_initial_beacon_state(initial_validator_deposits: List[Deposit],
         # Recent state
         latest_crosslinks=[CrosslinkRecord(slot=GENESIS_SLOT, shard_block_root=ZERO_HASH) for _ in range(SHARD_COUNT)],
         latest_block_roots=[ZERO_HASH for _ in range(LATEST_BLOCK_ROOTS_LENGTH)],
-        latest_penalized_exit_balances=[0 for _ in LATEST_PENALIZED_EXIT_LENGTH],
+        latest_penalized_exit_balances=[0 for _ in range(LATEST_PENALIZED_EXIT_LENGTH)],
         latest_attestations=[],
         batched_block_roots=[],
 


### PR DESCRIPTION
The spec as written is not valid python -- the generator of the list
comprehension must be iterable.

It looks like the author simply meant to `range` over the intended length.

This commit fixes the missing `range` operator