### PR TITLE
Remove the unnecessary double backticks on 'validator' in docstring.

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1020,7 +1020,7 @@ def is_power_of_two(value: int) -> bool:
 ```python
 def get_effective_balance(state: State, index: ValidatorIndex) -> Gwei:
     """
-    Return the effective balance (also known as "balance at stake") for a ``validator`` with the given ``index``.
+    Return the effective balance (also known as "balance at stake") for a validator with the given ``index``.
     """
     return min(state.validator_balances[index], MAX_DEPOSIT_AMOUNT)
 ```


### PR DESCRIPTION
The usual convention is that we mark function parameters in docstrings with
double backticks. There is no (longer a) parameter called 'validator' so we
update the docstring to conform to the convention.

Seems like this was a holdover from iirc a time when this function did have a parameter `validator` (when the balances where hanging off the `Validator` type)