### PR TITLE
Updated phase 1: branch and early subkey reveal challenges

### DIFF
--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -381,7 +381,7 @@ Define a `SubkeyReveal` as follows:
 ### `get_attestation_merkle_depth`
 
 ```python
-def get_merkle_depth(attestation: Attestation) -> int:
+def get_attestation_merkle_depth(attestation: Attestation) -> int:
     start_epoch = attestation.data.latest_crosslink.epoch
     end_epoch = slot_to_epoch(attestation.data.slot)
     chunks_per_slot = SHARD_BLOCK_SIZE // 32
@@ -489,7 +489,7 @@ For each `challenge` in `block.body.branch_challenges`:
 * Verify that `state.validator_registry[responder_index].exit_epoch >= get_current_epoch(state) - MAX_BRANCH_CHALLENGE_DELAY`.
 * Verify that `verify_slashable_attestation(state, challenge.attestation)` returns `True`.
 * Verify that `challenge.responder_index` is in `challenge.attestation.validator_indices`.
-* Let `depth = get_attestation_merkle_depth(challenge.attestation))`. Verify that `challenge.data_index < 2**depth`.
+* Let `depth = get_attestation_merkle_depth(challenge.attestation)`. Verify that `challenge.data_index < 2**depth`.
 * Verify that there does not exist a `BranchChallengeRecord` in `state.validator_registry[challenge.responder_index].open_branch_challenges` with `root == challenge.attestation.data.shard_chain_commitment` and `data_index == data_index`.
 * Append to `state.validator_registry[challenge.responder_index].open_branch_challenges` the object `BranchChallengeRecord(challenger_index=get_beacon_proposer_index(state, state.slot), root=challenge.attestation.data.shard_chain_commitment, depth=depth, inclusion_epoch=get_current_epoch(state), data_index=data_index)`.
 

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -20,7 +20,7 @@ Phase 1 depends upon all of the constants defined in [Phase 0](0_beacon-chain.md
 |------------------------------|-----------------|--------|---------------|
 | `SHARD_CHUNK_SIZE`           | 2**5 (= 32)     | bytes  |               |
 | `SHARD_BLOCK_SIZE`           | 2**14 (= 16384) | bytes  |               |
-| `CROSSLINK_LOOKBACK`         | 2**5 (= 32)     | slots |               |
+| `CROSSLINK_LOOKBACK`         | 2**5 (= 32)     | slots  |               |
 | `MAX_BRANCH_CHALLENGE_DELAY` | 2**11 (= 2048)  | epochs | 9 days        |
 | `CHALLENGE_RESPONSE_DEADLINE`| 2**14 (= 16384) | epochs | 73 days       |
 | `MAX_BRANCH_CHALLENGES`      | 2**2 (= 4)      |        |               |

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -238,5 +238,3 @@ def process_challenge_absences(state: BeaconState) -> None:
         if len(validator.open_branch_challenges) > 0 and get_current_epoch(state) > validator.open_branch_challenges[0].inclusion_epoch + CHALLENGE_RESPONSE_DEADLINE:
             penalize_validator(state, index)
 ```
-
-Run penalize_validator(state, index) for each index in slashable_indices.

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -418,7 +418,8 @@ Change the definition of `prepare_validator_for_withdrawal` as follows:
 ```python
 def prepare_validator_for_withdrawal(state: BeaconState, index: ValidatorIndex) -> None:
     """
-    Set the validator with the given ``index`` with ``WITHDRAWABLE`` flag.
+    Set the validator with the given ``index`` as withdrawable
+    ``MIN_VALIDATOR_WITHDRAWAL_EPOCHS`` from now.
     Note that this function mutates ``state``.
     """
     validator = state.validator_registry[index]

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -44,6 +44,7 @@
             - [Branch responses](#branch-responses)
             - [Subkey reveals](#subkey-reveals)
     - [Per-epoch processing](#per-epoch-processing)
+    - [One-time phase 1 initiation transition](#one-time-phase-1-initiation-transition)
 
 <!-- /TOC -->
 

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -399,7 +399,7 @@ def epoch_to_custody_period(epoch: int) -> int:
 ### `slot_to_custody_period`
 
 ```python
