### PR TITLE
docs: fix typo in 0_beacon-chain.md

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -181,7 +181,7 @@ Code snippets appearing in `this style` are to be interpreted as Python code.
 ### Misc
 
 | Name | Value |
-| - | - | :-: |
+| - | - |
 | `SHARD_COUNT` | `2**10` (= 1,024) |
 | `TARGET_COMMITTEE_SIZE` | `2**7` (= 128) |
 | `MAX_BALANCE_CHURN_QUOTIENT` | `2**5` (= 32) |


### PR DESCRIPTION
I fixed a broken markdown table.

## before
<img width="981" alt="0_beacon-chain" src="https://user-images.githubusercontent.com/5894385/52895757-05caa200-3202-11e9-9c15-f73e8c718d5c.png">

## after
<img width="984" alt="0_beacon-chain_after" src="https://user-images.githubusercontent.com/5894385/52895839-3f4fdd00-3203-11e9-8213-0a385a856c56.png">