### PR TITLE
Stricter aggregation_bitfield validation

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1604,8 +1604,9 @@ For each `attestation` in `block.body.attestations`:
 * Verify that either `attestation.data.latest_crosslink_root` or `attestation.data.shard_block_root` equals `state.latest_crosslinks[shard].shard_block_root`.
 * Verify bitfields and aggregate signature:
 
-```python
+```python    
     assert attestation.custody_bitfield == b'\x00' * len(attestation.custody_bitfield)  # [TO BE REMOVED IN PHASE 1]
+    assert attestation.aggregation_bitfield != b'\x00' * len(attestation.aggregation_bitfield)
 
     for i in range(len(crosslink_committee)):
         if get_bitfield_bit(attestation.aggregation_bitfield) == 0b0:


### PR DESCRIPTION
Make sure that there's at least one vote in attestations (`bls_verify_multiple` can return `True` with zero votes)