### PR TITLE
Replace `proposer_slots` with `slot`

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -517,8 +517,6 @@ Code snippets appearing in `this style` are to be interpreted as Python code. Be
     'pubkey': 'bytes48',
     # Withdrawal credentials
     'withdrawal_credentials': 'bytes32',
-    # Number of proposer slots since genesis
-    'proposer_slots': 'uint64',
     # Slot when validator activated
     'activation_slot': 'uint64',
     # Slot when validator exited
@@ -1333,7 +1331,6 @@ def process_deposit(state: BeaconState,
         validator = Validator(
             pubkey=pubkey,
             withdrawal_credentials=withdrawal_credentials,
-            proposer_slots=0,
             activation_slot=FAR_FUTURE_SLOT,
             exit_slot=FAR_FUTURE_SLOT,
             withdrawal_slot=FAR_FUTURE_SLOT,
@@ -1430,7 +1427,6 @@ Below are the processing steps that happen at every slot.
 ### Misc counters
 
 * Set `state.slot += 1`.
-* Set `state.validator_registry[get_beacon_proposer_index(state, state.slot)].proposer_slots += 1`.
 * Set `state.latest_randao_mixes[state.slot % LATEST_RANDAO_MIXES_LENGTH] = state.latest_randao_mixes[(state.slot - 1) % LATEST_RANDAO_MIXES_LENGTH]`
 
 ### Block roots
@@ -1456,7 +1452,7 @@ Below are the processing steps that happen at every `block`.
 ### RANDAO
 
 * Let `proposer = state.validator_registry[get_beacon_proposer_index(state, state.slot)]`.
-* Verify that `bls_verify(pubkey=proposer.pubkey, message=int_to_bytes32(proposer.proposer_slots), signature=block.randao_reveal, domain=get_domain(state.fork, state.slot, DOMAIN_RANDAO))`.
+* Verify that `bls_verify(pubkey=proposer.pubkey, message=int_to_bytes32(block.slot), signature=block.randao_reveal, domain=get_domain(state.fork, state.slot, DOMAIN_RANDAO))`.
 * Set `state.latest_randao_mixes[state.slot % LATEST_RANDAO_MIXES_LENGTH] = hash(state.latest_randao_mixes[state.slot % LATEST_RANDAO_MIXES_LENGTH] + block.randao_reveal)`.
 
 ### Eth1 data


### PR DESCRIPTION
## What

Use `slot` instead of `proposer_slots` when producing the `randao_reveal` signature.

## Why

In the separate Beacon Node (BN) & Validator Client (VC) model, it's difficult for a VC to know the BN isn't causing the VC to reveal future values. This is because the BN is the source of truth for the current `proposer_slots`.

If `slot` is used, a validator can use their system clock to determine if a reveal is a "future reveal" (bad) or a "present reveal" (good).

Additionally, using `slot` removes one API call from the VC to the BN. It already knows the `slot` but it must request `proposer_slots`.