### PR TITLE
Reduce and revamp custody placeholder logic

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1109,8 +1109,7 @@ def verify_bitfield(bitfield: bytes, size: int) -> bool:
 
 ```python
 def verify_slashable_vote_data(state: BeaconState, slashable_vote_data: SlashableVoteData) -> bool:
-    # [TO BE REMOVED IN PHASE 1]
-    if len(slashable_vote_data.custody_bit_1_indices) > 0:
+    if len(slashable_vote_data.custody_bit_1_indices) > 0:  # [TO BE REMOVED IN PHASE 1]
         return False
 
     if len(indices(slashable_vote_data)) > MAX_CASPER_VOTES:
@@ -1532,6 +1531,7 @@ For each `attestation` in `block.body.attestations`:
     assert verify_bitfield(attestation.aggregation_bitfield)
     assert verify_bitfield(attestation.custody_bitfield)
     assert attestation.custody_bitfield & attestation.aggregation_bitfield == attestation.custody_bitfield
+    assert attestation.custody_bitfield == 0 # [TO BE REMOVED IN PHASE 1]
 ```
 
 * Verify aggregate signature:

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1561,8 +1561,7 @@ For each `attestation` in `block.body.attestations`:
         ],
         signature=attestation.aggregate_signature,
         domain=get_domain(state.fork, attestation.data.slot, DOMAIN_ATTESTATION),
-    )
-    
+    ) 
 ```
 
 * [TO BE REMOVED IN PHASE 1] Verify that `attestation.data.shard_block_root == ZERO_HASH`.

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -20,7 +20,6 @@
         - [Max operations per block](#max-operations-per-block)
         - [Validator registry delta flags](#validator-registry-delta-flags)
         - [Signature domains](#signature-domains)
-        - [Custody bits](#custody-bits)
     - [Data structures](#data-structures)
         - [Beacon chain operations](#beacon-chain-operations)
             - [Proposer slashings](#proposer-slashings)
@@ -1080,6 +1079,9 @@ def get_domain(fork: Fork,
 
 ```python
 def get_bitfield_bit(bitfield: bytes, i: int) -> int:
