### PR TITLE
Silently skip deposits with invalid proof in process_deposit

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1252,36 +1252,37 @@ def process_deposit(state: BeaconState,
     Note that this function mutates ``state``.
     """
     # Validate the given `proof_of_possession`
-    assert validate_proof_of_possession(
+    valid_proof = validate_proof_of_possession(
         state,
         pubkey,
         proof_of_possession,
         withdrawal_credentials,
     )
 
-    validator_pubkeys = [v.pubkey for v in state.validator_registry]
-
-    if pubkey not in validator_pubkeys:
-        # Add new validator
-        validator = Validator(
-            pubkey=pubkey,
-            withdrawal_credentials=withdrawal_credentials,
-            activation_epoch=FAR_FUTURE_EPOCH,
-            exit_epoch=FAR_FUTURE_EPOCH,
-            withdrawal_epoch=FAR_FUTURE_EPOCH,
-            penalized_epoch=FAR_FUTURE_EPOCH,
-            status_flags=0,
-        )
-
-        # Note: In phase 2 registry indices that have been withdrawn for a long time will be recycled.
-        state.validator_registry.append(validator)
-        state.validator_balances.append(amount)
-    else:
-        # Increase balance by deposit amount
-        index = validator_pubkeys.index(pubkey)
-        assert state.validator_registry[index].withdrawal_credentials == withdrawal_credentials
-
-        state.validator_balances[index] += amount
+    if valid_proof:
+        validator_pubkeys = [v.pubkey for v in state.validator_registry]
+    
+        if pubkey not in validator_pubkeys:
+            # Add new validator
+            validator = Validator(
+                pubkey=pubkey,
+                withdrawal_credentials=withdrawal_credentials,
+                activation_epoch=FAR_FUTURE_EPOCH,
+                exit_epoch=FAR_FUTURE_EPOCH,
+                withdrawal_epoch=FAR_FUTURE_EPOCH,
+                penalized_epoch=FAR_FUTURE_EPOCH,
+                status_flags=0,
+            )
+    
+            # Note: In phase 2 registry indices that have been withdrawn for a long time will be recycled.
+            state.validator_registry.append(validator)
+            state.validator_balances.append(amount)
+        else:
+            # Increase balance by deposit amount
+            index = validator_pubkeys.index(pubkey)
+            assert state.validator_registry[index].withdrawal_credentials == withdrawal_credentials
+    
+            state.validator_balances[index] += amount
 ```
 
 ### Routines for updating validator status

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1259,30 +1259,32 @@ def process_deposit(state: BeaconState,
         withdrawal_credentials,
     )
 
-    if proof_is_valid:
-        validator_pubkeys = [v.pubkey for v in state.validator_registry]
-    
-        if pubkey not in validator_pubkeys:
-            # Add new validator
-            validator = Validator(
-                pubkey=pubkey,
-                withdrawal_credentials=withdrawal_credentials,
-                activation_epoch=FAR_FUTURE_EPOCH,
-                exit_epoch=FAR_FUTURE_EPOCH,
-                withdrawal_epoch=FAR_FUTURE_EPOCH,
-                penalized_epoch=FAR_FUTURE_EPOCH,
-                status_flags=0,
-            )
-    
-            # Note: In phase 2 registry indices that have been withdrawn for a long time will be recycled.
-            state.validator_registry.append(validator)
-            state.validator_balances.append(amount)
-        else:
-            # Increase balance by deposit amount
-            index = validator_pubkeys.index(pubkey)
-            assert state.validator_registry[index].withdrawal_credentials == withdrawal_credentials
-    
-            state.validator_balances[index] += amount
+    if not proof_is_valid:
+        return
+
+    validator_pubkeys = [v.pubkey for v in state.validator_registry]
+
+    if pubkey not in validator_pubkeys:
+        # Add new validator
+        validator = Validator(
+            pubkey=pubkey,
+            withdrawal_credentials=withdrawal_credentials,
+            activation_epoch=FAR_FUTURE_EPOCH,
+            exit_epoch=FAR_FUTURE_EPOCH,
+            withdrawal_epoch=FAR_FUTURE_EPOCH,
+            penalized_epoch=FAR_FUTURE_EPOCH,
+            status_flags=0,
+        )
+
+        # Note: In phase 2 registry indices that have been withdrawn for a long time will be recycled.
+        state.validator_registry.append(validator)
+        state.validator_balances.append(amount)
+    else:
+        # Increase balance by deposit amount
+        index = validator_pubkeys.index(pubkey)
+        assert state.validator_registry[index].withdrawal_credentials == withdrawal_credentials
+
+        state.validator_balances[index] += amount
 ```
 
 ### Routines for updating validator status

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1259,7 +1259,7 @@ def process_deposit(state: BeaconState,
         withdrawal_credentials,
     )
 
-    if valid_proof:
+    if proof_is_valid:
         validator_pubkeys = [v.pubkey for v in state.validator_registry]
     
         if pubkey not in validator_pubkeys:

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1252,7 +1252,7 @@ def process_deposit(state: BeaconState,
     Note that this function mutates ``state``.
     """
     # Validate the given `proof_of_possession`
-    valid_proof = validate_proof_of_possession(
+    proof_is_valid = validate_proof_of_possession(
         state,
         pubkey,
         proof_of_possession,


### PR DESCRIPTION
### What's wrong:
`process_deposit` has the 
```python
assert validate_proof_of_possession(...)
```
statement which aborts processing of the block containing a deposit with invalid proof resulting this block being invalid. 
Thus a proposer needs to skip deposits with invalid proofs when composing a block. The same way malicious/incorrect proposer may skip a number of valid deposits. 

### Suggestion:
Include *all* deposits to blocks (this is verified by constantly incremented deposit index) but silently ignore deposits with invalid proofs on block transition: i.e. not change the validator registry/balances 