### PR TITLE
"proposer_slots" -> "proposer_nonce"

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -518,7 +518,7 @@ Code snippets appearing in `this style` are to be interpreted as Python code. Be
     # Withdrawal credentials
     'withdrawal_credentials': 'bytes32',
     # Number of proposer slots since genesis
-    'proposer_slots': 'uint64',
+    'proposer_nonce': 'uint64',
     # Slot when validator activated
     'activation_slot': 'uint64',
     # Slot when validator exited
@@ -1333,7 +1333,7 @@ def process_deposit(state: BeaconState,
         validator = Validator(
             pubkey=pubkey,
             withdrawal_credentials=withdrawal_credentials,
-            proposer_slots=0,
+            proposer_nonce=0,
             activation_slot=FAR_FUTURE_SLOT,
             exit_slot=FAR_FUTURE_SLOT,
             withdrawal_slot=FAR_FUTURE_SLOT,
@@ -1430,7 +1430,7 @@ Below are the processing steps that happen at every slot.
 ### Misc counters
 
 * Set `state.slot += 1`.
-* Set `state.validator_registry[get_beacon_proposer_index(state, state.slot)].proposer_slots += 1`.
+* Set `state.validator_registry[get_beacon_proposer_index(state, state.slot)].proposer_nonce += 1`.
 * Set `state.latest_randao_mixes[state.slot % LATEST_RANDAO_MIXES_LENGTH] = state.latest_randao_mixes[(state.slot - 1) % LATEST_RANDAO_MIXES_LENGTH]`
 
 ### Block roots
@@ -1456,7 +1456,7 @@ Below are the processing steps that happen at every `block`.
 ### RANDAO
 
 * Let `proposer = state.validator_registry[get_beacon_proposer_index(state, state.slot)]`.
-* Verify that `bls_verify(pubkey=proposer.pubkey, message=int_to_bytes32(proposer.proposer_slots), signature=block.randao_reveal, domain=get_domain(state.fork, state.slot, DOMAIN_RANDAO))`.
+* Verify that `bls_verify(pubkey=proposer.pubkey, message=int_to_bytes32(proposer.proposer_nonce), signature=block.randao_reveal, domain=get_domain(state.fork, state.slot, DOMAIN_RANDAO))`.
 * Set `state.latest_randao_mixes[state.slot % LATEST_RANDAO_MIXES_LENGTH] = hash(state.latest_randao_mixes[state.slot % LATEST_RANDAO_MIXES_LENGTH] + block.randao_reveal)`.
 
 ### Eth1 data


### PR DESCRIPTION
## What
 
Rename `proposer_slots` to `proposer_nonce`.

## Why

The naming "proposer_slots" is confusing when considering the API between the Beacon Node and the Validator. Consider that the validator must ask the following questions of the Beacon Node:

- What slots should I propose on? (shuffling)
- What is my proposer slots? (`proposer_slots`)

AFAIK we don't care how many slots that proposer has proposed, only that the number is different for each proposal. Nonce sounds like a better descriptor to me.