### PR TITLE
Remove the repeated checks

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1742,7 +1742,7 @@ For each `attestation` in `block.body.attestations`:
         committee for committee, shard in get_crosslink_committees_at_slot(state, attestation.data.slot)
         if shard == attestation.data.shard
     ][0]
-    for i in range(len(crosslink_committee):
+    for i in range(len(crosslink_committee)):
         if get_bitfield_bit(attestation.aggregation_bitfield, i) == 0b0:
             assert get_bitfield_bit(attestation.custody_bitfield, i) == 0b0
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1742,9 +1742,6 @@ For each `attestation` in `block.body.attestations`:
         committee for committee, shard in get_crosslink_committees_at_slot(state, attestation.data.slot)
         if shard == attestation.data.shard
     ][0]
-    verify_bitfield(attestation.aggregation_bitfield, len(crosslink_committee))
-    verify_bitfield(attestation.custody_bitfield, len(crosslink_committee))
-    
     for i in range(len(crosslink_committee):
         if get_bitfield_bit(attestation.aggregation_bitfield, i) == 0b0:
             assert get_bitfield_bit(attestation.custody_bitfield, i) == 0b0


### PR DESCRIPTION
`verify_bitfield(attestation.aggregation_bitfield, len(crosslink_committee))` and `verify_bitfield(attestation.custody_bitfield, len(crosslink_committee))` will be checked in the following `get_attestation_participants(state, attestation.data, attestation.aggregation_bitfield)` and `get_attestation_participants(state, attestation.data, attestation.custody_bitfield)`.
