### PR TITLE
epoch processing before block processing

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -946,27 +946,26 @@ def get_crosslink_committees_at_slot(state: BeaconState,
     """
     Returns the list of ``(committee, shard)`` tuples for the ``slot``.
     """
-    state_epoch_slot = state.slot - (state.slot % EPOCH_LENGTH) 
-    assert state_epoch_slot <= slot + EPOCH_LENGTH
-    assert slot < state_epoch_slot + EPOCH_LENGTH
-    offset = slot % EPOCH_LENGTH
+    assert slot >= state.previous_epoch_calculation_slot
 
-    if slot < state_epoch_slot:
+    if slot < state.current_epoch_calculation_slot:
         committees_per_slot = get_previous_epoch_committee_count_per_slot(state)
-        shuffling = get_shuffling(
-            state.previous_epoch_randao_mix,
-            state.validator_registry,
-            state.previous_epoch_calculation_slot,
-        )
-        slot_start_shard = (state.previous_epoch_start_shard + committees_per_slot * offset) % SHARD_COUNT
+        seed = state.previous_epoch_randao_mix
+        shuffling_slot = state.previous_epoch_calculation_slot
+        shuffling_start_shard = state.previous_epoch_start_shard
     else:
         committees_per_slot = get_current_epoch_committee_count_per_slot(state)
-        shuffling = get_shuffling(
-            state.current_epoch_randao_mix,
-            state.validator_registry,
-            state.current_epoch_calculation_slot,
-        )
-        slot_start_shard = (state.current_epoch_start_shard + committees_per_slot * offset) % SHARD_COUNT
+        seed = state.current_epoch_randao_mix
+        shuffling_slot = state.current_epoch_calculation_slot
+        shuffling_start_shard = state.current_epoch_start_shard
+
+    offset = slot % EPOCH_LENGTH
+    shuffling = get_shuffling(
+        seed,
+        state.validator_registry,
+        shuffling_slot,
+    )
+    slot_start_shard = (shuffling_start_shard + committees_per_slot * offset) % SHARD_COUNT
 
     return [
         (


### PR DESCRIPTION

* Move epoch processing before block processing (resolves https://github.com/ethereum/eth2.0-specs/issues/267#issuecomment-446139113). Epoch transitions now happen at the _beginning_ of an epoch before any blocks are processed from the new epoch. 
* This resolves some issues with the shuffling available in state (#409, #92, #352) by ensuring epoch shuffling is updated before blocks are processed. Also changed the bounds of `get_crosslink_committees_at_slot` to be based upon the `current_` and `previous_epoch_calculation_slot` and to allow for accessing shufflings arbitrarily in the future.

Note: `get_crosslink_committees_at_slot` can access shufflings arbitrarily in the future, but this is not guaranteed to remain stable if a state transition changes the shuffling between `state.slot` and the future slot (validator registry change, or power of 2 reshuffling).

Note: The per-slot transition line "Set state.validator_registry[get_beacon_proposer_index(state, state.slot)].randao_layers += 1" is still broken at the state transition epochs because the shuffling is not yet updated at this point, but I'm leaving it in because it is very likely to be removed after our discussion about removing the hash-onion entirely.