### PR TITLE
Remove hashing bottleneck from swap or not

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -747,10 +747,10 @@ def get_permuted_index(index: int, list_size: int, seed: Bytes32) -> int:
     assert index < list_size
     
     for round in range(SHUFFLE_ROUND_COUNT):
-        pivot = bytes_to_int(hash(seed + int_to_bytes2(round))[0:8]) % list_size
+        pivot = bytes_to_int(hash(seed + int_to_bytes32(round))[0:8]) % list_size
         flip = (pivot - index) % list_size
         position = max(index, flip)
-        source = xor(hash(seed + int_to_bytes2(round)), hash(int_to_bytes32(position // 256)))
+        source = xor(hash(seed + int_to_bytes32(round)), hash(int_to_bytes32(position // 256)))
         byte = source[(position % 256) // 8]
         bit = (byte >> (position % 8)) % 2
         index = flip if bit else index

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -747,10 +747,10 @@ def get_permuted_index(index: int, list_size: int, seed: Bytes32) -> int:
     assert index < list_size
     
     for round in range(SHUFFLE_ROUND_COUNT):
-        pivot = bytes_to_int(hash(seed + int_to_bytes1(round))[0:8]) % list_size
+        pivot = bytes_to_int(hash(seed + int_to_bytes2(round))[0:8]) % list_size
         flip = (pivot - index) % list_size
         position = max(index, flip)
-        source = xor(hash(seed), hash(int_to_bytes2(round) + int_to_bytes30(position // 256)))
+        source = xor(hash(seed + int_to_bytes2(round)), hash(int_to_bytes32(position // 256)))
         byte = source[(position % 256) // 8]
         bit = (byte >> (position % 8)) % 2
         index = flip if bit else index

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -750,7 +750,7 @@ def get_permuted_index(index: int, list_size: int, seed: Bytes32) -> int:
         pivot = bytes_to_int(hash(seed + int_to_bytes1(round))[0:8]) % list_size
         flip = (pivot - index) % list_size
         position = max(index, flip)
-        source = hash(seed + int_to_bytes1(round) + int_to_bytes4(position // 256))
+        source = xor(hash(seed), hash(int_to_bytes2(round) + int_to_bytes30(position // 256)))
         byte = source[(position % 256) // 8]
         bit = (byte >> (position % 8)) % 2
         index = flip if bit else index

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -747,10 +747,10 @@ def get_permuted_index(index: int, list_size: int, seed: Bytes32) -> int:
     assert index < list_size
     
     for round in range(SHUFFLE_ROUND_COUNT):
-        pivot = bytes_to_int(hash(seed + int_to_bytes32(round))[0:8]) % list_size
+        pivot = bytes_to_int(hash(seed + int_to_bytes1(round))[0:8]) % list_size
         flip = (pivot - index) % list_size
         position = max(index, flip)
-        source = xor(hash(seed + int_to_bytes32(round)), hash(int_to_bytes32(position // 256)))
+        source = hash(int_to_bytes31(position // 256) + int_to_bytes1(round) + seed)
         byte = source[(position % 256) // 8]
         bit = (byte >> (position % 8)) % 2
         index = flip if bit else index

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -747,10 +747,10 @@ def get_permuted_index(index: int, list_size: int, seed: Bytes32) -> int:
     assert index < list_size
     
     for round in range(SHUFFLE_ROUND_COUNT):
-        pivot = bytes_to_int(hash(seed + int_to_bytes1(round))[0:8]) % list_size
+        pivot = bytes_to_int(hash(seed + int_to_bytes2(round))[0:8]) % list_size
         flip = (pivot - index) % list_size
         position = max(index, flip)
-        source = hash(int_to_bytes31(position // 256) + int_to_bytes1(round) + seed)
+        source = hash(int_to_bytes62(position // 256) + int_to_bytes2(round) + seed)
         byte = source[(position % 256) // 8]
         bit = (byte >> (position % 8)) % 2
         index = flip if bit else index


### PR DESCRIPTION
Optimise hashing in swap or not:

1) `hash(seed + int_to_bytes32(round))` can now be computed once and cached for all values of `round` (90 of them).
2) `hash(int_to_bytes32(position // 256))` can be precomputed and cached for all relevant values of `position`. Even with 4,000,000 validators that's only 0.5MB (!!!) of cached data.

I also use `int_to_bytes32` instead of `int_to_bytes1` and `int_to_bytes4` to be more generic.