### PR TITLE
fix is_surround as per #410

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1095,10 +1095,8 @@ def is_surround_vote(attestation_data_1: AttestationData,
     source_epoch_2 = attestation_data_2.justified_epoch
     target_epoch_1 = slot_to_epoch(attestation_data_1.slot)
     target_epoch_2 = slot_to_epoch(attestation_data_2.slot)
-    return (
-        (source_epoch_1 < source_epoch_2) and
-        (target_epoch_2 < target_epoch_1)
-    )
+
+    return source_epoch_1 < source_epoch_2 and target_epoch_2 < target_epoch_1
 ```
 
 ### `integer_squareroot`

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1097,7 +1097,6 @@ def is_surround_vote(attestation_data_1: AttestationData,
     target_epoch_2 = slot_to_epoch(attestation_data_2.slot)
     return (
         (source_epoch_1 < source_epoch_2) and
-        (source_epoch_2 + 1 == target_epoch_2) and
         (target_epoch_2 < target_epoch_1)
     )
 ```


### PR DESCRIPTION
Removes the sequential condition from `is_surround`.
This was supposed to be handled when fixing #410 but was missed.

(specific ref here https://github.com/ethereum/eth2.0-specs/issues/410#issuecomment-453330653)