-def epoch_to_custody_period(slot: int) -> int:
+def slot_to_custody_period(slot: int) -> int:
     return epoch_to_custody_period(slot_to_epoch(slot))
 ```
 

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -12,9 +12,9 @@
         - [Terminology](#terminology)
         - [Constants](#constants)
             - [Misc](#misc)
-        - [Time parameters](#time-parameters)
+            - [Time parameters](#time-parameters)
             - [Max operations per block](#max-operations-per-block)
-        - [Signature domains](#signature-domains)
+            - [Signature domains](#signature-domains)
     - [Helper functions](#helper-functions)
             - [get_split_offset](#get_split_offset)
             - [get_persistent_committee](#get_persistent_committee)
@@ -67,7 +67,7 @@ Phase 1 depends upon all of the constants defined in [Phase 0](0_beacon-chain.md
 | `SHARD_BLOCK_SIZE`            | 2**14 (= 16,384) | bytes  |
 | `MINOR_REWARD_QUOTIENT`       | 2**8 (= 256)     |        |
 
-### Time parameters
+#### Time parameters
 
 | Name | Value | Unit | Duration |
 | - | - | :-: | :-: |
@@ -85,7 +85,7 @@ Phase 1 depends upon all of the constants defined in [Phase 0](0_beacon-chain.md
 | `MAX_BRANCH_RESPONSES`        | 2**4 (= 16)   |
 | `MAX_EARLY_SUBKEY_REVEALS`    | 2**4 (= 16)   |
 
-### Signature domains
+#### Signature domains
 
 | Name                   | Value           |
 |------------------------|-----------------|

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -17,6 +17,7 @@
             - [Signature domains](#signature-domains)
     - [Helper functions](#helper-functions)
             - [get_split_offset](#get_split_offset)
+            - [get_shuffled_committee](#get_shuffled_committee)
             - [get_persistent_committee](#get_persistent_committee)
             - [get_shard_proposer_index](#get_shard_proposer_index)
     - [Data Structures](#data-structures)

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -418,8 +418,7 @@ Change the definition of `prepare_validator_for_withdrawal` as follows:
 ```python
 def prepare_validator_for_withdrawal(state: BeaconState, index: ValidatorIndex) -> None:
     """
-    Set the validator with the given ``index`` as withdrawable
-    ``MIN_VALIDATOR_WITHDRAWAL_EPOCHS`` from now.
+    Set the validator with the given ``index`` as withdrawable ``MIN_VALIDATOR_WITHDRAWAL_EPOCHS`` the current epoch.
     Note that this function mutates ``state``.
     """
     validator = state.validator_registry[index]

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -149,6 +149,8 @@ The fork choice rule for any shard is LMD GHOST using the shard chain attestatio
 
 ## Data structures
 
+### `Validator`
+
 Add member values to the end of the `Validator` object:
 
 ```python
@@ -167,6 +169,8 @@ And the initializers:
 
 Rename `withdrawal_epoch` to `withdrawable_epoch`.
 
+### `BranchChallengeRecord`
+
 Define a `BranchChallengeRecord` as follows:
 
 ```python
@@ -179,6 +183,8 @@ Define a `BranchChallengeRecord` as follows:
 }
 ```
 
+### `BeaconBlockBody`
+
 Add two member values to the `BeaconBlockBody` structure:
 
 ```python
@@ -186,6 +192,8 @@ Add two member values to the `BeaconBlockBody` structure:
     'branch_responses': [BranchResponse],
     'subkey_reveals': [SubkeyReveal],
 ```
+
+### `BranchChallenge`
 
 Define a `BranchChallenge` as follows:
 
@@ -196,6 +204,8 @@ Define a `BranchChallenge` as follows:
     'attestation': SlashableAttestation,
 }
 ```
+
+### `BranchResponse`
 
 Define a `BranchResponse` as follows:
 
@@ -209,6 +219,8 @@ Define a `BranchResponse` as follows:
 }
 ```
 
+### `SubkeyReveal`
+
 Define a `SubkeyReveal` as follows:
 
 ```python
@@ -221,10 +233,14 @@ Define a `SubkeyReveal` as follows:
 
 ## Helpers
 
+### `get_current_custody_period`
+
 ```python
 def get_current_custody_period(state: BeaconState) -> int:
     return get_current_epoch(state) // CUSTODY_PERIOD_LENGTH
 ```
+
+### `verify_custody_subkey`
 
 ```python
 def verify_custody_subkey(pubkey: bytes48, subkey: bytes96, period: int) -> bool:
@@ -240,6 +256,8 @@ def verify_custody_subkey(pubkey: bytes48, subkey: bytes96, period: int) -> bool
     )
 ```
 
