### PR TITLE
Fix SSZ merkleisation bug

### DIFF
--- a/specs/simple-serialize.md
+++ b/specs/simple-serialize.md
@@ -417,6 +417,7 @@ def merkle_hash(lst):
     # Merkleise
     def next_power_of_2(x):  
         return 1 if x == 0 else 2**(x - 1).bit_length()
+
     for i in range(len(chunkz), next_power_of_2(len(chunkz))):
         chunkz.append(b'\x00' * SSZ_CHUNK_SIZE)
     while len(chunkz) > 1:     

--- a/specs/simple-serialize.md
+++ b/specs/simple-serialize.md
@@ -414,13 +414,15 @@ def merkle_hash(lst):
         # Leave large items alone
         chunkz = lst
 
-    # Tree-hash
-    while len(chunkz) > 1:
-        if len(chunkz) % 2 == 1:
-            chunkz.append(b'\x00' * SSZ_CHUNK_SIZE)
+    # Merkleise
+    def next_power_of_2(x):  
+        return 1 if x == 0 else 2**(x - 1).bit_length()
+    for i in range(len(chunkz), next_power_of_2(len(chunkz))):
+        chunkz.append(b'\x00' * SSZ_CHUNK_SIZE)
+    while len(chunkz) > 1:     
         chunkz = [hash(chunkz[i] + chunkz[i+1]) for i in range(0, len(chunkz), 2)]
 
-    # Return hash of root and length data
+    # Return hash of root and data length
     return hash(chunkz[0] + datalen)
 ```
 


### PR DESCRIPTION
We want `b'\x00' * SSZ_CHUNK_SIZE` in the leaves, *not* in intermediate nodes.