### PR TITLE
fix off by one attestaton issue

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1708,7 +1708,7 @@ Verify that `len(block.body.attestations) <= MAX_ATTESTATIONS`.
 For each `attestation` in `block.body.attestations`:
 
 * Verify that `attestation.data.slot <= state.slot - MIN_ATTESTATION_INCLUSION_DELAY < attestation.data.slot + EPOCH_LENGTH`.
-* Verify that `attestation.data.justified_epoch` is equal to `state.justified_epoch if attestation.data.slot >= get_epoch_start_slot(get_current_epoch(state)) else state.previous_justified_epoch`.
+* Verify that `attestation.data.justified_epoch` is equal to `state.justified_epoch if slot_to_epoch(attestation.data.slot + 1) >= get_current_epoch(state) else state.previous_justified_epoch`.
 * Verify that `attestation.data.justified_block_root` is equal to `get_block_root(state, get_epoch_start_slot(attestation.data.justified_epoch))`.
 * Verify that either (i) `state.latest_crosslinks[attestation.data.shard] == attestation.data.latest_crosslink` or (ii) `state.latest_crosslinks[attestation.data.shard] == Crosslink(shard_block_root=attestation.data.shard_block_root, epoch=slot_to_epoch(attestation.data.slot))`.
 * Verify bitfields and aggregate signature:


### PR DESCRIPTION
addresses #618 

Note that this is the quick fix. There is a discussion to be had on when exactly the epoch transition should occur. An alternative would be to be at the _start_ of the 0th slot of an epoch rather than at the _end_ of the last slot of an epoch. I'd like to get this fix merged now for the spec release because this is a critical bug and can save any debate for over this next week.