### PR TITLE
Update BLS and core specs for `bytes32` and `bytes48` SSZ types

### DIFF
--- a/specs/bls_signature.md
+++ b/specs/bls_signature.md
@@ -106,11 +106,11 @@ def modular_squareroot(value: int) -> int:
 
 ### `bls_aggregate_pubkeys`
 
-Let `bls_aggregate_pubkeys(pubkeys: [uint384]) -> uint384` return `pubkeys[0] + .... + pubkeys[len(pubkeys)-1]`, where `+` is the elliptic curve addition operation over the G1 curve.
+Let `bls_aggregate_pubkeys(pubkeys: List[Bytes48]) -> Bytes48` return `pubkeys[0] + .... + pubkeys[len(pubkeys)-1]`, where `+` is the elliptic curve addition operation over the G1 curve.
 
 ### `bls_aggregate_signatures`
 
-Let `bls_aggregate_signatures(signatures: [[uint384]]) -> [uint384]` return `signatures[0] + .... + signatures[len(signatures)-1]`, where `+` is the elliptic curve addition operation over the G2 curve.
+Let `bls_aggregate_signatures(signatures: Tuple[Bytes48, Bytes48]) -> Tuple[Bytes48, Bytes48]` return `signatures[0] + .... + signatures[len(signatures)-1]`, where `+` is the elliptic curve addition operation over the G2 curve.
 
 ## Signature verification
 
@@ -124,7 +124,7 @@ g = Fq2(g_x, g_y)
 
 ### `bls_verify`
 
-Let `bls_verify(pubkey: uint384, message: bytes32, signature: [uint384], domain: uint64) -> bool`:
+Let `bls_verify(pubkey: Bytes48, message: Bytes32, signature: Tuple[Bytes48, Bytes48], domain: uint64) -> bool`:
 
 * Verify that `pubkey` is a valid G1 point.
 * Verify that `signature` is a valid G2 point.
