### PR TITLE
Fix `verify_bitfield`

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1099,7 +1099,7 @@ def verify_bitfield(bitfield: bytes, committee_size: int) -> bool:
     if len(bitfield) != (committee_size + 7) // 8:
         return False
 
-    # Check if `bitfield` has padding zeros
+    # Check `bitfield` is padded with zero bits only
     for i in range(committee_size, len(bitfield) * 8):
         if get_bitfield_bit(bitfield, i) == 0b1:
             return False

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1099,9 +1099,11 @@ def verify_bitfield(bitfield: bytes, committee_size: int) -> bool:
     if len(bitfield) != (committee_size + 7) // 8:
         return False
 
-    for i in range(committee_size + 1, committee_size - committee_size % 8 + 8):
-        if get_bitfield_bit(bitfield, i) == 0b1:
-            return False
+    # Check if `bitfield` has padding zeros
+    if committee_size % 8 != 0:
+        for i in range(committee_size, committee_size - committee_size % 8 + 8):
+            if get_bitfield_bit(bitfield, i) == 0b1:
+                return False
 
     return True
 ```

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1100,10 +1100,9 @@ def verify_bitfield(bitfield: bytes, committee_size: int) -> bool:
         return False
 
     # Check if `bitfield` has padding zeros
-    if committee_size % 8 != 0:
-        for i in range(committee_size, committee_size - committee_size % 8 + 8):
-            if get_bitfield_bit(bitfield, i) == 0b1:
-                return False
+    for i in range(committee_size, len(bitfield) * 8):
+        if get_bitfield_bit(bitfield, i) == 0b1:
+            return False
 
     return True
 ```


### PR DESCRIPTION
### Issues
1. When `committee_size` is 16, the bitfield length is 2, and then `get_bitfield_bit(bitfield, committee_size)` is out of range.
2. If `committee_size % 8 != 0`, the padding zero should be added from `index=committee_size` in `bitfield`.

### Fixes
1. Only check the padding zeros when `committee_size % 8 != 0`, otherwise it will trigger `IndexError`.
2. Check the zero padding bits from the bitfield index `committee_size`. (it was starting from `committee_size + 1`)