### PR TITLE
Fix to verify bitfields and aggregate signature.

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1632,7 +1632,8 @@ For each `attestation` in `block.body.attestations`:
     assert attestation.custody_bitfield == b'\x00' * len(attestation.custody_bitfield)  # [TO BE REMOVED IN PHASE 1]
     assert attestation.aggregation_bitfield != b'\x00' * len(attestation.aggregation_bitfield)
 
-    for i in range(len(crosslink_committee)):
+    assert len(attestation.aggregation_bitfield) <= len(attestation.custody_bitfield)
+    for i in range(len(attestation.aggregation_bitfield)):
         if get_bitfield_bit(attestation.aggregation_bitfield, i) == 0b0:
             assert get_bitfield_bit(attestation.custody_bitfield, i) == 0b0
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1632,7 +1632,10 @@ For each `attestation` in `block.body.attestations`:
     assert attestation.custody_bitfield == b'\x00' * len(attestation.custody_bitfield)  # [TO BE REMOVED IN PHASE 1]
     assert attestation.aggregation_bitfield != b'\x00' * len(attestation.aggregation_bitfield)
     
-    crosslink_committee = get_crosslink_committee_at_slot(state, attestation.data.slot)[0]
+    crosslink_committee = [
+        committee for committee, shard in get_crosslink_committees_at_slot(state, attestation.data.slot)
+        if shard == attestation.data.shard
+    ][0]
     verify_bitfield(attestation.aggregation_bitfield, len(crosslink_committee))
     verify_bitfield(attestation.custody_bitfield, len(crosslink_committee))
     

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1631,9 +1631,12 @@ For each `attestation` in `block.body.attestations`:
 ```python
     assert attestation.custody_bitfield == b'\x00' * len(attestation.custody_bitfield)  # [TO BE REMOVED IN PHASE 1]
     assert attestation.aggregation_bitfield != b'\x00' * len(attestation.aggregation_bitfield)
-
-    assert len(attestation.aggregation_bitfield) <= len(attestation.custody_bitfield)
-    for i in range(len(attestation.aggregation_bitfield)):
+    
+    crosslink_committee = get_crosslink_committee_at_slot(state, attestation.data.slot)[0]
+    verify_bitfield(attestation.aggregation_bitfield, len(crosslink_committee))
+    verify_bitfield(attestation.custody_bitfield, len(crosslink_committee))
+    
+    for i in range(len(crosslink_committee):
         if get_bitfield_bit(attestation.aggregation_bitfield, i) == 0b0:
             assert get_bitfield_bit(attestation.custody_bitfield, i) == 0b0
 


### PR DESCRIPTION
In block processing, `crosslink_committee` is not defined. This is a fix.

In Phase 0 this check is redundant since we've already asserted that the
custody bitfield is all zero, but it will matter in later phases.