### PR TITLE
Add custom type hinting

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -752,7 +752,7 @@ The beacon chain fork choice rule is a hybrid that combines justification and fi
 * Let `get_ancestor(store: Store, block: BeaconBlock, slot: SlotNumber) -> BeaconBlock` be the ancestor of `block` with slot number `slot`. The `get_ancestor` function can be defined recursively as `def get_ancestor(store: Store, block: BeaconBlock, slot: SlotNumber) -> BeaconBlock: return block if block.slot == slot else get_ancestor(store, store.get_parent(block), slot)`.
 * Let `get_latest_attestation(store: Store, validator: Validator) -> Attestation` be the attestation with the highest slot number in `store` from `validator`. If several such attestations exist, use the one the [validator](#dfn-validator) `v` observed first.
 * Let `get_latest_attestation_target(store: Store, validator: Validator) -> BeaconBlock` be the target block in the attestation `get_latest_attestation(store, validator)`.
-* Let `get_children(block: BeaconBlock) -> List[BeaconBlock]` returns the children blocks of the given `block`.
+* Let `get_children(store: Store, block: BeaconBlock) -> List[BeaconBlock]` returns the children blocks of the given `block`.
 * Let `justified_head_state` be the `BeaconState` object after processing `justified_head`.
 * The `head` is `lmd_ghost(store, justified_head_state, justified_head)` where the function `lmd_ghost` is defined below. Note that the implementation below is suboptimal; there are implementations that compute the head in time logarithmic in slot count.
 
@@ -777,7 +777,7 @@ def lmd_ghost(store: Store, start_state: BeaconState, start_block: BeaconBlock) 
 
     head = start_block
     while 1:
-        children = get_children(head)
+        children = get_children(store, head)
         if len(children) == 0:
             return head
         head = max(children, key=get_vote_count)

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -116,7 +116,7 @@
             - [Attestation inclusion](#attestation-inclusion)
             - [Crosslinks](#crosslinks-1)
         - [Ejections](#ejections)
-        - [Validator registry](#validator-registry)
+        - [Validator registry and shuffling seed data](#validator-registry-and-shuffling-seed-data)
         - [Final updates](#final-updates)
     - [State root processing](#state-root-processing)
 - [References](#references)
@@ -1013,7 +1013,7 @@ def get_randao_mix(state: BeaconState,
 
 ```python
 def get_active_index_root(state: BeaconState,
-                          slot: int) -> Bytes32:
+                          slot: SlotNumber) -> Bytes32:
     """
     Returns the index root at a recent ``slot``.
     """

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -601,9 +601,9 @@ Unless otherwise indicated, code appearing in `this style` is to be interpreted 
 ```python
 {
     # Root of the deposit tree
-    'deposit_root': 'hash32',
+    'deposit_root': 'bytes32',
     # Block hash
-    'block_hash': 'hash32',
+    'block_hash': 'bytes32',
 }
 ```
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -746,26 +746,36 @@ Beacon block production is significantly different because of the proof of stake
 
 The beacon chain fork choice rule is a hybrid that combines justification and finality with Latest Message Driven (LMD) Greediest Heaviest Observed SubTree (GHOST). At any point in time a [validator](#dfn-validator) `v` subjectively calculates the beacon chain head as follows.
 
-* Let `store` be the set of attestations and blocks that the [validator](#dfn-validator) `v` has observed and verified (in particular, block ancestors must be recursively verified). Attestations not part of any chain are still included in `store`.
+* Abstractly define `Store` as the type of storage object for the chain data and `store` be the set of attestations and blocks that the [validator](#dfn-validator) `v` has observed and verified (in particular, block ancestors must be recursively verified). Attestations not part of any chain are still included in `store`.
 * Let `finalized_head` be the finalized block with the highest slot number. (A block `B` is finalized if there is a descendant of `B` in `store` the processing of which sets `B` as finalized.)
 * Let `justified_head` be the descendant of `finalized_head` with the highest slot number that has been justified for at least `EPOCH_LENGTH` slots. (A block `B` is justified if there is a descendant of `B` in `store` the processing of which sets `B` as justified.) If no such descendant exists set `justified_head` to `finalized_head`.
-* Let `get_ancestor(store, block, slot)` be the ancestor of `block` with slot number `slot`. The `get_ancestor` function can be defined recursively as `def get_ancestor(store, block, slot): return block if block.slot == slot else get_ancestor(store, store.get_parent(block), slot)`.
-* Let `get_latest_attestation(store, validator)` be the attestation with the highest slot number in `store` from `validator`. If several such attestations exist, use the one the [validator](#dfn-validator) `v` observed first.
-* Let `get_latest_attestation_target(store, validator)` be the target block in the attestation `get_latest_attestation(store, validator)`.
-* The head is `lmd_ghost(store, justified_head)` where the function `lmd_ghost` is defined below. Note that the implementation below is suboptimal; there are implementations that compute the head in time logarithmic in slot count.
+* Let `get_ancestor(store: Store, block: BeaconBlock, slot: SlotNumber) -> BeaconBlock` be the ancestor of `block` with slot number `slot`. The `get_ancestor` function can be defined recursively as `def get_ancestor(store: Store, block: BeaconBlock, slot: SlotNumber) -> BeaconBlock: return block if block.slot == slot else get_ancestor(store, store.get_parent(block), slot)`.
+* Let `get_latest_attestation(store: Store, validator: Validator) -> Attestation` be the attestation with the highest slot number in `store` from `validator`. If several such attestations exist, use the one the [validator](#dfn-validator) `v` observed first.
+* Let `get_latest_attestation_target(store: Store, validator: Validator) -> BeaconBlock` be the target block in the attestation `get_latest_attestation(store, validator)`.
+* Let `get_children(block: BeaconBlock) -> List[BeaconBlock]` returns the children blocks of the given `block`.
+* Let `justified_head_state` be the `BeaconState` object after processing `justified_head`.
+* The `head` is `lmd_ghost(store, justified_head_state, justified_head)` where the function `lmd_ghost` is defined below. Note that the implementation below is suboptimal; there are implementations that compute the head in time logarithmic in slot count.
 
 ```python
-def lmd_ghost(store, start):
-    validators = start.state.validator_registry
-    active_validators = [validators[i] for i in
-                         get_active_validator_indices(validators, start.state.slot)]
-    attestation_targets = [get_latest_attestation_target(store, validator)
-                           for validator in active_validators]
-    def get_vote_count(block):
-        return len([target for target in attestation_targets if
-                    get_ancestor(store, target, block.slot) == block])
+def lmd_ghost(store: Store, start_state: BeaconState, start_block: BeaconBlock) -> BeaconBlock:
+    validators = start_state.validator_registry
+    active_validators = [
+        validators[i]
+        for i in get_active_validator_indices(validators, start_state.slot)
+    ]
+    attestation_targets = [
+        get_latest_attestation_target(store, validator)
+        for validator in active_validators
+    ]
 
-    head = start
+    def get_vote_count(block: BeaconBlock) -> int:
+        return len([
+            target
+            for target in attestation_targets
+            if get_ancestor(store, target, block.slot) == block
+        ])
+
+    head = start_block
     while 1:
         children = get_children(head)
         if len(children) == 0:

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -622,11 +622,11 @@ We define the following Python custom types for type hinting and readability:
 | - | - | - |
 | `SlotNumber` | unsigned 64-bit integer | the number of a slot |
 | `ShardNumber` | unsigned 64-bit integer | the number of a shard |
-| `ValidatorIndex` | unsigned 24-bit integer | the index number of validator in the registry |
-| `Gwei` | unsigned 64-bit integer | the amount in Gwei |
-| `Bytes32` | 32-byte data | the binary data in 32-byte length |
-| `BLSPubkey` | 48-byte data | the public key in BLS signature scheme |
-| `BLSSignature` | 96-byte data | the signature in BLS signature scheme |
+| `ValidatorIndex` | unsigned 24-bit integer | the index number of a validator in the registry |
+| `Gwei` | unsigned 64-bit integer | an amount in Gwei |
+| `Bytes32` | 32-byte data | binary data with 32-byte length |
+| `BLSPubkey` | 48-byte data | a public key in BLS signature scheme |
+| `BLSSignature` | 96-byte data | a signature in BLS signature scheme |
 
 ## Ethereum 1.0 deposit contract
 
@@ -746,14 +746,14 @@ Beacon block production is significantly different because of the proof of stake
 
 The beacon chain fork choice rule is a hybrid that combines justification and finality with Latest Message Driven (LMD) Greediest Heaviest Observed SubTree (GHOST). At any point in time a [validator](#dfn-validator) `v` subjectively calculates the beacon chain head as follows.
 
-* Abstractly define `Store` as the type of storage object for the chain data and `store` be the set of attestations and blocks that the [validator](#dfn-validator) `v` has observed and verified (in particular, block ancestors must be recursively verified). Attestations not part of any chain are still included in `store`.
+* Abstractly define `Store` as the type of storage object for the chain data and `store` be the set of attestations and blocks that the [validator](#dfn-validator) `v` has observed and verified (in particular, block ancestors must be recursively verified). Attestations not yet included in any chain are still included in `store`.
 * Let `finalized_head` be the finalized block with the highest slot number. (A block `B` is finalized if there is a descendant of `B` in `store` the processing of which sets `B` as finalized.)
 * Let `justified_head` be the descendant of `finalized_head` with the highest slot number that has been justified for at least `EPOCH_LENGTH` slots. (A block `B` is justified if there is a descendant of `B` in `store` the processing of which sets `B` as justified.) If no such descendant exists set `justified_head` to `finalized_head`.
 * Let `get_ancestor(store: Store, block: BeaconBlock, slot: SlotNumber) -> BeaconBlock` be the ancestor of `block` with slot number `slot`. The `get_ancestor` function can be defined recursively as `def get_ancestor(store: Store, block: BeaconBlock, slot: SlotNumber) -> BeaconBlock: return block if block.slot == slot else get_ancestor(store, store.get_parent(block), slot)`.
 * Let `get_latest_attestation(store: Store, validator: Validator) -> Attestation` be the attestation with the highest slot number in `store` from `validator`. If several such attestations exist, use the one the [validator](#dfn-validator) `v` observed first.
 * Let `get_latest_attestation_target(store: Store, validator: Validator) -> BeaconBlock` be the target block in the attestation `get_latest_attestation(store, validator)`.
-* Let `get_children(store: Store, block: BeaconBlock) -> List[BeaconBlock]` returns the children blocks of the given `block`.
-* Let `justified_head_state` be the `BeaconState` object after processing `justified_head`.
+* Let `get_children(store: Store, block: BeaconBlock) -> List[BeaconBlock]` returns the child blocks of the given `block`.
+* Let `justified_head_state` be the resulting `BeaconState` object from processing the chain up to the `justified_head`.
 * The `head` is `lmd_ghost(store, justified_head_state, justified_head)` where the function `lmd_ghost` is defined below. Note that the implementation below is suboptimal; there are implementations that compute the head in time logarithmic in slot count.
 
 ```python

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -254,7 +254,7 @@ Unless otherwise indicated, code appearing in `this style` is to be interpreted 
 
 ## Data structures
 
-The following data structures are [SimpleSerialize (SSZ)](https://github.com/ethereum/eth2.0-specs/blob/master/specs/simple-serialize.md) objects.
+The following data structures are defined as [SimpleSerialize (SSZ)](https://github.com/ethereum/eth2.0-specs/blob/master/specs/simple-serialize.md) objects.
 
 ### Beacon chain operations
 
@@ -801,7 +801,7 @@ Note: We aim to migrate to a S[T/N]ARK-friendly hash function in a future Ethere
 
 #### `hash_tree_root`
 
-`hash_tree_root` is a function for hashing objects into a single root utilizing a hash tree structure. `hash_tree_root` is defined in the [SimpleSerialize spec](https://github.com/ethereum/eth2.0-specs/blob/master/specs/simple-serialize.md#tree-hash).
+`def hash_tree_root(object: SSZSerializable) -> Bytes32` is a function for hashing objects into a single root utilizing a hash tree structure. `hash_tree_root` is defined in the [SimpleSerialize spec](https://github.com/ethereum/eth2.0-specs/blob/master/specs/simple-serialize.md#tree-hash).
 
 #### `is_active_validator`
 ```python
@@ -815,7 +815,7 @@ def is_active_validator(validator: Validator, slot: SlotNumber) -> bool:
 #### `get_active_validator_indices`
 
 ```python
-def get_active_validator_indices(validators: [Validator], slot: SlotNumber) -> List[ValidatorIndex]:
+def get_active_validator_indices(validators: List[Validator], slot: SlotNumber) -> List[ValidatorIndex]:
     """
     Gets indices of active validators from ``validators``.
     """
@@ -1568,7 +1568,7 @@ For each `deposit` in `block.body.deposits`:
 * Verify that `verify_merkle_branch(hash(serialized_deposit_data), deposit.branch, DEPOSIT_CONTRACT_TREE_DEPTH, deposit.index, state.latest_eth1_data.deposit_root)` is `True`.
 
 ```python
-def verify_merkle_branch(leaf: Bytes32, branch: [Bytes32], depth: int, index: int, root: Bytes32) -> bool:
+def verify_merkle_branch(leaf: Bytes32, branch: List[Bytes32], depth: int, index: int, root: Bytes32) -> bool:
     value = leaf
     for i in range(depth):
         if index // (2**i) % 2:


### PR DESCRIPTION
Fix #370 except for the fork choice rule section:

The `lmd_ghost` has a highly abstracted `store` and `start` objects. For correctness, we *can* define the `TStore = TypeVar("Store")` and `TStart = TypeVar("Start")` to deal with it. Would that be "too Pythonic" to our readers?
