### PR TITLE
Clean Up Deposit Contract

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -666,7 +666,7 @@ deposit_tree: map(uint256, bytes32)
 deposit_count: uint256
 full_deposit_count: uint256
 
-@private
+@public
 @constant
 def to_bytes8(value: uint256) -> bytes[8]:
     return slice(concat("", convert(value, bytes32)), start=24, len=8)

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -652,9 +652,8 @@ When sufficiently many full deposits have been made the deposit contract emits t
 ```python
 ## compiled with v0.1.0-beta.7 ##
 
-MIN_DEPOSIT: constant(uint256) = 1000000000 # In terms of gwei
-MAX_DEPOSIT: constant(uint256) = 32000000000 # In terms of gwei
-WEI_PER_GWEI: constant(uint256(wei)) = as_wei_value(1,"gwei") # 10**9
+MIN_DEPOSIT_AMOUNT: constant(uint256) = 1000000000  # In Gwei
+MAX_DEPOSIT_AMOUNT: constant(uint256) = 32000000000  # In Gwei
 CHAIN_START_FULL_DEPOSIT_THRESHOLD: constant(uint256) = 16384  # 2**14
 DEPOSIT_CONTRACT_TREE_DEPTH: constant(uint256) = 32
 TWO_TO_POWER_OF_TREE_DEPTH: constant(uint256) = 4294967296  # 2**32
@@ -667,50 +666,52 @@ deposit_tree: map(uint256, bytes32)
 deposit_count: uint256
 full_deposit_count: uint256
 
-@payable
-@public
-def deposit(deposit_input: bytes[2048]):
-    deposit_in_gwei: uint256  = msg.value / WEI_PER_GWEI
-    
-    assert deposit_in_gwei >= MIN_DEPOSIT
-    assert deposit_in_gwei <= MAX_DEPOSIT
-
-    index: uint256 = self.deposit_count + TWO_TO_POWER_OF_TREE_DEPTH
-    deposit_amount: bytes[8] = slice(concat("", convert(deposit_in_gwei, bytes32)), start=24, len=8)
-    deposit_timestamp: bytes[8] = slice(concat("", convert(block.timestamp, bytes32)), start=24, len=8)
-    deposit_data: bytes[2064] = concat(deposit_amount, deposit_timestamp, deposit_input)
-    merkle_tree_index: bytes[8] = slice(concat("", convert(index, bytes32)), start=24, len=8)
-
-    log.Deposit(self.deposit_tree[1], deposit_data, merkle_tree_index)
-
-    # add deposit to merkle tree
-    self.deposit_tree[index] = sha3(deposit_data)
-    for i in range(DEPOSIT_CONTRACT_TREE_DEPTH):
-        index /= 2
-        self.deposit_tree[index] = sha3(concat(self.deposit_tree[index * 2], self.deposit_tree[index * 2 + 1]))
-
-    self.deposit_count += 1
-    if deposit_in_gwei == MAX_DEPOSIT:
-        self.full_deposit_count += 1
-        if self.full_deposit_count == CHAIN_START_FULL_DEPOSIT_THRESHOLD:
-            timestamp_day_boundary: uint256 = as_unitless_number(block.timestamp) - as_unitless_number(block.timestamp) % SECONDS_PER_DAY + SECONDS_PER_DAY
-            chainstart_time: bytes[8] = slice(concat("", convert(timestamp_day_boundary, bytes32)), start=24, len=8)
-            log.ChainStart(self.deposit_tree[1], chainstart_time)
+@private
+@constant
+def to_bytes(value: uint256) -> bytes[8]:
+    return slice(concat("", convert(value, bytes32)), start=24, len=8)
 
 @public
 @constant
 def get_deposit_root() -> bytes32:
     return self.deposit_tree[1]
 
+@payable
+@public
+def deposit(deposit_input: bytes[2048]):
+    deposit_amount: uint256 = msg.value / as_wei_value(1, "gwei")
+
+    assert deposit_amount >= MIN_DEPOSIT_AMOUNT
+    assert deposit_amount <= MAX_DEPOSIT_AMOUNT
+
+    deposit_timestamp: uint256 = as_unitless_number(block.timestamp)
+    deposit_data: bytes[2064] = concat(self.to_bytes(deposit_amount), self.to_bytes(deposit_timestamp), deposit_input)
+    index: uint256 = self.deposit_count + TWO_TO_POWER_OF_TREE_DEPTH
+    log.Deposit(self.get_deposit_root(), deposit_data, self.to_bytes(index))
+
+    # Add deposit to merkle tree
+    self.deposit_tree[index] = sha3(deposit_data)
+    for i in range(DEPOSIT_CONTRACT_TREE_DEPTH):
+        index /= 2
+        self.deposit_tree[index] = sha3(concat(self.deposit_tree[index * 2], self.deposit_tree[index * 2 + 1]))
+
+    self.deposit_count += 1
+    if deposit_amount == MAX_DEPOSIT_AMOUNT:
+        self.full_deposit_count += 1
+        if self.full_deposit_count == CHAIN_START_FULL_DEPOSIT_THRESHOLD:
+            timestamp_day_boundary: uint256 = deposit_timestamp - deposit_timestamp % SECONDS_PER_DAY + SECONDS_PER_DAY
+            log.ChainStart(self.get_deposit_root(), self.to_bytes(timestamp_day_boundary))
+
 @public
 @constant
-def get_branch(leaf: uint256) -> bytes32[32]: # size is DEPOSIT_CONTRACT_TREE_DEPTH (symbolic const not supported)
+def get_branch(leaf: uint256) -> bytes32[DEPOSIT_CONTRACT_TREE_DEPTH]:
     branch: bytes32[32] # size is DEPOSIT_CONTRACT_TREE_DEPTH
     index: uint256 = leaf + TWO_TO_POWER_OF_TREE_DEPTH
     for i in range(DEPOSIT_CONTRACT_TREE_DEPTH):
         branch[i] = self.deposit_tree[bitwise_xor(index, 1)]
         index /= 2
     return branch
+
 ```
 
 ## Beacon chain processing

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -652,8 +652,8 @@ When sufficiently many full deposits have been made the deposit contract emits t
 ```python
 ## compiled with v0.1.0-beta.6 ##
 
-MIN_DEPOSIT: constant(uint256(wei)) = as_wei_value(1, "ether")
-MAX_DEPOSIT: constant(uint256(wei)) = as_wei_value(32, "ether")
+MIN_DEPOSIT: constant(uint256(wei)) = as_wei_value(1000000000 , "gwei")
+MAX_DEPOSIT: constant(uint256(wei)) = as_wei_value(32000000000, "gwei")
 GWEI_PER_ETH: constant(uint256) = 1000000000  # 10**9
 CHAIN_START_FULL_DEPOSIT_THRESHOLD: constant(uint256) = 16384  # 2**14
 DEPOSIT_CONTRACT_TREE_DEPTH: constant(uint256) = 32

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -652,8 +652,8 @@ When sufficiently many full deposits have been made the deposit contract emits t
 ```python
 ## compiled with v0.1.0-beta.6 ##
 
