### PR TITLE
Introduce swap-or-not shuffle

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -718,7 +718,7 @@ def shuffle(values: List[Any], seed: Bytes32) -> List[Any]:
             return flip if bit else pos
 
         indices = [permute(v) for v in indices]
-    return [v[index] for index in indices]
+    return [values[index] for index in indices]
 ```
 
 ### `split`

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -697,53 +697,22 @@ def get_active_validator_indices(validators: List[Validator], epoch: EpochNumber
 
 ```python
 def shuffle(values: List[Any], seed: Bytes32) -> List[Any]:
-    """
-    Return the shuffled ``values`` with ``seed`` as entropy.
-    """
-    values_count = len(values)
+    indices = list(range(len(values)))
+    for round in range(90):
+        hashvalues = b''.join([
+            hash(seed + round.to_bytes(1, 'big') + i.to_bytes(4, 'big'))
+            for i in range((n + 255) // 256)
+        ])
+        pivot = int.from_bytes(hash(seed + round.to_bytes(1, 'big')), 'big') % n
+        
+        def permute(pos):
+            flip = (pivot - pos) % n
+            maxpos = max(pos, flip)
+            bit = (hashvalues[maxpos // 8] >> (maxpos % 8)) % 2
+            return flip if bit else pos
 
-    # Entropy is consumed from the seed in 3-byte (24 bit) chunks.
-    rand_bytes = 3
-    # The highest possible result of the RNG.
-    rand_max = 2 ** (rand_bytes * 8) - 1
-
-    # The range of the RNG places an upper-bound on the size of the list that
-    # may be shuffled. It is a logic error to supply an oversized list.
-    assert values_count < rand_max
-
-    output = [x for x in values]
-    source = seed
-    index = 0
-    while index < values_count - 1:
-        # Re-hash the `source` to obtain a new pattern of bytes.
-        source = hash(source)
-        # Iterate through the `source` bytes in 3-byte chunks.
-        for position in range(0, 32 - (32 % rand_bytes), rand_bytes):
-            # Determine the number of indices remaining in `values` and exit
-            # once the last index is reached.
-            remaining = values_count - index
-            if remaining == 1:
-                break
-
-            # Read 3-bytes of `source` as a 24-bit big-endian integer.
-            sample_from_source = int.from_bytes(source[position:position + rand_bytes], 'big')
-
-            # Sample values greater than or equal to `sample_max` will cause
-            # modulo bias when mapped into the `remaining` range.
-            sample_max = rand_max - rand_max % remaining
-
-            # Perform a swap if the consumed entropy will not cause modulo bias.
-            if sample_from_source < sample_max:
-                # Select a replacement index for the current index.
-                replacement_position = (sample_from_source % remaining) + index
-                # Swap the current index with the replacement index.
-                output[index], output[replacement_position] = output[replacement_position], output[index]
-                index += 1
-            else:
-                # The sample causes modulo bias. A new sample should be read.
-                pass
-
-    return output
+        indices = [permute(v) for v in indices]
+    return [v[index] for index in indices]
 ```
 
 ### `split`

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -707,10 +707,10 @@ def shuffle(values: List[Any], seed: Bytes32) -> List[Any]:
     indices = list(range(len(values)))
     for round in range(90):
         hashvalues = b''.join([
-            hash(seed + round.to_bytes(1, 'big') + i.to_bytes(4, 'big'))
+            hash(seed + round.to_bytes(1, 'little') + i.to_bytes(4, 'little'))
             for i in range((len(values) + 255) // 256)
         ])
-        pivot = int.from_bytes(hash(seed + round.to_bytes(1, 'big')), 'big') % n
+        pivot = int.from_bytes(hash(seed + round.to_bytes(1, 'little')), 'little') % n
         def permute(pos):
             flip = (pivot - pos) % n
             maxpos = max(pos, flip)

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -708,7 +708,7 @@ def shuffle(values: List[Any], seed: Bytes32) -> List[Any]:
     for round in range(90):
         hashvalues = b''.join([
             hash(seed + round.to_bytes(1, 'big') + i.to_bytes(4, 'big'))
-            for i in range((n + 255) // 256)
+            for i in range((len(values) + 255) // 256)
         ])
         pivot = int.from_bytes(hash(seed + round.to_bytes(1, 'big')), 'big') % n
         def permute(pos):

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -704,7 +704,6 @@ def shuffle(values: List[Any], seed: Bytes32) -> List[Any]:
             for i in range((n + 255) // 256)
         ])
         pivot = int.from_bytes(hash(seed + round.to_bytes(1, 'big')), 'big') % n
-        
         def permute(pos):
             flip = (pivot - pos) % n
             maxpos = max(pos, flip)

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -697,7 +697,7 @@ def get_active_validator_indices(validators: List[Validator], epoch: EpochNumber
 ### `get_permuted_index`
 
 ```python
-def get_permuted_index(index: int, list_size: int, seed: Bytes32, round_count: int=90) -> List[int]:
+def get_permuted_index(index: int, list_size: int, seed: Bytes32, round_count: int=90) -> int:
     """
     Return `p(index)` in a pseudorandom permutation `p` of `0...list_size-1` with ``seed`` as entropy.
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -76,6 +76,7 @@
         - [`get_attestation_participants`](#get_attestation_participants)
         - [`is_power_of_two`](#is_power_of_two)
         - [`int_to_bytes1`, `int_to_bytes2`, ...](#int_to_bytes1-int_to_bytes2-)
+        - [`bytes_to_int`](#bytes_to_int)
         - [`get_effective_balance`](#get_effective_balance)
         - [`get_total_balance`](#get_total_balance)
         - [`get_fork_version`](#get_fork_version)
@@ -707,7 +708,7 @@ def get_permuted_index(index: int, list_size: int, seed: Bytes32, round_count: i
     See the 'generalized domain' algorithm on page 3.
     """
     for round in range(round_count):
-        pivot = int.from_bytes(hash(seed + int_to_bytes1(round)), 'little') % list_size
+        pivot = bytes_to_int(hash(seed + int_to_bytes1(round))) % list_size
         flip = (pivot - index) % list_size
         position = max(index, flip)
         source = hash(seed + int_to_bytes1(round) + int_to_bytes4(position // 256))
@@ -1006,6 +1007,13 @@ def is_power_of_two(value: int) -> bool:
 ### `int_to_bytes1`, `int_to_bytes2`, ...
 
 `int_to_bytes1(x): return x.to_bytes(1, 'big')`, `int_to_bytes2(x): return x.to_bytes(2, 'big')`, and so on for all integers, particularly 1, 2, 3, 4, 8, 32, 48, 96.
+
+### `bytes_to_int`
+
+```python
+def bytes_to_int(data: bytes) -> int:
+    return int.from_bytes(data, 'little')
+```
 
 ### `get_effective_balance`
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -774,7 +774,6 @@ def get_shuffling(seed: Bytes32,
     committees_per_epoch = get_epoch_committee_count(len(active_validator_indices))
 
     # Shuffle
-    shuffled_indices = shuffle(len(active_validator_indices), seed)
     shuffled_active_validator_indices = [
         active_validator_indices[i]
         for i in shuffle(len(active_validator_indices), seed)

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -698,7 +698,7 @@ def get_active_validator_indices(validators: List[Validator], epoch: EpochNumber
 ```python
 def get_permuted_index(index: int, list_size: int, seed: Bytes32) -> int:
     """
-    Return a pseudorandom permutation of `0...list_size-1` with ``seed`` as entropy.
+    Return `p(index)` in a pseudorandom permutation `p` of `0...list_size-1` with ``seed`` as entropy.
     
     Utilizes 'swap or not' shuffling found in
     https://link.springer.com/content/pdf/10.1007%2F978-3-642-32009-5_1.pdf

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -185,6 +185,7 @@ Code snippets appearing in `this style` are to be interpreted as Python code. Be
 | `BEACON_CHAIN_SHARD_NUMBER` | `2**64 - 1` | - |
 | `MAX_INDICES_PER_SLASHABLE_VOTE` | `2**12` (= 4,096) | votes |
 | `MAX_WITHDRAWALS_PER_EPOCH` | `2**2` (= 4) | withdrawals |
+| `SHUFFLE_ROUND_COUNT` | 90 | - |
 
 * For the safety of crosslinks `TARGET_COMMITTEE_SIZE` exceeds [the recommended minimum committee size of 111](https://vitalik.ca/files/Ithaca201807_Sharding.pdf); with sufficient active validators (at least `EPOCH_LENGTH * TARGET_COMMITTEE_SIZE`), the shuffling algorithm ensures committee sizes at least `TARGET_COMMITTEE_SIZE`. (Unbiasable randomness with a Verifiable Delay Function (VDF) will improve committee robustness and lower the safe minimum committee size.)
 
@@ -697,17 +698,15 @@ def get_active_validator_indices(validators: List[Validator], epoch: EpochNumber
 ### `get_permuted_index`
 
 ```python
-def get_permuted_index(index: int, list_size: int, seed: Bytes32, round_count: int=90) -> int:
+def get_permuted_index(index: int, list_size: int, seed: Bytes32) -> int:
     """
     Return `p(index)` in a pseudorandom permutation `p` of `0...list_size-1` with ``seed`` as entropy.
-
-    Note that ``round_count`` is ``90`` in protocol and parameterized for the shuffling tests.
 
     Utilizes 'swap or not' shuffling found in
     https://link.springer.com/content/pdf/10.1007%2F978-3-642-32009-5_1.pdf
     See the 'generalized domain' algorithm on page 3.
     """
-    for round in range(round_count):
+    for round in range(SHUFFLE_ROUND_COUNT):
         pivot = bytes_to_int(hash(seed + int_to_bytes1(round))[0:8]) % list_size
         flip = (pivot - index) % list_size
         position = max(index, flip)

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -708,7 +708,7 @@ def get_permuted_index(index: int, list_size: int, seed: Bytes32, round_count: i
     See the 'generalized domain' algorithm on page 3.
     """
     for round in range(round_count):
-        pivot = bytes_to_int(hash(seed + int_to_bytes1(round))) % list_size
+        pivot = bytes_to_int(hash(seed + int_to_bytes1(round))[0:8]) % list_size
         flip = (pivot - index) % list_size
         position = max(index, flip)
         source = hash(seed + int_to_bytes1(round) + int_to_bytes4(position // 256))

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -697,6 +697,13 @@ def get_active_validator_indices(validators: List[Validator], epoch: EpochNumber
 
 ```python
 def shuffle(values: List[Any], seed: Bytes32) -> List[Any]:
+    """
+    Return the shuffled ``values`` with ``seed`` as entropy.
+    
+    Utilizes 'swap or not' shuffling found in
+    https://link.springer.com/content/pdf/10.1007%2F978-3-642-32009-5_1.pdf
+    See the 'generalized domain' algorithm on page 3.
+    """
     indices = list(range(len(values)))
     for round in range(90):
         hashvalues = b''.join([


### PR DESCRIPTION
See #563 for discussion.

Here is a more efficient implementation for shuffling an entire set; it can live here until we come up with an explicit "efficient implementation" doc:

```python
def shuffle(list_size, seed):
    indices = list(range(list_size))
    for round in range(90):
        hash_bytes = b''.join([
            hash(seed + round.to_bytes(1, 'little') + (i).to_bytes(4, 'little'))
            for i in range((list_size + 255) // 256)
        ])
        pivot = int.from_bytes(hash(seed + round.to_bytes(1, 'little')), 'little') % list_size

        powers_of_two = [1, 2, 4, 8, 16, 32, 64, 128]
            
        for i, index in enumerate(indices):
            flip = (pivot - index) % list_size
            hash_pos = index if index > flip else flip
            byte = hash_bytes[hash_pos // 8]
            if byte & powers_of_two[hash_pos % 8]:
                indices[i] = flip
    return indices
```