### PR TITLE
Merkleise SSZ container elements

### DIFF
--- a/specs/simple-serialize.md
+++ b/specs/simple-serialize.md
@@ -434,10 +434,10 @@ Where the inner `hash_tree_root_internal` is a recursive application of the tree
 
 #### Container
 
-Recursively tree hash the values in the container in the same order as the fields, and return the hash of the concatenation of the results.
+Recursively tree hash the values in the container in the same order as the fields, and Merkle hash the results.
 
 ```python
-return hash(b''.join([hash_tree_root_internal(getattr(x, field)) for field in value.fields]))
+return merkle_hash([hash_tree_root_internal(getattr(x, field)) for field in value.fields])
 ```
 
 ## Implementations


### PR DESCRIPTION
Reasons to use `merkle_hash` instead of  `hash` for containers:

1) **Smaller witnesses**: `BeaconState` is a somewhat wide container (26 fields as of now, likely 30+ in phase 2). With concatenation and plain concatenation the size of the Merkle witnesses for the top level are ~32 bytes per field element.
2) **Faster incremental hashing**
3) **Consistency**: Consistent with `merkle_hash` for lists/vectors.