### PR TITLE
Add a note about exceptions in Python code

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -135,7 +135,7 @@ The primary source of load on the beacon chain is "attestations". Attestations a
 
 ## Notation
 
-Code snippets appearing in `this style` are to be interpreted as Python code. Beacon blocks that trigger unhandled Python exceptions (e.g. out-of-range list accesses) are considered invalid.
+Code snippets appearing in `this style` are to be interpreted as Python code. Beacon blocks that trigger unhandled Python exceptions (e.g. out-of-range list accesses) and failed asserts are considered invalid.
 
 ## Terminology
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -131,11 +131,11 @@ This document represents the specification for Phase 0 of Ethereum 2.0 -- The Be
 
 At the core of Ethereum 2.0 is a system chain called the "beacon chain". The beacon chain stores and manages the registry of [validators](#dfn-validator). In the initial deployment phases of Ethereum 2.0 the only mechanism to become a [validator](#dfn-validator) is to make a one-way ETH transaction to a deposit contract on Ethereum 1.0. Activation as a [validator](#dfn-validator) happens when Ethereum 1.0 deposit receipts are processed by the beacon chain, the activation balance is reached, and after a queuing process. Exit is either voluntary or done forcibly as a penalty for misbehavior.
 
-The primary source of load on the beacon chain is "attestations". Attestations are availability votes for a shard block, and simultaneously proof of stake votes for a beacon chain block. A sufficient number of attestations for the same shard block create a "crosslink", confirming the shard segment up to that shard block into the beacon chain. Crosslinks also serve as infrastructure for asynchronous cross-shard communication.
+The primary source of load on the beacon chain is "attestations". Attestations are availability votes for a shard block, and simultaneously proof of stake votes for a beacon block. A sufficient number of attestations for the same shard block create a "crosslink", confirming the shard segment up to that shard block into the beacon chain. Crosslinks also serve as infrastructure for asynchronous cross-shard communication.
 
 ## Notation
 
-Unless otherwise indicated, code appearing in `this style` is to be interpreted as an algorithm defined in Python. Hence, exceptional cases that are not explicitly handled by a logic in `this style` blocks are propagated to Python exception mechanism. In particular, out of range index access would turned into `IndexError: list index out of range` exception being thrown.
+Code snippets appearing in `this style` are to be interpreted as Python code. Beacon blocks that trigger unhandled Python exceptions (e.g. out-of-range list accesses) are considered invalid.
 
 Implementations may implement such algorithms using any code and programming language desired as long as the behavior is identical to that of the algorithm provided.
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -137,8 +137,6 @@ The primary source of load on the beacon chain is "attestations". Attestations a
 
 Code snippets appearing in `this style` are to be interpreted as Python code. Beacon blocks that trigger unhandled Python exceptions (e.g. out-of-range list accesses) are considered invalid.
 
-Implementations may implement such algorithms using any code and programming language desired as long as the behavior is identical to that of the algorithm provided.
-
 ## Terminology
 
 * **Validator** <a id="dfn-validator"></a> - a participant in the Casper/sharding consensus system. You can become one by depositing 32 ETH into the Casper mechanism.

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -135,7 +135,9 @@ The primary source of load on the beacon chain is "attestations". Attestations a
 
 ## Notation
 
-Unless otherwise indicated, code appearing in `this style` is to be interpreted as an algorithm defined in Python. Implementations may implement such algorithms using any code and programming language desired as long as the behavior is identical to that of the algorithm provided.
+Unless otherwise indicated, code appearing in `this style` is to be interpreted as an algorithm defined in Python. Hence, exceptional cases that are not explicitly handled by a logic in `this style` blocks are propagated to Python exception mechanism. In particular, out of range index access would turned into `IndexError: list index out of range` exception being thrown.
+
+Implementations may implement such algorithms using any code and programming language desired as long as the behavior is identical to that of the algorithm provided.
 
 ## Terminology
 


### PR DESCRIPTION
### What's done
`Notation` section is appended with a note about handling some errors with Python exceptions. In particular, out of range errors.

Addresses https://github.com/ethereum/eth2.0-specs/issues/446

Please, fix the language if it reads odd.