+    """
+    Extract the bit in ``bitfield`` at position ``i``.
+    """
     return (bitfield[i // 8] >> (7 - (i % 8))) % 2
 ```
 
@@ -1087,12 +1089,13 @@ def get_bitfield_bit(bitfield: bytes, i: int) -> int:
 
 ```python
 def verify_bitfield(bitfield: bytes, size: int) -> bool:
-    ```
+    """
     Verify ``bitfield`` against the ``size``.
+    """
     if len(bitfield) != (size + 7) // 8:
         return False
 
-    for i in range(size + 1, size + size % 8 + 8):
+    for i in range(size + 1, size - size % 8 + 8):
         if get_bitfield_bit(bitfield, i) != 0:
             return False
 
@@ -1103,6 +1106,9 @@ def verify_bitfield(bitfield: bytes, size: int) -> bool:
 
 ```python
 def verify_slashable_vote_data(state: BeaconState, slashable_vote_data: SlashableVoteData) -> bool:
+    """
+    Verify validity of ``slashable_vote_data`` fields.
+    """
     if slashable_vote_data.custody_bitfield != 0:  # [TO BE REMOVED IN PHASE 1]
         return False
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -167,7 +167,7 @@ Code snippets appearing in `this style` are to be interpreted as Python code. Be
 | `EJECTION_BALANCE` | `2**4 * 1e9` (= 16,000,000,000) | Gwei |
 | `MAX_BALANCE_CHURN_QUOTIENT` | `2**5` (= 32) | - |
 | `BEACON_CHAIN_SHARD_NUMBER` | `2**64 - 1` | - |
-| `MAX_CASPER_VOTES` | `2**12` (= 4,096) | votes |
+| `MAX_INDICES_PER_SLASHABLE_VOTE` | `2**12` (= 4,096) | votes |
 | `LATEST_BLOCK_ROOTS_LENGTH` | `2**13` (= 8,192) | block roots |
 | `LATEST_RANDAO_MIXES_LENGTH` | `2**13` (= 8,192) | randao mixes |
 | `LATEST_INDEX_ROOTS_LENGTH` | `2**13` (= 8,192) | index roots |
@@ -1147,7 +1147,7 @@ def verify_slashable_vote_data(state: BeaconState, slashable_vote_data: Slashabl
     if not verify_bitfield(slashable_vote_data.custody_bitfield, len(slashable_vote_data.validator_indices)):
         return False
 
-    if len(slashable_vote_data.validator_indices) > MAX_CASPER_VOTES:
+    if len(slashable_vote_data.validator_indices) > MAX_INDICES_PER_SLASHABLE_VOTE:
         return False
 
     custody_bit_0_indices = []

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1526,13 +1526,17 @@ For each `attestation` in `block.body.attestations`:
 * Verify that `attestation.data.justified_slot` is equal to `state.justified_slot if attestation.data.slot >= state.slot - (state.slot % EPOCH_LENGTH) else state.previous_justified_slot`.
 * Verify that `attestation.data.justified_block_root` is equal to `get_block_root(state, attestation.data.justified_slot)`.
 * Verify that either `attestation.data.latest_crosslink_root` or `attestation.data.shard_block_root` equals `state.latest_crosslinks[shard].shard_block_root`.
-* `attestation.aggregate_signature` verification:
+* Verify bitfields:
 
 ```python
     assert verify_bitfield(attestation.aggregation_bitfield)
     assert verify_bitfield(attestation.custody_bitfield)
     assert attestation.custody_bitfield & attestation.aggregation_bitfield == attestation.custody_bitfield
+```
 
+* Verify aggregate signature:
+
+```python
     participants = get_attestation_participants(state, attestation.data, attestation.aggregation_bitfield)
     custody_bit_0_participants = get_attestation_participants(state, attestation.data, attestation.custody_bitfield)
     custody_bit_1_participants = [i in participants for i not in custody_bit_0_participants]

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1554,7 +1554,7 @@ For each `attestation` in `block.body.attestations`:
 * Verify bitfields and aggregate signature:
 
 ```python
-    assert attestation.custody_bitfield == 0 # [TO BE REMOVED IN PHASE 1]
+    assert attestation.custody_bitfield == 0  # [TO BE REMOVED IN PHASE 1]
 
     for i in range(len(crosslink_committee)):
         if get_bitfield_bit(attestation.aggregation_bitfield) == 0:

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -30,6 +30,7 @@
             - [Attestations](#attestations)
                 - [`Attestation`](#attestation)
                 - [`AttestationData`](#attestationdata)
+                - [`AttestationDataWrapped`](#attestationdatawrapped)
             - [Deposits](#deposits)
                 - [`Deposit`](#deposit)
                 - [`DepositData`](#depositdata)
@@ -290,12 +291,12 @@ Code snippets appearing in `this style` are to be interpreted as Python code. Be
 
 ```python
 {
-    # Validator indices
-    'validator_indices': ['uint24'],
     # Attestation data
     'data': AttestationData,
     # Aggregate signature
     'aggregate_signature': 'bytes96',
+    # Validator indices
+    'validator_indices': ['uint24'],
 }
 ```
 
@@ -334,6 +335,15 @@ Code snippets appearing in `this style` are to be interpreted as Python code. Be
     'justified_slot': 'uint64',
     # Hash of the last justified beacon block
     'justified_block_root': 'bytes32',
+}
+```
+
+#### `AttestationDataWrapped`
+
+```python
+{
+    # Attestation data
+    'data': AttestationData,
 }
 ```
 
@@ -1065,7 +1075,7 @@ def verify_slashable_vote_data(state: BeaconState, vote_data: SlashableVoteData)
 
     return bls_verify(
         pubkey=bls_aggregate_pubkeys([state.validator_registry[i].pubkey for i in vote_data.validator_indices]),
-        message=hash_tree_root(AttestationData(vote_data.data)),
+        message=hash_tree_root(AttestationDataWrapped(data=vote_data.data)),
         signature=vote_data.aggregate_signature,
         domain=get_domain(state.fork, vote_data.data.slot, DOMAIN_ATTESTATION),
     )
@@ -1460,7 +1470,7 @@ For each `attestation` in `block.body.attestations`:
 * `aggregate_signature` verification:
     * Let `participants = get_attestation_participants(state, attestation.data, attestation.aggregation_bitfield)`.
     * Let `group_public_key = bls_aggregate_pubkeys([state.validator_registry[v].pubkey for v in participants])`.
-    * Verify that `bls_verify(pubkey=group_public_key, message=hash_tree_root(AttestationData(attestation.data)), signature=attestation.aggregate_signature, domain=get_domain(state.fork, attestation.data.slot, DOMAIN_ATTESTATION))`.
+    * Verify that `bls_verify(pubkey=group_public_key, message=hash_tree_root(AttestationDataWrapped(data=attestation.data)), signature=attestation.aggregate_signature, domain=get_domain(state.fork, attestation.data.slot, DOMAIN_ATTESTATION))`.
 * [TO BE REMOVED IN PHASE 1] Verify that `attestation.data.shard_block_root == ZERO_HASH`.
 * Append `PendingAttestation(data=attestation.data, aggregation_bitfield=attestation.aggregation_bitfield, slot_included=state.slot)` to `state.latest_attestations`.
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -20,6 +20,7 @@
         - [Max operations per block](#max-operations-per-block)
         - [Validator registry delta flags](#validator-registry-delta-flags)
         - [Signature domains](#signature-domains)
+        - [Custody bits](#custody-bits)
     - [Data structures](#data-structures)
         - [Beacon chain operations](#beacon-chain-operations)
             - [Proposer slashings](#proposer-slashings)

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1557,7 +1557,7 @@ For each `attestation` in `block.body.attestations`:
 ```
 
 * [TO BE REMOVED IN PHASE 1] Verify that `attestation.data.shard_block_root == ZERO_HASH`.
-* Append `PendingAttestation(data=attestation.data, aggregation_bitfield=attestation.aggregation_bitfield, slot_included=state.slot)` to `state.latest_attestations`.
+* Append `PendingAttestation(data=attestation.data, aggregation_bitfield=attestation.aggregation_bitfield, custody_bitfield=attestation.custody_bitfield, slot_included=state.slot)` to `state.latest_attestations`.
 
 #### Deposits
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1551,19 +1551,15 @@ For each `attestation` in `block.body.attestations`:
 * Verify that `attestation.data.justified_slot` is equal to `state.justified_slot if attestation.data.slot >= state.slot - (state.slot % EPOCH_LENGTH) else state.previous_justified_slot`.
 * Verify that `attestation.data.justified_block_root` is equal to `get_block_root(state, attestation.data.justified_slot)`.
 * Verify that either `attestation.data.latest_crosslink_root` or `attestation.data.shard_block_root` equals `state.latest_crosslinks[shard].shard_block_root`.
-* Verify bitfields:
+* Verify bitfields and aggregate signature:
 
 ```python
+    assert attestation.custody_bitfield == 0 # [TO BE REMOVED IN PHASE 1]
+
     for i in range(len(crosslink_committee)):
         if get_bitfield_bit(attestation.aggregation_bitfield) == 0:
             assert get_bitfield_bit(attestation.custody_bitfield) == 0
 
-    assert attestation.custody_bitfield == 0 # [TO BE REMOVED IN PHASE 1]
-```
-
-* Verify aggregate signature:
-
-```python
     participants = get_attestation_participants(state, attestation.data, attestation.aggregation_bitfield)
     custody_bit_0_participants = get_attestation_participants(state, attestation.data, attestation.custody_bitfield)
     custody_bit_1_participants = [i in participants for i not in custody_bit_0_participants]

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -255,13 +255,6 @@ Code snippets appearing in `this style` are to be interpreted as Python code. Be
 | `DOMAIN_EXIT` | `3` |
 | `DOMAIN_RANDAO` | `4` |
 
-### Custody bits
-
-| Name | Value |
-| - | - |
-| `CUSTODY_BIT_ZERO` | `False` |
-| `CUSTODY_BIT_ONE` | `True` |
-
 ## Data structures
 
 ### Beacon chain operations
@@ -1140,8 +1133,8 @@ def verify_slashable_vote_data(state: BeaconState, slashable_vote_data: Slashabl
             bls_aggregate_pubkeys([state.validator_registry[i].pubkey for i in custody_bit_1_indices]),
         ],
         messages=[
-            hash_tree_root(AttestationDataAndCustodyBit(slashable_vote_data.data, CUSTODY_BIT_ZERO)),
-            hash_tree_root(AttestationDataAndCustodyBit(slashable_vote_data.data, CUSTODY_BIT_ONE)),
+            hash_tree_root(AttestationDataAndCustodyBit(slashable_vote_data.data, 0)),
+            hash_tree_root(AttestationDataAndCustodyBit(slashable_vote_data.data, 1)),
         ],
         signature=slashable_vote_data.aggregate_signature,
         domain=get_domain(state.fork, slashable_vote_data.data.slot, DOMAIN_ATTESTATION),
@@ -1556,8 +1549,8 @@ For each `attestation` in `block.body.attestations`:
             bls_aggregate_pubkeys([state.validator_registry[i].pubkey for i in custody_bit_1_participants]),
         ],
         messages=[
-            hash_tree_root(AttestationDataAndCustodyBit(data=attestation.data, custody_bit=CUSTODY_BIT_ZERO)),
-            hash_tree_root(AttestationDataAndCustodyBit(data=attestation.data, custody_bit=CUSTODY_BIT_ONE)),
+            hash_tree_root(AttestationDataAndCustodyBit(data=attestation.data, custody_bit=0)),
+            hash_tree_root(AttestationDataAndCustodyBit(data=attestation.data, custody_bit=1)),
         ],
         signature=attestation.aggregate_signature,
         domain=get_domain(state.fork, attestation.data.slot, DOMAIN_ATTESTATION),

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -25,7 +25,7 @@
                 - [`ProposerSlashing`](#proposerslashing)
             - [Casper slashings](#casper-slashings)
                 - [`CasperSlashing`](#casperslashing)
-                - [`SlashableVote`](#SlashableVote)
+                - [`SlashableVote`](#slashablevote)
             - [Attestations](#attestations)
                 - [`Attestation`](#attestation)
                 - [`AttestationData`](#attestationdata)

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -361,7 +361,7 @@ The following data structures are defined as [SimpleSerialize (SSZ)](https://git
     # Attestation data
     'data': AttestationData,
     # Custody bit
-    'custody_bit': bool,
+    'custody_bit': 'bool',
 }
 ```
 
@@ -1624,7 +1624,7 @@ For each `attestation` in `block.body.attestations`:
             hash_tree_root(AttestationDataAndCustodyBit(data=attestation.data, custody_bit=0b1)),
         ],
         signature=attestation.aggregate_signature,
-        domain=get_domain(state.fork, attestation.data.slot, DOMAIN_ATTESTATION),
+        domain=get_domain(state.fork, slot_to_epoch(attestation.data.slot), DOMAIN_ATTESTATION),
     ) 
 ```
 


### PR DESCRIPTION
Remove all custody and VDF placeholders (56 lines less!). A few notes on the placeholder fields and logic:

* All placeholder fields were dummy fields that can easily be restored in the phase 1 hard fork.
* One special case to the above is `custody_bit_0_validator_indices` in `SlashableVoteData` which was renamed to `validator_indices`. Renaming it back is *not* a spec change because SSZ field names are [no longer part of the spec](https://github.com/ethereum/eth2.0-specs/commit/a9328157a87451ee4f372df272ece158b386ec41#diff-8d8fe480a35579c7be2f976d9b321216).
* The placeholder logic was written using generalised functions (e.g. `bls_verify_multiple` vs `bls_verify`, and `indices(slashable_vote_data)` vs `slashable_vote_data.validator_indices`). This generality was unnecessary because it was not triggered when all custody bits were 0. This means we can simplify the logic without being inconsistent with phase 1.

Rationale:

* Keep phase 0 (likely far harder to deliver than phase 1) as clean as possible
* Focus on upgrade paths and incremental releases
* Custody is still under research—keep the design space open