-MIN_DEPOSIT_AMOUNT: constant(uint256) = 1000000000  # Gwei
-MAX_DEPOSIT_AMOUNT: constant(uint256) = 32000000000  # Gwei
+MIN_DEPOSIT: constant(uint256(wei)) = as_wei_value(1, "ether")
+MAX_DEPOSIT: constant(uint256(wei)) = as_wei_value(32, "ether")
 GWEI_PER_ETH: constant(uint256) = 1000000000  # 10**9
 CHAIN_START_FULL_DEPOSIT_THRESHOLD: constant(uint256) = 16384  # 2**14
 DEPOSIT_CONTRACT_TREE_DEPTH: constant(uint256) = 32
@@ -670,8 +670,8 @@ full_deposit_count: uint256
 @payable
 @public
 def deposit(deposit_input: bytes[2048]):
-    assert msg.value >= as_wei_value(MIN_DEPOSIT_AMOUNT, "gwei")
-    assert msg.value <= as_wei_value(MAX_DEPOSIT_AMOUNT, "gwei")
+    assert msg.value >= MIN_DEPOSIT
+    assert msg.value <= MAX_DEPOSIT
 
     index: uint256 = self.deposit_count + TWO_TO_POWER_OF_TREE_DEPTH
     deposit_amount: bytes[8] = slice(concat("", convert(msg.value / GWEI_PER_ETH, bytes32)), start=24, len=8)

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -652,8 +652,8 @@ When sufficiently many full deposits have been made the deposit contract emits t
 ```python
 ## compiled with v0.1.0-beta.7 ##
 
-MIN_DEPOSIT_AMOUNT: constant(uint256) = 1000000000  # In Gwei
-MAX_DEPOSIT_AMOUNT: constant(uint256) = 32000000000  # In Gwei
+MIN_DEPOSIT_AMOUNT: constant(uint256) = 1000000000  # Gwei
+MAX_DEPOSIT_AMOUNT: constant(uint256) = 32000000000  # Gwei
 CHAIN_START_FULL_DEPOSIT_THRESHOLD: constant(uint256) = 16384  # 2**14
 DEPOSIT_CONTRACT_TREE_DEPTH: constant(uint256) = 32
 TWO_TO_POWER_OF_TREE_DEPTH: constant(uint256) = 4294967296  # 2**32

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -711,7 +711,6 @@ def get_branch(leaf: uint256) -> bytes32[DEPOSIT_CONTRACT_TREE_DEPTH]:
         branch[i] = self.deposit_tree[bitwise_xor(index, 1)]
         index /= 2
     return branch
-
 ```
 
 ## Beacon chain processing

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1350,7 +1350,7 @@ def prepare_validator_for_withdrawal(state: BeaconState, index: ValidatorIndex) 
 
 ## Ethereum 1.0 deposit contract
 
