### PR TITLE
Fix `slash_validator`

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1372,9 +1372,9 @@ def slash_validator(state: BeaconState, index: ValidatorIndex) -> None:
     Slash the validator with index ``index``.
     Note that this function mutates ``state``.
     """
+    validator = state.validator_registry[index]
     assert state.slot < validator.withdrawable_epoch  # [TO BE REMOVED IN PHASE 2]
     exit_validator(state, index)
-    validator = state.validator_registry[index]
     state.latest_slashed_balances[get_current_epoch(state) % LATEST_SLASHED_EXIT_LENGTH] += get_effective_balance(state, index)
 
     whistleblower_index = get_beacon_proposer_index(state, state.slot)

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1373,7 +1373,7 @@ def slash_validator(state: BeaconState, index: ValidatorIndex) -> None:
     Note that this function mutates ``state``.
     """
     validator = state.validator_registry[index]
-    assert state.slot < validator.withdrawable_epoch  # [TO BE REMOVED IN PHASE 2]
+    assert state.slot < get_epoch_start_slot(validator.withdrawable_epoch)  # [TO BE REMOVED IN PHASE 2]
     exit_validator(state, index)
     state.latest_slashed_balances[get_current_epoch(state) % LATEST_SLASHED_EXIT_LENGTH] += get_effective_balance(state, index)
 


### PR DESCRIPTION
1. Define `validator` before using it.
2. Compare `state.slot` and `validator.withdrawable_epoch` in slot level.