@@ -132,7 +132,7 @@ Let `bls_verify(pubkey: uint384, message: bytes32, signature: [uint384], domain:
 
 ### `bls_verify_multiple`
 
-Let `bls_verify_multiple(pubkeys: [uint384], messages: [bytes32], signature: [uint384], domain: uint64) -> bool`:
+Let `bls_verify_multiple(pubkeys: List[Bytes48], messages: List[Bytes32], signature: Tuple[Bytes48, Bytes48], domain: uint64) -> bool`:
 
 * Verify that each `pubkey` in `pubkeys` is a valid G1 point.
 * Verify that `signature` is a valid G2 point.

--- a/specs/bls_signature.md
+++ b/specs/bls_signature.md
@@ -110,7 +110,7 @@ Let `bls_aggregate_pubkeys(pubkeys: List[Bytes48]) -> Bytes48` return `pubkeys[0
 
 ### `bls_aggregate_signatures`
 
-Let `bls_aggregate_signatures(signatures: List[Tuple[Bytes48, Bytes48]]) -> Tuple[Bytes48, Bytes48]` return `signatures[0] + .... + signatures[len(signatures)-1]`, where `+` is the elliptic curve addition operation over the G2 curve.
+Let `bls_aggregate_signatures(signatures: List[Bytes96]) -> Bytes96` return `signatures[0] + .... + signatures[len(signatures)-1]`, where `+` is the elliptic curve addition operation over the G2 curve.
 
 ## Signature verification
 
@@ -124,7 +124,7 @@ g = Fq2(g_x, g_y)
 
 ### `bls_verify`
 
-Let `bls_verify(pubkey: Bytes48, message: Bytes32, signature: Tuple[Bytes48, Bytes48], domain: uint64) -> bool`:
+Let `bls_verify(pubkey: Bytes48, message: Bytes32, signature: Bytes96, domain: uint64) -> bool`:
 
 * Verify that `pubkey` is a valid G1 point.
 * Verify that `signature` is a valid G2 point.
@@ -132,7 +132,7 @@ Let `bls_verify(pubkey: Bytes48, message: Bytes32, signature: Tuple[Bytes48, Byt
 
 ### `bls_verify_multiple`
 
-Let `bls_verify_multiple(pubkeys: List[Bytes48], messages: List[Bytes32], signature: Tuple[Bytes48, Bytes48], domain: uint64) -> bool`:
+Let `bls_verify_multiple(pubkeys: List[Bytes48], messages: List[Bytes32], signature: Bytes96, domain: uint64) -> bool`:
 
 * Verify that each `pubkey` in `pubkeys` is a valid G1 point.
 * Verify that `signature` is a valid G2 point.

--- a/specs/bls_signature.md
+++ b/specs/bls_signature.md
@@ -110,7 +110,7 @@ Let `bls_aggregate_pubkeys(pubkeys: List[Bytes48]) -> Bytes48` return `pubkeys[0
 
 ### `bls_aggregate_signatures`
 
-Let `bls_aggregate_signatures(signatures: Tuple[Bytes48, Bytes48]) -> Tuple[Bytes48, Bytes48]` return `signatures[0] + .... + signatures[len(signatures)-1]`, where `+` is the elliptic curve addition operation over the G2 curve.
+Let `bls_aggregate_signatures(signatures: List[Tuple[Bytes48, Bytes48]]) -> Tuple[Bytes48, Bytes48]` return `signatures[0] + .... + signatures[len(signatures)-1]`, where `+` is the elliptic curve addition operation over the G2 curve.
 
 ## Signature verification
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -810,7 +810,7 @@ def get_active_validator_indices(validators: [ValidatorRecord], slot: int) -> Li
 #### `shuffle`
 
 ```python
-def shuffle(values: List[Any], seed: Hash32) -> List[Any]:
+def shuffle(values: List[Any], seed: Bytes32) -> List[Any]:
     """
     Returns the shuffled ``values`` with ``seed`` as entropy.
     """
@@ -890,7 +890,7 @@ def get_committee_count_per_slot(active_validator_count: int) -> int:
 #### `get_shuffling`
 
 ```python
-def get_shuffling(seed: Hash32,
+def get_shuffling(seed: Bytes32,
                   validators: List[ValidatorRecord],
                   slot: int) -> List[List[int]]
     """
@@ -984,7 +984,7 @@ def get_crosslink_committees_at_slot(state: BeaconState,
 
 ```python
 def get_block_root(state: BeaconState,
-                   slot: int) -> Hash32:
+                   slot: int) -> Bytes32:
     """
     Returns the block root at a recent ``slot``.
     """
@@ -999,7 +999,7 @@ def get_block_root(state: BeaconState,
 
 ```python
 def get_randao_mix(state: BeaconState,
-                   slot: int) -> Hash32:
+                   slot: int) -> Bytes32:
     """
     Returns the randao mix at a recent ``slot``.
     """
@@ -1023,7 +1023,7 @@ def get_beacon_proposer_index(state: BeaconState,
 #### `merkle_root`
 
 ```python
-def merkle_root(values: List[Hash32]) -> Hash32:
+def merkle_root(values: List[Bytes32]) -> Bytes32:
     """
     Merkleize ``values`` (where ``len(values)`` is a power of two) and return the Merkle root.
     """
@@ -1217,7 +1217,7 @@ A valid block with slot `GENESIS_SLOT` (a "genesis block") has the following val
 ```python
 def get_initial_beacon_state(initial_validator_deposits: List[Deposit],
                              genesis_time: int,
-                             latest_deposit_root: Hash32) -> BeaconState:
+                             latest_deposit_root: Bytes32) -> BeaconState:
     state = BeaconState(
         # Misc
         slot=GENESIS_SLOT,
@@ -1294,9 +1294,9 @@ First, a helper function:
 def validate_proof_of_possession(state: BeaconState,
                                  pubkey: int,
                                  proof_of_possession: bytes,
-                                 withdrawal_credentials: Hash32,
-                                 randao_commitment: Hash32,
-                                 custody_commitment: Hash32) -> bool:
+                                 withdrawal_credentials: Bytes32,
+                                 randao_commitment: Bytes32,
+                                 custody_commitment: Bytes32) -> bool:
     proof_of_possession_data = DepositInput(
         pubkey=pubkey,
         withdrawal_credentials=withdrawal_credentials,
@@ -1324,9 +1324,9 @@ def process_deposit(state: BeaconState,
                     pubkey: int,
                     amount: int,
                     proof_of_possession: bytes,
-                    withdrawal_credentials: Hash32,
-                    randao_commitment: Hash32,
-                    custody_commitment: Hash32) -> None:
+                    withdrawal_credentials: Bytes32,
+                    randao_commitment: Bytes32,
+                    custody_commitment: Bytes32) -> None:
     """
     Process a deposit from Ethereum 1.0.
     Note that this function mutates ``state``.
@@ -1550,7 +1550,7 @@ For each `deposit` in `block.body.deposits`:
 * Verify that `verify_merkle_branch(hash(serialized_deposit_data), deposit.branch, DEPOSIT_CONTRACT_TREE_DEPTH, deposit.index, state.latest_deposit_root)` is `True`.
 
 ```python
-def verify_merkle_branch(leaf: Hash32, branch: [Hash32], depth: int, index: int, root: Hash32) -> bool:
+def verify_merkle_branch(leaf: Bytes32, branch: [Bytes32], depth: int, index: int, root: Bytes32) -> bool:
     value = leaf
     for i in range(depth):
         if index // (2**i) % 2:

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -399,7 +399,7 @@ Unless otherwise indicated, code appearing in `this style` is to be interpreted 
 ```python
 {
     # BLS pubkey
-    'pubkey': 'uint384',
+    'pubkey': 'bytes48',
     # Withdrawal credentials
     'withdrawal_credentials': 'bytes32',
     # Initial RANDAO commitment
@@ -530,7 +530,7 @@ Unless otherwise indicated, code appearing in `this style` is to be interpreted 
 ```python
 {
     # BLS public key
-    'pubkey': 'uint384',
+    'pubkey': 'bytes48',
     # Withdrawal credentials
     'withdrawal_credentials': 'bytes32',
     # RANDAO commitment
@@ -614,7 +614,7 @@ Unless otherwise indicated, code appearing in `this style` is to be interpreted 
 {
     latest_registry_delta_root: 'bytes32',
     validator_index: 'uint24',
-    pubkey: 'uint384',
+    pubkey: 'bytes48',
     slot: 'uint64',
     flag: 'uint64',
 }

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -373,7 +373,7 @@ Unless otherwise indicated, code appearing in `this style` is to be interpreted 
 ```python
 {
     # Branch in the deposit tree
-    'branch': '[bytes32]',
+    'branch': ['bytes32'],
     # Index in the deposit tree
     'index': 'uint64',
     # Data

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -21,6 +21,8 @@
         - [Validator registry delta flags](#validator-registry-delta-flags)
         - [Signature domains](#signature-domains)
     - [Data structures](#data-structures)
+        - [Signatures](#signatures)
+            - [`Signature`](#signature)
         - [Beacon chain operations](#beacon-chain-operations)
             - [Proposer slashings](#proposer-slashings)
                 - [`ProposerSlashing`](#proposerslashing)
@@ -252,6 +254,17 @@ Unless otherwise indicated, code appearing in `this style` is to be interpreted 
 | `DOMAIN_EXIT` | `3` |
 
 ## Data structures
+
+### Signatures
+
+#### `Signature`
+
+```python
+{
+    'z_1': 'bytes48',
+    'z_2': 'bytes48',
+}
+```
 
 ### Beacon chain operations
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -311,7 +311,7 @@ Unless otherwise indicated, code appearing in `this style` is to be interpreted 
     # Attestation data
     'data': AttestationData,
     # Aggregate signature
-    'aggregate_signature': ['uint384'],
+    'aggregate_signature': Signature,
 }
 ```
 
@@ -328,7 +328,7 @@ Unless otherwise indicated, code appearing in `this style` is to be interpreted 
     # Custody bitfield
     'custody_bitfield': 'bytes',
     # BLS aggregate signature
-    'aggregate_signature': ['uint384'],
+    'aggregate_signature': Signature,
 }
 ```
 
@@ -407,7 +407,7 @@ Unless otherwise indicated, code appearing in `this style` is to be interpreted 
     # Initial custody commitment
     'custody_commitment': 'bytes32',
     # A BLS signature of this `DepositInput`
-    'proof_of_possession': ['uint384'],
+    'proof_of_possession': Signature,
 }
 ```
 
@@ -438,7 +438,7 @@ Unless otherwise indicated, code appearing in `this style` is to be interpreted 
     'state_root': 'bytes32',
     'randao_reveal': 'bytes32',
     'deposit_root': 'bytes32',
-    'signature': ['uint384'],
+    'signature': Signature,
 
     ## Body ##
     'body': BeaconBlockBody,

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -328,17 +328,17 @@ Unless otherwise indicated, code appearing in `this style` is to be interpreted 
     # Shard number
     'shard': 'uint64',
     # Hash of root of the signed beacon block
-    'beacon_block_root': 'hash32',
+    'beacon_block_root': 'bytes32',
     # Hash of root of the ancestor at the epoch boundary
-    'epoch_boundary_root': 'hash32',
+    'epoch_boundary_root': 'bytes32',
     # Shard block's hash of root
-    'shard_block_root': 'hash32',
+    'shard_block_root': 'bytes32',
     # Last crosslink's hash of root
-    'latest_crosslink_root': 'hash32',
+    'latest_crosslink_root': 'bytes32',
     # Slot of the last justified beacon block
     'justified_slot': 'uint64',
     # Hash of the last justified beacon block
-    'justified_block_root': 'hash32',
+    'justified_block_root': 'bytes32',
 }
 ```
 
@@ -360,7 +360,7 @@ Unless otherwise indicated, code appearing in `this style` is to be interpreted 
 ```python
 {
     # Branch in the deposit tree
-    'branch': '[hash32]',
+    'branch': '[bytes32]',
     # Index in the deposit tree
     'index': 'uint64',
     # Data
@@ -388,11 +388,11 @@ Unless otherwise indicated, code appearing in `this style` is to be interpreted 
     # BLS pubkey
     'pubkey': 'uint384',
     # Withdrawal credentials
-    'withdrawal_credentials': 'hash32',
+    'withdrawal_credentials': 'bytes32',
     # Initial RANDAO commitment
-    'randao_commitment': 'hash32',
+    'randao_commitment': 'bytes32',
     # Initial custody commitment
-    'custody_commitment': 'hash32',
+    'custody_commitment': 'bytes32',
     # A BLS signature of this `DepositInput`
     'proof_of_possession': ['uint384'],
 }
@@ -421,10 +421,10 @@ Unless otherwise indicated, code appearing in `this style` is to be interpreted 
 {
     ## Header ##
     'slot': 'uint64',
-    'parent_root': 'hash32',
-    'state_root': 'hash32',
-    'randao_reveal': 'hash32',
-    'deposit_root': 'hash32',
+    'parent_root': 'bytes32',
+    'state_root': 'bytes32',
+    'randao_reveal': 'bytes32',
+    'deposit_root': 'bytes32',
     'signature': ['uint384'],
 
     ## Body ##
@@ -458,7 +458,7 @@ Unless otherwise indicated, code appearing in `this style` is to be interpreted 
     # Shard number (`BEACON_CHAIN_SHARD_NUMBER` for beacon chain)
     'shard': 'uint64',
     # Block's hash of root
-    'block_root': 'hash32',
+    'block_root': 'bytes32',
 }
 ```
 
@@ -478,17 +478,17 @@ Unless otherwise indicated, code appearing in `this style` is to be interpreted 
     'validator_balances': ['uint64'],
     'validator_registry_latest_change_slot': 'uint64',
     'validator_registry_exit_count': 'uint64',
-    'validator_registry_delta_chain_tip': 'hash32',  # For light clients to track deltas
+    'validator_registry_delta_chain_tip': 'bytes32',  # For light clients to track deltas
 
     # Randomness and committees
-    'latest_randao_mixes': ['hash32'],
-    'latest_vdf_outputs': ['hash32'],
+    'latest_randao_mixes': ['bytes32'],
+    'latest_vdf_outputs': ['bytes32'],
     'previous_epoch_start_shard': 'uint64',
     'current_epoch_start_shard': 'uint64',
     'previous_epoch_calculation_slot': 'uint64',
     'current_epoch_calculation_slot': 'uint64',
-    'previous_epoch_randao_mix': 'hash32',
-    'current_epoch_randao_mix': 'hash32',
+    'previous_epoch_randao_mix': 'bytes32',
+    'current_epoch_randao_mix': 'bytes32',
 
     # Custody challenges
     'custody_challenges': [CustodyChallenge],
@@ -501,13 +501,13 @@ Unless otherwise indicated, code appearing in `this style` is to be interpreted 
 
     # Recent state
     'latest_crosslinks': [CrosslinkRecord],
-    'latest_block_roots': ['hash32'],  # Needed to process attestations, older to newer
+    'latest_block_roots': ['bytes32'],  # Needed to process attestations, older to newer
     'latest_penalized_exit_balances': ['uint64'],  # Balances penalized at every withdrawal period
     'latest_attestations': [PendingAttestationRecord],
-    'batched_block_roots': ['hash32'],
+    'batched_block_roots': ['bytes32'],
 
     # Ethereum 1.0 deposit root
-    'latest_deposit_root': 'hash32',
+    'latest_deposit_root': 'bytes32',
     'deposit_root_votes': [DepositRootVote],
 }
 ```
@@ -519,9 +519,9 @@ Unless otherwise indicated, code appearing in `this style` is to be interpreted 
     # BLS public key
     'pubkey': 'uint384',
     # Withdrawal credentials
-    'withdrawal_credentials': 'hash32',
+    'withdrawal_credentials': 'bytes32',
     # RANDAO commitment
-    'randao_commitment': 'hash32',
+    'randao_commitment': 'bytes32',
     # Slots the proposer has skipped (i.e. layers of RANDAO expected)
     'randao_layers': 'uint64',
     # Slot when validator activated
@@ -537,7 +537,7 @@ Unless otherwise indicated, code appearing in `this style` is to be interpreted 
     # Status flags
     'status_flags': 'uint64',
     # Custody commitment
-    'custody_commitment': 'hash32',
+    'custody_commitment': 'bytes32',
     # Slot of latest custody reseed
     'latest_custody_reseed_slot': 'uint64',
     # Slot of second-latest custody reseed
@@ -552,7 +552,7 @@ Unless otherwise indicated, code appearing in `this style` is to be interpreted 
     # Slot number
     'slot': 'uint64',
     # Shard block root
-    'shard_block_root': 'hash32',
+    'shard_block_root': 'bytes32',
 }
 ```
 
@@ -561,7 +561,7 @@ Unless otherwise indicated, code appearing in `this style` is to be interpreted 
 ```python
 {
     # Deposit root
-    'deposit_root': 'hash32',
+    'deposit_root': 'bytes32',
     # Vote count
     'vote_count': 'uint64',
 }
@@ -599,7 +599,7 @@ Unless otherwise indicated, code appearing in `this style` is to be interpreted 
 
 ```python
 {
-    latest_registry_delta_root: 'hash32',
+    latest_registry_delta_root: 'bytes32',
     validator_index: 'uint24',
     pubkey: 'uint384',
     slot: 'uint64',

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1059,7 +1059,7 @@ def get_attestation_participants(state: BeaconState,
 
 #### `int_to_bytes1`, `int_to_bytes2`, ...
 
-`int_to_bytes1(x): return x.to_bytes(1, 'big')`, `int_to_bytes2(x): return x.to_bytes(2, 'big')`, and so on for all integers, particularly 1, 2, 3, 4, 8, 32.
+`int_to_bytes1(x): return x.to_bytes(1, 'big')`, `int_to_bytes2(x): return x.to_bytes(2, 'big')`, and so on for all integers, particularly 1, 2, 3, 4, 8, 32, 48, 96.
 
 #### `get_effective_balance`
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1292,7 +1292,7 @@ First, a helper function:
 
 ```python
 def validate_proof_of_possession(state: BeaconState,
-                                 pubkey: int,
+                                 pubkey: bytes,
                                  proof_of_possession: bytes,
                                  withdrawal_credentials: Bytes32,
                                  randao_commitment: Bytes32,
@@ -1321,7 +1321,7 @@ Now, to add a [validator](#dfn-validator) or top up an existing [validator](#dfn
 
 ```python
 def process_deposit(state: BeaconState,
-                    pubkey: int,
+                    pubkey: bytes,
                     amount: int,
                     proof_of_possession: bytes,
                     withdrawal_credentials: Bytes32,

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1303,7 +1303,7 @@ First, a helper function:
 
 ```python
 def validate_proof_of_possession(state: BeaconState,
-                                 pubkey: bytes,
+                                 pubkey: Bytes48,
                                  proof_of_possession: Signature,
                                  withdrawal_credentials: Bytes32,
                                  randao_commitment: Bytes32,
@@ -1332,7 +1332,7 @@ Now, to add a [validator](#dfn-validator) or top up an existing [validator](#dfn
 
 ```python
 def process_deposit(state: BeaconState,
-                    pubkey: bytes,
+                    pubkey: Bytes48,
                     amount: int,
                     proof_of_possession: Signature,
                     withdrawal_credentials: Bytes32,

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -75,7 +75,7 @@
             - [`get_beacon_proposer_index`](#get_beacon_proposer_index)
             - [`merkle_root`](#merkle_root)
             - [`get_attestation_participants`](#get_attestation_participants)
-            - [`bytes1`, `bytes2`, ...](#bytes1-bytes2-)
+            - [`int_to_bytes1`, `int_to_bytes2`, ...](#int_to_bytes1-int_to_bytes2-)
             - [`get_effective_balance`](#get_effective_balance)
             - [`get_fork_version`](#get_fork_version)
             - [`get_domain`](#get_domain)
@@ -190,9 +190,9 @@ Unless otherwise indicated, code appearing in `this style` is to be interpreted 
 | `GENESIS_SLOT` | `0` |
 | `GENESIS_START_SHARD` | `0` |
 | `FAR_FUTURE_SLOT` | `2**64 - 1` |
-| `ZERO_HASH` | `bytes32(0)` |
-| `EMPTY_SIGNATURE` | `[bytes48(0), bytes48(0)]` |
-| `BLS_WITHDRAWAL_PREFIX_BYTE` | `bytes1(0)` |
+| `ZERO_HASH` | `int_to_bytes32(0)` |
+| `EMPTY_SIGNATURE` | `[int_to_bytes48(0), int_to_bytes48(0)]` |
+| `BLS_WITHDRAWAL_PREFIX_BYTE` | `int_to_bytes1(0)` |
 
 ### Time parameters
 
@@ -894,7 +894,7 @@ def get_shuffling(seed: Hash32,
     committees_per_slot = get_committee_count_per_slot(len(active_validator_indices))
 
     # Shuffle
-    seed = xor(seed, bytes32(slot))
+    seed = xor(seed, int_to_bytes32(slot))
     shuffled_active_validator_indices = shuffle(active_validator_indices, seed)
 
     # Split the shuffled list into epoch_length * committees_per_slot pieces
@@ -1046,9 +1046,9 @@ def get_attestation_participants(state: BeaconState,
     return participants
 ```
 
-#### `bytes1`, `bytes2`, ...
+#### `int_to_bytes1`, `int_to_bytes2`, ...
 
-`bytes1(x): return x.to_bytes(1, 'big')`, `bytes2(x): return x.to_bytes(2, 'big')`, and so on for all integers, particularly 1, 2, 3, 4, 8, 32.
+`int_to_bytes1(x): return x.to_bytes(1, 'big')`, `int_to_bytes2(x): return x.to_bytes(2, 'big')`, and so on for all integers, particularly 1, 2, 3, 4, 8, 32.
 
 #### `get_effective_balance`
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -279,11 +279,11 @@ Unless otherwise indicated, code appearing in `this style` is to be interpreted 
     # First proposal data
     'proposal_data_1': ProposalSignedData,
     # First proposal signature
-    'proposal_signature_1': '[uint384]',
+    'proposal_signature_1': Signature,
     # Second proposal data
     'proposal_data_2': ProposalSignedData,
     # Second proposal signature
-    'proposal_signature_2': '[uint384]',
+    'proposal_signature_2': Signature,
 }
 ```
 
@@ -422,7 +422,7 @@ Unless otherwise indicated, code appearing in `this style` is to be interpreted 
     # Index of the exiting validator
     'validator_index': 'uint24',
     # Validator signature
-    'signature': '[uint384]',
+    'signature': Signature,
 }
 ```
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1293,7 +1293,7 @@ First, a helper function:
 ```python
 def validate_proof_of_possession(state: BeaconState,
                                  pubkey: bytes,
-                                 proof_of_possession: bytes,
+                                 proof_of_possession: Signature,
                                  withdrawal_credentials: Bytes32,
                                  randao_commitment: Bytes32,
                                  custody_commitment: Bytes32) -> bool:
@@ -1323,7 +1323,7 @@ Now, to add a [validator](#dfn-validator) or top up an existing [validator](#dfn
 def process_deposit(state: BeaconState,
                     pubkey: bytes,
                     amount: int,
-                    proof_of_possession: bytes,
+                    proof_of_possession: Signature,
                     withdrawal_credentials: Bytes32,
                     randao_commitment: Bytes32,
                     custody_commitment: Bytes32) -> None:

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -193,7 +193,7 @@ Unless otherwise indicated, code appearing in `this style` is to be interpreted 
 | `GENESIS_START_SHARD` | `0` |
 | `FAR_FUTURE_SLOT` | `2**64 - 1` |
 | `ZERO_HASH` | `int_to_bytes32(0)` |
-| `EMPTY_SIGNATURE` | `[int_to_bytes48(0), int_to_bytes48(0)]` |
+| `EMPTY_SIGNATURE` | `Signature(int_to_bytes48(0), int_to_bytes48(0))` |
 | `BLS_WITHDRAWAL_PREFIX_BYTE` | `int_to_bytes1(0)` |
 
 ### Time parameters

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -70,7 +70,7 @@ To validate a block header on shard `shard_id`, compute as follows:
 * Verify that `beacon_chain_ref` is the hash of a block in the beacon chain with slot less than or equal to `slot`. Verify that `beacon_chain_ref` is equal to or a descendant of the `beacon_chain_ref` specified in the `ShardBlock` pointed to by `parent_root`.
 * Let `state` be the state of the beacon chain block referred to by `beacon_chain_ref`. Let `validators` be `[validators[i] for i in state.current_persistent_committees[shard_id]]`.
 * Assert `len(participation_bitfield) == ceil_div8(len(validators))`
-* Let `proposer_index = hash(state.randao_mix + bytes8(shard_id) + bytes8(slot)) % len(validators)`. Let `msg` be the block but with the `block.signature` set to `[0, 0]`. Verify that `BLSVerify(pub=validators[proposer_index].pubkey, msg=hash(msg), sig=block.signature, domain=get_domain(state, slot, SHARD_PROPOSER_DOMAIN))` passes.
+* Let `proposer_index = hash(state.randao_mix + int_to_bytes8(shard_id) + int_to_bytes8(slot)) % len(validators)`. Let `msg` be the block but with the `block.signature` set to `[0, 0]`. Verify that `BLSVerify(pub=validators[proposer_index].pubkey, msg=hash(msg), sig=block.signature, domain=get_domain(state, slot, SHARD_PROPOSER_DOMAIN))` passes.
 * Generate the `group_public_key` by adding the public keys of all the validators for whom the corresponding position in the bitfield is set to 1. Verify that `BLSVerify(pub=group_public_key, msg=parent_root, sig=block.aggregate_signature, domain=get_domain(state, slot, SHARD_ATTESTER_DOMAIN))` passes.
 
 ### Block Merklization helper


### PR DESCRIPTION
Fix #432 - core specs and BLS spec sides.
The SSZ update part is in #455

#### BLS specs
- Update API parameters type
    - `signature: [uint384]` => `signature: Bytes96`
    - `pubkey: uint384` => `pubkey: Bytes48`
- TODO: will define `Bytes48` and `Bytes96` in the type hinting cleanup PR.

#### Core specs
- Rename `bytes1(x)`, `bytes2(x)`... function to `int_to_bytes1(x)`, `int_to_bytes2(x)`.
- Replace:
    - `hash32` => `bytes32`
    - `Hash32` => `Bytes32`
- Replace most `uint384` with `bytes48`
- TODO: will define `Bytes32`, `Bytes48` and `Bytes96` in the type hinting cleanup PR
- Other
    - Fix `Deposit.branch` type notation.