-The initial deployment phases of Ethereum 2.0 are implemented without consensus changes to Ethereum 1.0. A deposit contract at address `DEPOSIT_CONTRACT_ADDRESS` is added to Ethereum 1.0 for deposits of ETH to the beacon chain. Validator balances will be withdrawable to the shards in phase 2, i.e. when the EVM2.0 is deployed and the shards have state.
+The initial deployment phases of Ethereum 2.0 are implemented without consensus changes to Ethereum 1.0. A deposit contract at address `DEPOSIT_ADDRESS` is added to Ethereum 1.0 for deposits of ETH to the beacon chain. Validator balances will be withdrawable to the shards in phase 2, i.e. when the EVM2.0 is deployed and the shards have state.
 
 ### Deposit arguments
 
@@ -1385,7 +1385,7 @@ When sufficiently many full deposits have been made the deposit contract emits t
 MIN_DEPOSIT_AMOUNT: constant(uint256) = 1000000000  # Gwei
 MAX_DEPOSIT_AMOUNT: constant(uint256) = 32000000000  # Gwei
 CHAIN_START_FULL_DEPOSIT_THRESHOLD: constant(uint256) = 16384  # 2**14
-DEPOSIT_CONTRACT_TREE_DEPTH: constant(uint256) = 32
+DEPOSIT_TREE_DEPTH: constant(uint256) = 32
 TWO_TO_POWER_OF_TREE_DEPTH: constant(uint256) = 4294967296  # 2**32
 SECONDS_PER_DAY: constant(uint256) = 86400
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -668,7 +668,7 @@ full_deposit_count: uint256
 
 @private
 @constant
-def to_bytes(value: uint256) -> bytes[8]:
+def to_bytes8(value: uint256) -> bytes[8]:
     return slice(concat("", convert(value, bytes32)), start=24, len=8)
 
 @public
@@ -685,9 +685,9 @@ def deposit(deposit_input: bytes[2048]):
     assert deposit_amount <= MAX_DEPOSIT_AMOUNT
 
     deposit_timestamp: uint256 = as_unitless_number(block.timestamp)
-    deposit_data: bytes[2064] = concat(self.to_bytes(deposit_amount), self.to_bytes(deposit_timestamp), deposit_input)
+    deposit_data: bytes[2064] = concat(self.to_bytes8(deposit_amount), self.to_bytes8(deposit_timestamp), deposit_input)
     index: uint256 = self.deposit_count + TWO_TO_POWER_OF_TREE_DEPTH
-    log.Deposit(self.get_deposit_root(), deposit_data, self.to_bytes(index))
+    log.Deposit(self.get_deposit_root(), deposit_data, self.to_bytes8(index))
 
     # Add deposit to merkle tree
     self.deposit_tree[index] = sha3(deposit_data)
@@ -700,7 +700,7 @@ def deposit(deposit_input: bytes[2048]):
         self.full_deposit_count += 1
         if self.full_deposit_count == CHAIN_START_FULL_DEPOSIT_THRESHOLD:
             timestamp_day_boundary: uint256 = deposit_timestamp - deposit_timestamp % SECONDS_PER_DAY + SECONDS_PER_DAY
-            log.ChainStart(self.get_deposit_root(), self.to_bytes(timestamp_day_boundary))
+            log.ChainStart(self.get_deposit_root(), self.to_bytes8(timestamp_day_boundary))
 
 @public
 @constant

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -650,7 +650,7 @@ When sufficiently many full deposits have been made the deposit contract emits t
 ### Vyper code
 
 ```python
-## compiled with v0.1.0-beta.6 ##
+## compiled with v0.1.0-beta.7 ##
 
 MIN_DEPOSIT: constant(uint256(wei)) = as_wei_value(1000000000 , "gwei")
 MAX_DEPOSIT: constant(uint256(wei)) = as_wei_value(32000000000, "gwei")

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -688,7 +688,7 @@ def deposit(deposit_input: bytes[2048]):
         self.deposit_tree[index] = sha3(concat(self.deposit_tree[index * 2], self.deposit_tree[index * 2 + 1]))
 
     self.deposit_count += 1
-    if msg.value == as_wei_value(MAX_DEPOSIT_AMOUNT, "gwei"):
+    if msg.value == MAX_DEPOSIT:
         self.full_deposit_count += 1
         if self.full_deposit_count == CHAIN_START_FULL_DEPOSIT_THRESHOLD:
             timestamp_day_boundary: uint256 = as_unitless_number(block.timestamp) - as_unitless_number(block.timestamp) % SECONDS_PER_DAY + SECONDS_PER_DAY


### PR DESCRIPTION
This PR cleans up the deposit contract, with changes in declarations, which was suggested by @jacqueswww. 

Also another issue was that the vyper contract was not able to be compiled, however @jacqueswww has been kind enough to put up a quick fix here: https://github.com/ethereum/vyper/pull/1202. After that is merged in the deposit contract should have no issues being compiled.

Changes in Contract
- Update version number to reflect latest vyper release.
- Perform all calculations in terms of gwei
- Change global constant from `Gwei_Per_Eth` to `Wei_Per_Gwei`