### PR TITLE
randao reveal is signed epoch number

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -517,8 +517,6 @@ Code snippets appearing in `this style` are to be interpreted as Python code. Be
     'pubkey': 'bytes48',
     # Withdrawal credentials
     'withdrawal_credentials': 'bytes32',
-    # Number of proposer slots since genesis
-    'proposer_slots': 'uint64',
     # Slot when validator activated
     'activation_slot': 'uint64',
     # Slot when validator exited
@@ -1333,7 +1331,6 @@ def process_deposit(state: BeaconState,
         validator = Validator(
             pubkey=pubkey,
             withdrawal_credentials=withdrawal_credentials,
-            proposer_slots=0,
             activation_slot=FAR_FUTURE_SLOT,
             exit_slot=FAR_FUTURE_SLOT,
             withdrawal_slot=FAR_FUTURE_SLOT,
@@ -1430,7 +1427,6 @@ Below are the processing steps that happen at every slot.
 ### Misc counters
 
 * Set `state.slot += 1`.
-* Set `state.validator_registry[get_beacon_proposer_index(state, state.slot)].proposer_slots += 1`.
 * Set `state.latest_randao_mixes[state.slot % LATEST_RANDAO_MIXES_LENGTH] = state.latest_randao_mixes[(state.slot - 1) % LATEST_RANDAO_MIXES_LENGTH]`
 
 ### Block roots
@@ -1456,8 +1452,8 @@ Below are the processing steps that happen at every `block`.
 ### RANDAO
 
 * Let `proposer = state.validator_registry[get_beacon_proposer_index(state, state.slot)]`.
-* Verify that `bls_verify(pubkey=proposer.pubkey, message=int_to_bytes32(proposer.proposer_slots), signature=block.randao_reveal, domain=get_domain(state.fork, state.slot, DOMAIN_RANDAO))`.
-* Set `state.latest_randao_mixes[state.slot % LATEST_RANDAO_MIXES_LENGTH] = hash(state.latest_randao_mixes[state.slot % LATEST_RANDAO_MIXES_LENGTH] + block.randao_reveal)`.
+* Verify that `bls_verify(pubkey=proposer.pubkey, message=int_to_bytes32(state.slot // EPOCH_LENGTH), signature=block.randao_reveal, domain=get_domain(state.fork, state.slot, DOMAIN_RANDAO))`.
+* Set `state.latest_randao_mixes[state.slot % LATEST_RANDAO_MIXES_LENGTH] = xor(state.latest_randao_mixes[state.slot % LATEST_RANDAO_MIXES_LENGTH], hash(block.randao_reveal))`.
 
 ### Eth1 data
 

--- a/specs/validator/0_beacon-chain-validator.md
+++ b/specs/validator/0_beacon-chain-validator.md
@@ -158,12 +158,12 @@ _Note_: To calculate `state_root`, the validator should first run the state tran
 
 ##### Randao reveal
 
-Set `block.randao_reveal = reveal_signature` where `reveal_signature` is defined as:
+Set `block.randao_reveal = epoch_signature` where `epoch_signature` is defined as:
 
 ```python
-reveal_signature = bls_sign(
+epoch_signature = bls_sign(
     privkey=validator.privkey,  # privkey store locally, not in state
-    message=int_to_bytes32(validator.proposer_slots + 1),
+    message=int_to_bytes32(block.slot // EPOCH_LENGTH),
     domain=get_domain(
         fork_data,  # `fork_data` is the fork_data at the slot `block.slot`
         block.slot,


### PR DESCRIPTION
Addresses changes to randao reveal noted [here](https://github.com/ethereum/eth2.0-specs/pull/496#issuecomment-457569088).

- remove `proposer_slots`
- sign `block.slot // EPOCH_LENGTH` (the epoch number) as randao reveal
- Hash the reveal to reduce to 32 bytes and create a reveal chain
- XOR with previous randao mix to get new mix

Thanks @JustinDrake and @paulhauner for the ideas and conversation!