### PR TITLE
Add cautionary assert for divide-by-zero

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -742,7 +742,7 @@ def get_permuted_index(index: int, list_size: int, seed: Bytes32) -> int:
     https://link.springer.com/content/pdf/10.1007%2F978-3-642-32009-5_1.pdf
     See the 'generalized domain' algorithm on page 3.
     """
-    assert(index < list_size)
+    assert index < list_size
     
     for round in range(SHUFFLE_ROUND_COUNT):
         pivot = bytes_to_int(hash(seed + int_to_bytes1(round))[0:8]) % list_size

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -742,6 +742,9 @@ def get_permuted_index(index: int, list_size: int, seed: Bytes32) -> int:
     https://link.springer.com/content/pdf/10.1007%2F978-3-642-32009-5_1.pdf
     See the 'generalized domain' algorithm on page 3.
     """
+    # A zero-length list causes a divide-by-zero
+    assert(list_size > 0)
+    
     for round in range(SHUFFLE_ROUND_COUNT):
         pivot = bytes_to_int(hash(seed + int_to_bytes1(round))[0:8]) % list_size
         flip = (pivot - index) % list_size

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -742,8 +742,7 @@ def get_permuted_index(index: int, list_size: int, seed: Bytes32) -> int:
     https://link.springer.com/content/pdf/10.1007%2F978-3-642-32009-5_1.pdf
     See the 'generalized domain' algorithm on page 3.
     """
-    # A zero-length list causes a divide-by-zero
-    assert(list_size > 0)
+    assert(index < list_size)
     
     for round in range(SHUFFLE_ROUND_COUNT):
         pivot = bytes_to_int(hash(seed + int_to_bytes1(round))[0:8]) % list_size


### PR DESCRIPTION
## What

Adds a cautionary assert for divide-by-zero on `get_permutated_index`

## Why

![safety first](https://memegenerator.net/img/instances/500x/65100801/safety-first.jpg)