### PR TITLE
Replace shard_committee with crosslink_committee

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -931,7 +931,7 @@ def get_current_epoch_committee_count_per_slot(state: BeaconState) -> int:
 
 ```python
 def get_crosslink_committees_at_slot(state: BeaconState,
-                                 slot: int) -> List[Tuple[List[int], int]]:
+                                     slot: int) -> List[Tuple[List[int], int]]:
     """
     Returns the list of ``(committee, shard)`` tuples for the ``slot``.
     """

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -881,7 +881,7 @@ def get_shuffling(seed: Hash32,
                   validators: List[ValidatorRecord],
                   slot: int) -> List[List[int]]
     """
-    Shuffles ``validators`` into shard committees seeded by ``seed`` and ``slot``.
+    Shuffles ``validators`` into crosslink committees seeded by ``seed`` and ``slot``.
     Returns a list of ``EPOCH_LENGTH * committees_per_slot`` committees where each
     committee is itself a list of validator indices.
     """


### PR DESCRIPTION
This is part of #358 (Item 6)

We replaced `shard_committee` with `crosslink_committee`