### PR TITLE
Add explicit assert to get_permutated_index

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -745,7 +745,7 @@ def get_permuted_index(index: int, list_size: int, seed: Bytes32) -> int:
     See the 'generalized domain' algorithm on page 3.
     """
     assert index < list_size
-    assert list_size < 2**24
+    assert list_size <= 2**24
     
     for round in range(SHUFFLE_ROUND_COUNT):
         pivot = bytes_to_int(hash(seed + int_to_bytes1(round))[0:8]) % list_size

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -745,7 +745,7 @@ def get_permuted_index(index: int, list_size: int, seed: Bytes32) -> int:
     See the 'generalized domain' algorithm on page 3.
     """
     assert index < list_size
-    assert list_size <= 2**24
+    assert list_size <= 2**40
     
     for round in range(SHUFFLE_ROUND_COUNT):
         pivot = bytes_to_int(hash(seed + int_to_bytes1(round))[0:8]) % list_size

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -745,6 +745,7 @@ def get_permuted_index(index: int, list_size: int, seed: Bytes32) -> int:
     See the 'generalized domain' algorithm on page 3.
     """
     assert index < list_size
+    assert list_size < 2**24
     
     for round in range(SHUFFLE_ROUND_COUNT):
         pivot = bytes_to_int(hash(seed + int_to_bytes1(round))[0:8]) % list_size


### PR DESCRIPTION
## What

Add an explicit assertion that the list size is within the bounds of the shuffler.

## Why

There is an implicit assert in `int_to_bytes4` but I don't think it' immediately obvious.

To find it you would need to be thinking about how Python handles `x.to_bytes(len, ..)` when `x >= 2**(len * 8)`.

Also, it illustrates the bounds of the algorithm.

## Additional Info

You could `assert SHUFFLE_ROUND_COUNT < 2**8` for `int_to_bytes1` but it's a constant so I omitted that.