### PR TITLE
fix domain in verify_slashable_vote_data

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1113,7 +1113,7 @@ def verify_slashable_vote_data(state: BeaconState, vote_data: SlashableVoteData)
         signature=vote_data.aggregate_signature,
         domain=get_domain(
             state.fork,
-            state.slot,
+            vote_data.data.slot,
             DOMAIN_ATTESTATION,
         ),
     )


### PR DESCRIPTION
Fixes an error when verifying signatures in casper slashings.
Discussion here https://github.com/ethereum/eth2.0-specs/issues/445#issuecomment-455277573