+### `prepare_validator_for_withdrawal`
+
 Change the definition of `prepare_validator_for_withdrawal` as follows:
 
 ```python
@@ -251,6 +269,8 @@ def prepare_validator_for_withdrawal(state: BeaconState, index: ValidatorIndex) 
     validator = state.validator_registry[index]
     validator.withdrawable_epoch = get_current_epoch(state) + MIN_VALIDATOR_WITHDRAWAL_EPOCHS
 ```
+
+### `penalize_validator`
 
 Change the definition of `penalize_validator` as follows:
 
@@ -274,9 +294,11 @@ def penalize_validator(state: BeaconState, index: ValidatorIndex) -> None:
 
 ## Per-slot processing
 
-Add two object processing categories to the per-slot processing, in order given below and lower than all other objects (specifically, right below exits) as follows.
+### Operations
 
-### Branch challenges
+Add the following operations to the per-slot processing, in order given below and _following_ all other operations (specifically, right after exits) as follows.
+
+#### Branch challenges
 
 Verify that `len(block.body.branch_challenges) <= MAX_BRANCH_CHALLENGES`.
 
@@ -292,7 +314,7 @@ For each `challenge` in `block.body.branch_challenges`:
 
 **Invariant**: the `open_branch_challenges` array will always stay sorted in order of `inclusion_epoch`.
 
-### Branch responses
+#### Branch responses
 
 Verify that `len(block.body.branch_responses) <= MAX_BRANCH_RESPONSES`.
 
@@ -304,7 +326,7 @@ For each `response` in `block.body.branch_responses`:
 * Remove the `record` from `state.validator_registry[response.responder_index].open_branch_challenges`
 * Determine the proposer `proposer_index = get_beacon_proposer_index(state, state.slot)` and set `state.validator_balances[proposer_index] += base_reward(state, index) // MINOR_REWARD_QUOTIENT`.
 
-### Subkey reveals
+#### Subkey reveals
 
 Verify that `len(block.body.early_subkey_reveals) <= MAX_EARLY_SUBKEY_REVEALS`.
 

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -267,7 +267,7 @@ For each `reveal` in `block.body.early_subkey_reveals`:
 
 * Verify that `state.validator_registry[reveal.validator_index].penalized_epoch > get_current_epoch(state) + ENTRY_EXIT_DELAY`.
 * Verify that `verify_custody_subkey(state.validator_registry[reveal.validator_index].pubkey, reveal.subkey, reveal.period)` returns `True`.
-* Verify that `reveal.period > get_current_custody_period(state)`.
+* Verify that `reveal.period >= get_current_custody_period(state)`.
 * Run `penalize_validator(state, reveal.validator_index)`.
 
 ## Per-epoch processing

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -301,8 +301,6 @@ And the initializers:
     'reveal_max_periods_late': 0,
 ```
 
-Rename `withdrawal_epoch` to `withdrawable_epoch`.
-
 ### `BeaconBlockBody`
 
 Add member values to the `BeaconBlockBody` structure:
@@ -417,20 +415,6 @@ def verify_custody_subkey_reveal(pubkey: bytes48,
     )
 ```
 
-### `prepare_validator_for_withdrawal`
-
-Change the definition of `prepare_validator_for_withdrawal` as follows:
-
-```python
-def prepare_validator_for_withdrawal(state: BeaconState, index: ValidatorIndex) -> None:
-    """
-    Set the validator with the given ``index`` as withdrawable ``MIN_VALIDATOR_WITHDRAWAL_EPOCHS`` the current epoch.
-    Note that this function mutates ``state``.
-    """
-    validator = state.validator_registry[index]
-    validator.withdrawable_epoch = get_current_epoch(state) + MIN_VALIDATOR_WITHDRAWAL_EPOCHS
-```
-
 ### `penalize_validator`
 
 Change the definition of `penalize_validator` as follows:
