### PR TITLE
Fix out-of-bounds in `get_shuffling`

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -795,7 +795,7 @@ def get_shuffling(seed: Bytes32,
                   validators: List[Validator],
                   epoch: Epoch) -> List[List[ValidatorIndex]]
     """
-    Shuffle (seeded by ``seed`` and ``epoch``) active validators and split into crosslink committees.
+    Shuffle active validators and split into crosslink committees.
     Return a list of committees (each a list of validator indices).
     """
     # Shuffle active validator indices

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -807,7 +807,7 @@ def get_shuffling(seed: Bytes32,
     # Shuffle
     shuffled_active_validator_indices = [
         active_validator_indices[get_permuted_index(i, len(active_validator_indices), seed)]
-        for i in active_validator_indices
+        for i in range(len(active_validator_indices))
     ]
 
     # Split the shuffled list into committees_per_epoch pieces

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -795,23 +795,16 @@ def get_shuffling(seed: Bytes32,
                   validators: List[Validator],
                   epoch: Epoch) -> List[List[ValidatorIndex]]
     """
-    Shuffle ``validators`` into crosslink committees seeded by ``seed`` and ``epoch``.
-    Return a list of ``committees_per_epoch`` committees where each
-    committee is itself a list of validator indices.
+    Shuffle (seeded by ``seed`` and ``epoch``) active validators and split into crosslink committees.
+    Return a list of committees (each a list of validator indices).
     """
-
+    # Shuffle active validator indices
     active_validator_indices = get_active_validator_indices(validators, epoch)
+    length = len(active_validator_indices)
+    shuffled_indices = [active_validator_indices[get_permuted_index(i, length, seed)] for i in range(length)]
 
-    committees_per_epoch = get_epoch_committee_count(len(active_validator_indices))
-
-    # Shuffle
-    shuffled_active_validator_indices = [
-        active_validator_indices[get_permuted_index(i, len(active_validator_indices), seed)]
-        for i in range(len(active_validator_indices))
-    ]
-
-    # Split the shuffled list into committees_per_epoch pieces
-    return split(shuffled_active_validator_indices, committees_per_epoch)
+    # Split the shuffled active validator indices
+    return split(shuffled_indices, get_epoch_committee_count(length))
 ```
 
 **Invariant**: if `get_shuffling(seed, validators, epoch)` returns some value `x` for some `epoch <= get_current_epoch(state) + ACTIVATION_EXIT_DELAY`, it should return the same value `x` for the same `seed` and `epoch` and possible future modifications of `validators` forever in phase 0, and until the ~1 year deletion delay in phase 2 and in the future.


### PR DESCRIPTION
## What

Change `get_shuffling(...)` so it gives shuffles using an _index_ of `active_validator_indices` instead of a _value_ of `active_validator_indices`.

## Why

The following fails with a `IndexError: list index out of range`:

```python
validator_indices = [
    0,    # inactive
    1,    # active
    2,    # inactive
    3,    # active
]

# ... therefore ...

active_validator_indices = [
    1,    # active
    3,    # active
]

def get_permuted_index(i, length):
    return i

shuffled_active_validator_indices = [
        active_validator_indices[get_permuted_index(i, len(active_validator_indices))]
        for i in active_validator_indices
]
```

Whereas this does not:

```python
shuffled_active_validator_indices = [
        active_validator_indices[get_permuted_index(i, len(active_validator_indices))]
        for i in range(len(active_validator_indices))
]
```