### PR TITLE
Sign full `Exit` message so that a validator can prevent tampering

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1584,16 +1584,7 @@ For each `exit` in `block.body.exits`:
 * Let `validator = state.validator_registry[exit.validator_index]`.
 * Verify that `validator.exit_slot > state.slot + ENTRY_EXIT_DELAY`.
 * Verify that `state.slot >= exit.slot`.
-* Let `exit_message` be the value returned by the following function, following a similar scheme to verifying the proposer signature:
-
-```python
-# NOTE: this function suggests mutation; in this case, the intention is that `exit` here is
-# a copy of the message that will ultimately be broadcast with all other fields set to the desired values.
-def message_to_sign_for_exit_operation(exit: Exit) -> bytes32:
-    exit.signature = EMPTY_SIGNATURE
-    return hash_tree_root(exit)
-```
-
+* Let `exit_message = hash_tree_root(Exit(slot=exit.slot, validator_index=exit.validator_index, signature=EMPTY_SIGNATURE))`.
 * Verify that `bls_verify(pubkey=validator.pubkey, message=exit_message, signature=exit.signature, domain=get_domain(state.fork, exit.slot, DOMAIN_EXIT))`.
 * Run `initiate_validator_exit(state, exit.validator_index)`.
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1584,7 +1584,17 @@ For each `exit` in `block.body.exits`:
 * Let `validator = state.validator_registry[exit.validator_index]`.
 * Verify that `validator.exit_slot > state.slot + ENTRY_EXIT_DELAY`.
 * Verify that `state.slot >= exit.slot`.
-* Verify that `bls_verify(pubkey=validator.pubkey, message=ZERO_HASH, signature=exit.signature, domain=get_domain(state.fork, exit.slot, DOMAIN_EXIT))`.
+* Let `exit_message` be the value returned by the following function, following a similar scheme to verifying the proposer signature:
+
+```python
+# NOTE: this function suggests mutation; in this case, the intention is that `exit` here is
+# a copy of the message that will ultimately be broadcast with all other fields set to the desired values.
+def message_to_sign_for_exit_operation(exit: Exit) -> bytes32:
+    exit.signature = EMPTY_SIGNATURE
+    return hash_tree_root(exit)
+```
+
+* Verify that `bls_verify(pubkey=validator.pubkey, message=exit_message, signature=exit.signature, domain=get_domain(state.fork, exit.slot, DOMAIN_EXIT))`.
 * Run `initiate_validator_exit(state, exit.validator_index)`.
 
 #### Custody


### PR DESCRIPTION
Fixes #385.

# Problem 
The previous implementation had a validator who wished to exit the active set
do so by signing the `ZERO_HASH`. This meant that the validator is not
committing to any particular values in the `Exit` message except for the
signature itself (and by extension via public-key cryptography, their identity
in the validator set). This situation implies a malicious proposer could alter
the other fields of this message, possibly at the expense of the message's
originator.

# Solution
This commit updates the spec so that the signature covers the entire `Exit`
message and this attack vector is nullified.

# Other info
It seems clearest to specify the message generation algorithm in Python; however, an implementer who is not carefully following the spec may accidentally mutate an `Exit` message following this code directly, e.g. dropping a valid signature and losing the ability to include what was a valid `Exit`. There is a clarifying comment attached to the Python code about being careful with this mutation, but still accidents happen so I'm open to rephrasing this if someone suggests something better. In particular, this may be blurring the lines between the style and intention of the spec as a reference document and what will be required knowledge in something like an implementer's document.  Happy to discuss if there is concern.