@@ -458,6 +442,8 @@ def penalize_validator(state: BeaconState, index: ValidatorIndex, whistleblower_
     validator.penalized_epoch = get_current_epoch(state)
     validator.withdrawable_epoch = get_current_epoch(state) + LATEST_PENALIZED_EXIT_LENGTH
 ```
+
+The only change is that this introduces the possibility of a penalization where the "whistleblower" that takes credit is NOT the block proposer.
 
 ## Per-slot processing
 

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -392,14 +392,14 @@ def get_merkle_depth(attestation: Attestation) -> int:
 ### `epoch_to_custody_period`
 
 ```python
-def epoch_to_custody_period(epoch: int) -> int:
+def epoch_to_custody_period(epoch: Epoch) -> int:
     return epoch // CUSTODY_PERIOD_LENGTH
 ```
 
 ### `slot_to_custody_period`
 
 ```python
-def slot_to_custody_period(slot: int) -> int:
+def slot_to_custody_period(slot: Slot) -> int:
     return epoch_to_custody_period(slot_to_epoch(slot))
 ```
 

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -89,8 +89,8 @@ Phase 1 depends upon all of the constants defined in [Phase 0](0_beacon-chain.md
 
 | Name                   | Value           |
 |------------------------|-----------------|
-| `SHARD_PROPOSER_DOMAIN`| 129             |
-| `SHARD_ATTESTER_DOMAIN`| 130             |
+| `DOMAIN_SHARD_PROPOSER`| 129             |
+| `DOMAIN_SHARD_ATTESTER`| 130             |
 | `DOMAIN_CUSTODY_SUBKEY`| 131             |
 
 ## Helper functions
@@ -218,9 +218,9 @@ To validate a block header on shard `shard_block.shard_id`, compute as follows:
 * Let `proposer_index = get_shard_proposer_index(state, shard_block.shard_id, shard_block.slot)`.
 * Verify that `proposer_index` is not `None`.
 * Let `msg` be the `shard_block` but with `shard_block.signature` set to `[0, 0]`.
-* Verify that `bls_verify(pubkey=validators[proposer_index].pubkey, message_hash=hash(msg), signature=shard_block.signature, domain=get_domain(state, slot_to_epoch(shard_block.slot), SHARD_PROPOSER_DOMAIN))` passes.
+* Verify that `bls_verify(pubkey=validators[proposer_index].pubkey, message_hash=hash(msg), signature=shard_block.signature, domain=get_domain(state, slot_to_epoch(shard_block.slot), DOMAIN_SHARD_PROPOSER))` passes.
 * Let `group_public_key = bls_aggregate_pubkeys([state.validators[index].pubkey for i, index in enumerate(persistent_committee) if get_bitfield_bit(shard_block.participation_bitfield, i) is True])`.
-* Verify that `bls_verify(pubkey=group_public_key, message_hash=shard_block.parent_root, sig=shard_block.aggregate_signature, domain=get_domain(state, slot_to_epoch(shard_block.slot), SHARD_ATTESTER_DOMAIN))` passes.
+* Verify that `bls_verify(pubkey=group_public_key, message_hash=shard_block.parent_root, sig=shard_block.aggregate_signature, domain=get_domain(state, slot_to_epoch(shard_block.slot), DOMAIN_SHARD_ATTESTER))` passes.
 
 ### Verifying shard block data
 

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -501,7 +501,7 @@ For each `reveal` in `block.body.early_subkey_reveals`:
 
 In case (i):
 
-* Verify that `state.validator_registry[reveal.validator_index].penalized_epoch > get_current_epoch(state) + ENTRY_EXIT_DELAY`.
+* Verify that `state.validator_registry[reveal.validator_index].penalized_epoch > get_current_epoch(state).
 * Run `penalize_validator(state, reveal.validator_index, reveal.revealer_index)`.
 * Set `state.validator_balances[reveal.revealer_index] += base_reward(state, index) // MINOR_REWARD_QUOTIENT`
 

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -156,7 +156,7 @@ Add member values to the end of the `Validator` object:
 ```python
     'open_branch_challenges': [BranchChallengeRecord],
     'next_subkey_to_reveal': 'uint64',
-    'reveal_max_periods_late': 'uint64'
+    'reveal_max_periods_late': 'uint64',
 ```
 
 And the initializers:
@@ -179,18 +179,26 @@ Define a `BranchChallengeRecord` as follows:
     'root': 'bytes32',
     'depth': 'uint64',
     'inclusion_epoch': 'uint64',
-    'data_index': 'uint64'
+    'data_index': 'uint64',
 }
 ```
 
 ### `BeaconBlockBody`
 
-Add two member values to the `BeaconBlockBody` structure:
+Add member values to the `BeaconBlockBody` structure:
 
 ```python
     'branch_challenges': [BranchChallenge],
     'branch_responses': [BranchResponse],
     'subkey_reveals': [SubkeyReveal],
