### PR TITLE
Clarify merkle_root documentation

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -995,6 +995,7 @@ def get_beacon_proposer_index(state: BeaconState,
 def merkle_root(values: List[Bytes32]) -> Bytes32:
     """
     Merkleize ``values`` (where ``len(values)`` is a power of two) and return the Merkle root.
+    Note that the leaves are not hashed.
     """
     o = [0] * len(values) + values
     for i in range(len(values) - 1, 0, -1):


### PR DESCRIPTION
This function is used to get the merkle root of some block roots which are themselves hashes, so the leaves do not need to be rehashed.
Unfortunately, it's easy to assume that a merkle_root function would hash its leaves, so it should be clarified somehow.