### PR TITLE
(Do not merge yet) Reduce SSZ_CHUNK_SIZE to 32

### DIFF
--- a/specs/simple-serialize.md
+++ b/specs/simple-serialize.md
@@ -57,8 +57,8 @@ overhead.
 
 | Constant          | Value | Definition                                                                            |
 |:------------------|:-----:|:--------------------------------------------------------------------------------------|
-| `LENGTH_BYTES`    |   4   | Number of bytes used for the length added before a variable-length serialized object. |
-| `SSZ_CHUNK_SIZE`  |  128  | Number of bytes for the chunk size of the Merkle tree leaf.                           |
+| `LENGTH_BYTES`    | 4     | Number of bytes used for the length added before a variable-length serialized object. |
+| `SSZ_CHUNK_SIZE`  | 32    | Number of bytes for the chunk size of the Merkle tree leaf.                           |
 
 ## Overview
 


### PR DESCRIPTION
The intent of setting SSZ_CHUNK_SIZE = 128 is to reduce the cost of hashing. It is possible (to be confirmed once we have more concrete numbers from implementers) that the gains are limited and not worth the complexity of using a non-standard chunk size.

If the gains indeed are limited, this PR aligns with the Eth2 goal "to minimize complexity, even at the cost of some losses in efficiency".