### PR TITLE
Update `Beacon chain state transition function` chapter intro

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -765,12 +765,13 @@ def lmd_ghost(store: Store, start_state: BeaconState, start_block: BeaconBlock) 
 
 ## Beacon chain state transition function
 
-We now define the state transition function. At a high level the state transition is made up of two parts:
+We now define the state transition function. At a high level the state transition is made up of three parts:
 
-1. The per-slot transitions, which happens every slot, and only affects a parts of the `state`.
-2. The per-epoch transitions, which happens at every epoch boundary (i.e. `state.slot % EPOCH_LENGTH == 0`), and affects the entire `state`.
+1. The per-slot transitions, which happens every slot.
+2. The per-block transitions, which happens at every block.
+3. The per-epoch transitions, which happens at every epoch boundary (i.e. `state.slot % EPOCH_LENGTH == 0`).
 
-The per-slot transitions generally focus on verifying aggregate signatures and saving temporary records relating to the per-slot activity in the `BeaconState`. The per-epoch transitions focus on the [validator](#dfn-validator) registry, including adjusting balances and activating and exiting [validators](#dfn-validator), as well as processing crosslinks and managing block justification/finalization.
+The per-slot transitions focus on the slot counter and block roots records updates; the per-block transitions generally focus on verifying aggregate signatures and saving temporary records relating to the per-block activity in the `BeaconState`; the per-epoch transitions focus on the [validator](#dfn-validator) registry, including adjusting balances and activating and exiting [validators](#dfn-validator), as well as processing crosslinks and managing block justification/finalization.
 
 ### Helper functions
 


### PR DESCRIPTION
- The current `per-slot` description should be for `per-block`.
- Add the real `per-slot` transition description.
- Personally feel that indicating "only affects a parts of the `state`" and "affects the entire `state`"  is not very helpful information here - they all affect the state anyway. 😅 