+```
+
+And initialize to the following:
+
+```python
+    'branch_challenges': [],
+    'branch_responses': [],
+    'subkey_reveals': [],
 ```
 
 ### `BranchChallenge`
@@ -215,7 +223,7 @@ Define a `BranchResponse` as follows:
     'data': 'bytes32',
     'branch': ['bytes32'],
     'data_index': 'uint64',
-    'root': 'bytes32'
+    'root': 'bytes32',
 }
 ```
 
@@ -227,7 +235,7 @@ Define a `SubkeyReveal` as follows:
 {
     'validator_index': 'uint64',
     'period': 'uint64',
-    'subkey': 'bytes96'
+    'subkey': 'bytes96',
 }
 ```
 
@@ -249,9 +257,9 @@ def verify_custody_subkey(pubkey: bytes48, subkey: bytes96, period: int) -> bool
         message_hash=hash(int_to_bytes8(period)),
         signature=subkey,
         domain=get_domain(
-            state.fork,
-            period * CUSTODY_PERIOD_LENGTH,
-            DOMAIN_CUSTODY_SUBKEY
+            fork=state.fork,
+            epoch=period * CUSTODY_PERIOD_LENGTH,
+            domain_type=DOMAIN_CUSTODY_SUBKEY,
         )
     )
 ```
@@ -296,7 +304,7 @@ def penalize_validator(state: BeaconState, index: ValidatorIndex) -> None:
 
 ### Operations
 
-Add the following operations to the per-slot processing, in order given below and _following_ all other operations (specifically, right after exits) as follows.
+Add the following operations to the per-slot processing, in order the given below and _after_ all other operations (specifically, right after exits).
 
 #### Branch challenges
 

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -291,7 +291,7 @@ And the initializers:
 
 ```python
     'open_branch_challenges': [],
-    'next_subkey_to_reveal': 0,
+    'next_subkey_to_reveal': get_current_custody_period(state),
     'reveal_max_periods_late': 0,
 ```
 
@@ -543,4 +543,16 @@ def eligible(index):
     # Return minimum time
     else:
         return current_epoch >= validator.exit_epoch + MIN_VALIDATOR_WITHDRAWAL_EPOCHS
+```
+
+## One-time phase 1 initiation transition
+
+Run the following on the fork block after per-slot processing and before per-block and per-epoch processing.
+
+For all `validator` in `ValidatorRegistry`, update it to the new format and fill the new member values with:
+
+```python
+    'open_branch_challenges': [],
+    'next_subkey_to_reveal': get_current_custody_period(state),
+    'reveal_max_periods_late': 0,
 ```

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -1,7 +1,5 @@
 # Ethereum 2.0 Phase 1 -- Shard Data Chains
 
-###### tags: `spec`, `eth2.0`, `casper`, `sharding`
-
 **NOTICE**: This document is a work-in-progress for researchers and implementers. It reflects recent spec changes and takes precedence over the [Python proof-of-concept implementation](https://github.com/ethereum/beacon_chain).
 
 ## Table of contents
@@ -9,7 +7,6 @@
 <!-- TOC -->
 
 - [Ethereum 2.0 Phase 1 -- Shard Data Chains](#ethereum-20-phase-1----shard-data-chains)
-                    - [tags: `spec`, `eth2.0`, `casper`, `sharding`](#tags-spec-eth20-casper-sharding)
     - [Table of contents](#table-of-contents)
         - [Introduction](#introduction)
         - [Terminology](#terminology)


### PR DESCRIPTION
Includes:

* Branch challenges (ask for a branch of some signed attestation)
* Responses to branch challenges
* Code for calculating the subkey for some custody period (~9 days)
* Mechanism for revealing subkeys, both punitively (if the subkey is revealed early) and legitimately (if the subkey is revealed after it's expired), with a proof-of-knowledge-based mechanism for preventing proposer stealing of early subkey whistleblower rewards
* Cannot leave the withdraw queue until all branch challenges answered and all subkeys revealed
* After a validator leaves the withdraw queue, they still cannot withdraw for ~1 day; this period can be used as an opportunity to initiate an interactive proof of custody challenge game (not yet included)

So far all of the machinery is agnostic to what is discussed in #568; everything after this point, however, will not be.

Not included:

* The actual proof of custody game