### PR TITLE
Parent root reconstruction + granular state roots + body/header segregation

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -298,9 +298,9 @@ The following data structures are defined as [SimpleSerialize (SSZ)](https://git
     # Proposer index
     'proposer_index': 'uint64',
     # First block metadata
-    'block_metadata_1': BeaconBlockMetadata,
+    'metadata_1': BeaconBlockMetadata,
     # Second block metadata
-    'block_metadata_2': BeaconBlockMetadata,
+    'metadata_2': BeaconBlockMetadata,
 }
 ```
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1410,13 +1410,13 @@ For convenience, we provide the interface to the contract here:
 
 ## On genesis
 
-When enough full deposits have been made to the deposit contract a `Eth2Genesis` log is emitted. Construct a corresponding `genesis_state` and `genesis_block` as follows:
+When enough full deposits have been made to the deposit contract, an `Eth2Genesis` log is emitted. Construct a corresponding `genesis_state` and `genesis_block` as follows:
 
 * Let `genesis_validator_deposits` be the list of deposits, ordered chronologically, up to and including the deposit that triggered the `Eth2Genesis` log.
 * Let `genesis_time` be the timestamp specified in the `Eth2Genesis` log.
 * Let `genesis_eth1_data` be the `Eth1Data` object where:
-    * `genesis_eth1_data.deposit_root` is the deposit root when the `Eth2Genesis` log was emitted
-    * `genesis_eth1_data.block_hash` is the hash of the block that emitted the `Eth2Genesis` log
+    * `genesis_eth1_data.deposit_root` is the `deposit_root` contained in the `Eth2Genesis` log.
+    * `genesis_eth1_data.block_hash` is the hash of the Ethereum 1.0 block that emitted the `Eth2Genesis` log.
 * Let `genesis_state = get_genesis_beacon_state(genesis_validator_deposits, genesis_time, genesis_eth1_data)`.
 * Let `genesis_block = get_empty_block()`.
 * Set `genesis_block.state_root = hash_tree_root(genesis_state)`.

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1402,7 +1402,9 @@ When enough full deposits have been made to the deposit contract a `Eth2Genesis`
 
 * Let `genesis_validator_deposits` be the list of deposits, ordered chronologically, up to and including the deposit that triggered the `Eth2Genesis` log.
 * Let `genesis_time` be the timestamp specified in the `Eth2Genesis` log.
-* Let `genesis_eth1_data` be the `Eth1Data` when `Eth2Genesis` is emitted.
+* Let `genesis_eth1_data` be the `Eth1Data` object where:
+    * `genesis_eth1_data.deposit_root` is the deposit root when the `Eth2Genesis` log was emitted
+    * `genesis_eth1_data.block_hash` is the block hash of the block that emitted the `Eth2Genesis` log
 * Let `genesis_block_body = get_genesis_beacon_block_body()`.
 * Let `genesis_state = get_genesis_beacon_state(genesis_validator_deposits, genesis_time, genesis_block_body, genesis_eth1_data)`.
 * Let `genesis_block = get_genesis_beacon_block(genesis_state, genesis_block_body)`.

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1410,7 +1410,7 @@ When enough full deposits have been made to the deposit contract a `Eth2Genesis`
 * Let `genesis_block = get_genesis_beacon_block(genesis_state, genesis_block_body)`.
 
 ```python
-def get_genesis_beacon_block_body() -> BeaconBlock
+def get_genesis_beacon_block_body() -> BeaconBlockBody:
     """
     Get the genesis ``BeaconBlockBody``.
     """
@@ -1504,7 +1504,7 @@ def get_genesis_beacon_state(genesis_validator_deposits: List[Deposit],
 
 ```python
 def get_genesis_beacon_block(genesis_state: BeaconState,
-                             genesis_block_body: BeaconBlockBody) -> BeaconBlock
+                             genesis_block_body: BeaconBlockBody) -> BeaconBlock:
     """
     Get the genesis ``BeaconBlock``.
     """
@@ -1613,7 +1613,7 @@ _Note_: If there are skipped slots between a block and its parent block, run the
 
 Below are the processing steps that happen at every `slot > GENESIS_SLOT`.
 
-* Set `state.latest_state_roots[state.slot % SLOTS_PER_BATCHING] = hash(state)`.
+* Set `state.latest_state_roots[state.slot % SLOTS_PER_BATCHING] = hash_tree_root(state)`.
 * Set `state.latest_block_roots[state.slot % SLOTS_PER_BATCHING] = get_block_root(state, state.slot)`.
 * If `state.slot % SLOTS_PER_BATCHING == 0` append `merkle_root(state.latest_block_roots + state.latest_state_roots)` to `state.historical_batchings`.
 * Set `state.slot += 1`.

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1613,8 +1613,8 @@ Below are the processing steps that happen at every `block`.
 
 * Verify that `block.header.slot == state.slot`.
 * Verify that `block.header.block_body_root == hash_tree_root(block.body)`.
-* Set `state.latest_partial_block.state_root = get_state_root(state, state.slot - 1)`.
-* Verify that `block.header.previous_block_root == hash_tree_root(block)`.
+* Set `state.latest_partial_block.header.state_root = get_state_root(state, state.slot - 1)`.
+* Verify that `block.header.previous_block_root == hash_tree_root(state.latest_partial_block)`.
 * Set `state.latest_block_roots[(state.slot - 1) % SLOTS_PER_BATCHING] = block.header.previous_block_root`.
 * Set `state.latest_partial_block = block`.
 * Set `state.latest_partial_block.header.state_root = ZERO_ROOT`.

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1644,7 +1644,6 @@ For each `proposer_slashing` in `block.proposer_slashings`:
 
 * Let `proposer = state.validator_registry[proposer_slashing.proposer_index]`.
 * Verify that `proposer_slashing.metadata_1.slot == proposer_slashing.metadata_2.slot`.
-* Verify that `proposer_slashing.metadata_1.shard == proposer_slashing.metadata_2.shard`.
 * Verify that `proposer_slashing.metadata_1.block_root != proposer_slashing.metadata_2.block_root`.
 * Verify that `proposer.slashed_epoch > get_current_epoch(state)`.
 * Verify that `bls_verify(pubkey=proposer.pubkey, message_hash=signed_root(proposer_slashing.metadata_1, "signature"), signature=proposer_slashing.metadata_1.signature, domain=get_domain(state.fork, slot_to_epoch(proposer_slashing.metadata_1.slot), DOMAIN_PROPOSAL))`.

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -475,7 +475,7 @@ The following data structures are defined as [SimpleSerialize (SSZ)](https://git
 ```python
 {
     'slot': 'uint64',
-    'parent_block_root': 'bytes32',
+    'previous_block_root': 'bytes32',
     'block_body_root': 'bytes32',
     'state_root': 'bytes32',
     'signature': 'bytes96',
@@ -1474,7 +1474,7 @@ def get_genesis_beacon_state(genesis_validator_deposits: List[Deposit],
         latest_attestations=[],
         latest_partial_header=BeaconBlockHeader(
             slot=GENESIS_SLOT,
-            parent_block_root=ZERO_HASH,
+            previous_block_root=ZERO_HASH,
             block_body_root=hash_tree_root(genesis_block_body),
             state_root=ZERO_HASH,
             signature=EMPTY_SIGNATURE,
@@ -1513,7 +1513,7 @@ def get_genesis_beacon_block(genesis_state: BeaconState,
     return BeaconBlock(
         header=BeaconBlockHeader(
             slot=GENESIS_SLOT,
-            parent_block_root=ZERO_HASH,
+            previous_block_root=ZERO_HASH,
             block_body_root=hash_tree_root(genesis_block_body),
             state_root=hash_tree_root(genesis_state),
             signature=EMPTY_SIGNATURE,
@@ -1534,7 +1534,7 @@ Processing the beacon chain is similar to processing the Ethereum 1.0 chain. Cli
 
 For a beacon chain block, `block`, to be processed by a node, the following conditions must be met:
 
-* The parent block with root `block.parent_block_root` has been processed and accepted.
+* The parent block with root `block.previous_block_root` has been processed and accepted.
 * An Ethereum 1.0 block pointed to by the `state.latest_eth1_data.block_hash` has been processed and accepted.
 * The node's Unix time is greater than or equal to `state.genesis_time + (block.header.slot - GENESIS_SLOT) * SECONDS_PER_SLOT`. (Note that leap seconds mean that slots will occasionally last `SECONDS_PER_SLOT + 1` or `SECONDS_PER_SLOT - 1` seconds, possibly several times a year.)
 
@@ -1629,8 +1629,8 @@ Below are the processing steps that happen at every `block`.
 * Verify that `block.header.slot == state.slot`.
 * Verify that `block.header.block_body_root == hash_tree_root(block.body)`.
 * Set `state.latest_partial_header.state_root = get_state_root(state, state.slot - 1)`.
-* Verify that `block.header.parent_block_root == hash_tree_root(state.latest_partial_header)`.
-* Set `state.latest_block_roots[(state.slot - 1) % SLOTS_PER_BATCHING] = block.header.parent_block_root`.
+* Verify that `block.header.previous_block_root == hash_tree_root(state.latest_partial_header)`.
+* Set `state.latest_block_roots[(state.slot - 1) % SLOTS_PER_BATCHING] = block.header.previous_block_root`.
 * Set `state.latest_partial_header = block.header`.
 * Set `state.latest_partial_header.state_root = ZERO_ROOT`.
 * Let `proposer = state.validator_registry[get_beacon_proposer_index(state, state.slot)]`.

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -276,11 +276,11 @@ Code snippets appearing in `this style` are to be interpreted as Python code.
 | Name | Value |
 | - | - |
 | `DOMAIN_BLOCK_HEADER` | `0` |
-| `DOMAIN_RANDAO` | `2` |
-| `DOMAIN_ATTESTATION` | `3` |
-| `DOMAIN_DEPOSIT` | `4` |
-| `DOMAIN_VOLUNTARY_EXIT` | `5` |
-| `DOMAIN_TRANSFER` | `6` |
+| `DOMAIN_RANDAO` | `1` |
+| `DOMAIN_ATTESTATION` | `2` |
+| `DOMAIN_DEPOSIT` | `3` |
+| `DOMAIN_VOLUNTARY_EXIT` | `4` |
+| `DOMAIN_TRANSFER` | `5` |
 
 ## Data structures
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1491,8 +1491,6 @@ def get_genesis_beacon_state(genesis_validator_deposits: List[Deposit],
         deposit_index=len(genesis_validator_deposits)
     )
 
-    state.latest_partial_block = get_empty_block()
-
     # Process genesis deposits
     for deposit in genesis_validator_deposits:
         process_deposit(state, deposit)
@@ -1506,6 +1504,8 @@ def get_genesis_beacon_state(genesis_validator_deposits: List[Deposit],
     for index in range(LATEST_ACTIVE_INDEX_ROOTS_LENGTH):
         state.latest_active_index_roots[index] = genesis_active_index_root
     state.current_shuffling_seed = generate_seed(state, GENESIS_EPOCH)
+
+    return state
 ```
 
 ## Beacon chain processing

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1378,7 +1378,7 @@ Every Ethereum 1.0 deposit, of size between `MIN_DEPOSIT_AMOUNT` and `MAX_DEPOSI
 
 ### `Eth2Genesis` log
 
-When sufficiently many full deposits have been made the deposit contract emits the `Eth2Genesis` log. The beacon chain state may then be initialized by calling the `get_genesis_state` function (defined below) where:
+When sufficiently many full deposits have been made the deposit contract emits the `Eth2Genesis` log. The beacon chain state may then be initialized by calling the `get_genesis_beacon_state` function (defined below) where:
 
 * `genesis_time` equals `time` in the `Eth2Genesis` log
 * `latest_eth1_data.deposit_root` equals `deposit_root` in the `Eth2Genesis` log
@@ -1399,14 +1399,14 @@ For convenience, we provide the interface to the contract here:
 
 ## On genesis
 
-When enough full deposits have been made to the deposit contract a `Eth2Genesis` log is emitted. The genesis block and state are defined by `get_genesis_block` and `get_genesis_state` where:
+When enough full deposits have been made to the deposit contract a `Eth2Genesis` log is emitted. The genesis block and state are defined by `get_genesis_beacon_block` and `get_genesis_beacon_state` where:
 
 * `genesis_validator_deposits` is the list of deposits, ordered chronologically, up to and including the deposit that triggered the `Eth2Genesis` log
 * `genesis_time` is timestamp specified in the `Eth2Genesis` log
 * `latest_eth1_data` is the `Eth1Data` when `Eth2Genesis` is emitted
 
 ```python
-def get_genesis_block(genesis_validator_deposits: List[Deposit],
+def get_genesis_beacon_block(genesis_validator_deposits: List[Deposit],
                       genesis_time: int,
                       latest_eth1_data: Eth1Data) -> BeaconBlock
     """
@@ -1435,14 +1435,14 @@ def get_genesis_block(genesis_validator_deposits: List[Deposit],
     )
 
     genesis_block_root = tree_hash_root(block.body)
-    state = get_genesis_state(genesis_validator_deposits, genesis_time, genesis_block_root, latest_eth1_data)
+    state = get_genesis_beacon_state(genesis_validator_deposits, genesis_time, genesis_block_root, latest_eth1_data)
     block.header.state_root = hash_tree_root(state)
     return block
 }
 ```
 
 ```python
-def get_genesis_state(genesis_validator_deposits: List[Deposit],
+def get_genesis_beacon_state(genesis_validator_deposits: List[Deposit],
                       genesis_time: int,
                       latest_eth1_data: Eth1Data,
                       genesis_block_root: Bytes32) -> BeaconState:

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1614,9 +1614,9 @@ _Note_: If there are skipped slots between a block and its parent block, run the
 Below are the processing steps that happen at every `slot >= GENESIS_SLOT`.
 
 * Set `state.latest_state_roots[state.slot % SLOTS_PER_BATCHING] = hash_tree_root(state)`.
-* Set `state.latest_block_roots[state.slot % SLOTS_PER_BATCHING] = get_block_root(state, state.slot)`.
-* If `state.slot % SLOTS_PER_BATCHING == 0` append `merkle_root(state.latest_block_roots + state.latest_state_roots)` to `state.historical_batchings`.
 * Set `state.slot += 1`.
+* Set `state.latest_block_roots[state.slot % SLOTS_PER_BATCHING] = get_block_root(state, state.slot - 1)`.
+* If `state.slot % SLOTS_PER_BATCHING == 0` append `merkle_root(state.latest_block_roots + state.latest_state_roots)` to `state.historical_batchings`.
 
 ### Per-block processing
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1629,7 +1629,7 @@ Below are the processing steps that happen at every `block`.
 * Verify that `block.header.slot == state.slot`.
 * Verify that `block.header.block_body_root == hash_tree_root(block.body)`.
 * Set `state.latest_partial_header.state_root = get_state_root(state, state.slot - 1)`.
-* Verify that `block.header.parent_block_root == tree_hash_root(state.latest_partial_header)`.
+* Verify that `block.header.parent_block_root == hash_tree_root(state.latest_partial_header)`.
 * Set `state.latest_block_roots[(state.slot - 1) % SLOTS_PER_BATCHING] = block.header.parent_block_root`.
 * Set `state.latest_partial_header = block.header`.
 * Set `state.latest_partial_header.state_root = ZERO_ROOT`.

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1608,7 +1608,7 @@ _Note_: If there are skipped slots between a block and its parent block, run the
 
 ### Per-slot processing
 
-Below are the processing steps that happen at every `slot >= GENESIS_SLOT`.
+Below are the processing steps that happen at every `slot > GENESIS_SLOT`.
 
 * Set `state.latest_state_roots[state.slot % SLOTS_PER_BATCHING] = hash_tree_root(state)`.
 * Set `state.latest_block_roots[state.slot % SLOTS_PER_BATCHING] = get_block_root(state, state.slot - 1)`.

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1456,7 +1456,7 @@ def get_empty_block() -> BeaconBlock:
 ```python
 def get_genesis_beacon_state(genesis_validator_deposits: List[Deposit],
                              genesis_time: int,
-                             genesis_eth1_data: Eth1Data) -> BeaconBlock:
+                             genesis_eth1_data: Eth1Data) -> BeaconState:
     """
     Get the genesis ``BeaconState``.
     """

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1611,7 +1611,7 @@ _Note_: If there are skipped slots between a block and its parent block, run the
 
 ### Per-slot processing
 
-Below are the processing steps that happen at every `slot > GENESIS_SLOT`.
+Below are the processing steps that happen at every `slot >= GENESIS_SLOT`.
 
 * Set `state.latest_state_roots[state.slot % SLOTS_PER_BATCHING] = hash_tree_root(state)`.
 * Set `state.latest_block_roots[state.slot % SLOTS_PER_BATCHING] = get_block_root(state, state.slot)`.

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1642,7 +1642,7 @@ For each `proposer_slashing` in `block.body.proposer_slashings`:
 
 * Let `proposer = state.validator_registry[proposer_slashing.proposer_index]`.
 * Verify that `proposer_slashing.header_1.slot == proposer_slashing.header_2.slot`.
-* Verify that `proposer_slashing.header_1.block_root != proposer_slashing.header_2.block_root`.
+* Verify that `proposer_slashing.header_1.block_body_root != proposer_slashing.header_2.block_body_root`.
 * Verify that `proposer.slashed_epoch > get_current_epoch(state)`.
 * Verify that `bls_verify(pubkey=proposer.pubkey, message_hash=signed_root(proposer_slashing.header_1, "signature"), signature=proposer_slashing.header_1.signature, domain=get_domain(state.fork, slot_to_epoch(proposer_slashing.header_1.slot), DOMAIN_BLOCK_HEADER))`.
 * Verify that `bls_verify(pubkey=proposer.pubkey, message_hash=signed_root(proposer_slashing.header_2, "signature"), signature=proposer_slashing.header_2.signature, domain=get_domain(state.fork, slot_to_epoch(proposer_slashing.header_2.slot), DOMAIN_BLOCK_HEADER))`.

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -275,7 +275,7 @@ Code snippets appearing in `this style` are to be interpreted as Python code.
 
 | Name | Value |
 | - | - |
-| `DOMAIN_BLOCK_HEADER` | `0` |
+| `DOMAIN_BEACON_BLOCK` | `0` |
 | `DOMAIN_RANDAO` | `1` |
 | `DOMAIN_ATTESTATION` | `2` |
 | `DOMAIN_DEPOSIT` | `3` |
@@ -1633,7 +1633,7 @@ Below are the processing steps that happen at every `block` except the genesis b
 * Set `state.latest_block_roots[(state.slot - 1) % SLOTS_PER_BATCHING] = block.previous_block_root`.
 * Set `state.latest_block_header = get_temporary_block_header(block)`.
 * Let `proposer = state.validator_registry[get_beacon_proposer_index(state, state.slot)]`.
-* Verify that `bls_verify(pubkey=proposer.pubkey, message_hash=signed_root(block, "signature"), signature=block.signature, domain=get_domain(state.fork, get_current_epoch(state), DOMAIN_BLOCK_HEADER))`.
+* Verify that `bls_verify(pubkey=proposer.pubkey, message_hash=signed_root(block, "signature"), signature=block.signature, domain=get_domain(state.fork, get_current_epoch(state), DOMAIN_BEACON_BLOCK))`.
 
 #### RANDAO
 
@@ -1657,8 +1657,8 @@ For each `proposer_slashing` in `block.body.proposer_slashings`:
 * Verify that `proposer_slashing.header_1.slot == proposer_slashing.header_2.slot`.
 * Verify that `proposer_slashing.header_1.block_body_root != proposer_slashing.header_2.block_body_root`.
 * Verify that `proposer.slashed_epoch > get_current_epoch(state)`.
-* Verify that `bls_verify(pubkey=proposer.pubkey, message_hash=signed_root(proposer_slashing.header_1, "signature"), signature=proposer_slashing.header_1.signature, domain=get_domain(state.fork, slot_to_epoch(proposer_slashing.header_1.slot), DOMAIN_BLOCK_HEADER))`.
-* Verify that `bls_verify(pubkey=proposer.pubkey, message_hash=signed_root(proposer_slashing.header_2, "signature"), signature=proposer_slashing.header_2.signature, domain=get_domain(state.fork, slot_to_epoch(proposer_slashing.header_2.slot), DOMAIN_BLOCK_HEADER))`.
+* Verify that `bls_verify(pubkey=proposer.pubkey, message_hash=signed_root(proposer_slashing.header_1, "signature"), signature=proposer_slashing.header_1.signature, domain=get_domain(state.fork, slot_to_epoch(proposer_slashing.header_1.slot), DOMAIN_BEACON_BLOCK))`.
+* Verify that `bls_verify(pubkey=proposer.pubkey, message_hash=signed_root(proposer_slashing.header_2, "signature"), signature=proposer_slashing.header_2.signature, domain=get_domain(state.fork, slot_to_epoch(proposer_slashing.header_2.slot), DOMAIN_BEACON_BLOCK))`.
 * Run `slash_validator(state, proposer_slashing.proposer_index)`.
 
 ##### Attester slashings

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1486,21 +1486,16 @@ def get_genesis_beacon_state(genesis_validator_deposits: List[Deposit],
         historical_batchings=[],
 
         # Ethereum 1.0 chain data
-        latest_eth1_data=Eth1Data(
-            deposit_root=ZERO_HASH,
-            block_hash=ZERO_HASH
-        ),
+        latest_eth1_data=genesis_eth1_data,
         eth1_data_votes=[],
-        deposit_index=len(genesis_validator_deposits),
+        deposit_index=len(genesis_validator_deposits)
     )
 
     state.latest_partial_block = get_empty_block()
-    state.latest_eth1_data = genesis_eth1_data
 
     # Process genesis deposits
     for deposit in genesis_validator_deposits:
         process_deposit(state, deposit)
-    state.deposit_index = len(genesis_validator_deposits)
 
     # Process genesis activations
     for validator_index, _ in enumerate(state.validator_registry):

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1404,7 +1404,7 @@ When enough full deposits have been made to the deposit contract a `Eth2Genesis`
 * Let `genesis_time` be the timestamp specified in the `Eth2Genesis` log.
 * Let `genesis_eth1_data` be the `Eth1Data` object where:
     * `genesis_eth1_data.deposit_root` is the deposit root when the `Eth2Genesis` log was emitted
-    * `genesis_eth1_data.block_hash` is the block hash of the block that emitted the `Eth2Genesis` log
+    * `genesis_eth1_data.block_hash` is the hash of the block that emitted the `Eth2Genesis` log
 * Let `genesis_block_body = get_genesis_beacon_block_body()`.
 * Let `genesis_state = get_genesis_beacon_state(genesis_validator_deposits, genesis_time, genesis_block_body, genesis_eth1_data)`.
 * Let `genesis_block = get_genesis_beacon_block(genesis_state, genesis_block_body)`.

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1608,7 +1608,7 @@ Below are the processing steps that happen at every `slot >= GENESIS_SLOT`.
 
 * Set `state.latest_state_roots[state.slot % SLOTS_PER_BATCHING] = hash_tree_root(state)`.
 * Set `state.latest_block_roots[state.slot % SLOTS_PER_BATCHING] = get_block_root(state, state.slot - 1)`.
-* Let `state.previous_block_header.state_root = get_state_root(state, state.slot)`.
+* Set `state.previous_block_header.state_root = get_state_root(state, state.slot)` if `state.previous_block_header.state_root == ZERO_HASH`.
 * Set `state.slot += 1`.
 * If `state.slot % SLOTS_PER_BATCHING == 0` append `merkle_root(state.latest_block_roots + state.latest_state_roots)` to `state.historical_batchings`.
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1425,7 +1425,7 @@ When enough full deposits have been made to the deposit contract a `Eth2Genesis`
     * `genesis_eth1_data.block_hash` is the hash of the block that emitted the `Eth2Genesis` log
 * Let `genesis_state = get_genesis_beacon_state(genesis_validator_deposits, genesis_time, genesis_eth1_data)`.
 * Let `genesis_block = get_empty_block()`.
-* let `genesis_block.state_root = hash_tree_root(genesis_state)`.
+* Set `genesis_block.state_root = hash_tree_root(genesis_state)`.
 
 ```python
 def get_empty_block() -> BeaconBlock:

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1636,9 +1636,8 @@ signed_root(BeaconBlockHeader(
     signature=EMPTY_SIGNATURE,
 ), "signature")`
 ```
-
+* Set `state.latest_block_roots[(state.slot - 1) % SLOTS_PER_BATCHING] = block.header.parent_block_root`.
 * Verify that `block.header.block_body_root == hash_tree_root(block.body)`.
-* Set `state.latest_block_roots[state.slot % SLOTS_PER_BATCHING] = signed_root(block.header, "signature")`.
 * Set `state.latest_block_body_root = block.header.block_body_root`.
 * Let `proposer = state.validator_registry[get_beacon_proposer_index(state, state.slot)]`.
 * Verify that `bls_verify(pubkey=proposer.pubkey, message_hash=signed_root(block.header, "signature"), signature=block.header.signature, domain=get_domain(state.fork, get_current_epoch(state), DOMAIN_BLOCK_HEADER))`.

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1614,7 +1614,6 @@ Below are the processing steps that happen at every `slot >= GENESIS_SLOT`.
 * Set `state.latest_block_roots[state.slot % SLOTS_PER_BATCHING] = get_block_root(state, state.slot - 1)`.
 * Set `state.latest_block_header.state_root = get_state_root(state, state.slot)` if `state.latest_block_header.state_root == ZERO_HASH`.
 * Set `state.slot += 1`.
-* If `state.slot % SLOTS_PER_BATCHING == 0` append `merkle_root(state.latest_block_roots + state.latest_state_roots)` to `state.historical_batchings`.
 
 ### Per-block processing
 
@@ -2063,6 +2062,7 @@ def process_exit_queue(state: BeaconState) -> None:
 * Set `state.latest_active_index_roots[(next_epoch + ACTIVATION_EXIT_DELAY) % LATEST_ACTIVE_INDEX_ROOTS_LENGTH] = hash_tree_root(get_active_validator_indices(state.validator_registry, next_epoch + ACTIVATION_EXIT_DELAY))`.
 * Set `state.latest_slashed_balances[next_epoch % LATEST_SLASHED_EXIT_LENGTH] = state.latest_slashed_balances[current_epoch % LATEST_SLASHED_EXIT_LENGTH]`.
 * Set `state.latest_randao_mixes[next_epoch % LATEST_RANDAO_MIXES_LENGTH] = get_randao_mix(state, current_epoch)`.
+* If `next_epoch % slot_to_epoch(SLOTS_PER_BATCHING) == 0`, append `merkle_root(state.latest_block_roots + state.latest_state_roots)` to `state.historical_batchings`.
 * Remove any `attestation` in `state.latest_attestations` such that `slot_to_epoch(attestation.data.slot) < current_epoch`.
 
 ### State root verification

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1613,8 +1613,9 @@ Below are the processing steps that happen at every `block` except the genesis b
 
 * Verify that `block.header.slot == state.slot`.
 * Verify that `block.header.block_body_root == hash_tree_root(block.body)`.
-* Set `state.latest_partial_block.header.state_root = get_state_root(state, state.slot - 1)`.
-* Verify that `block.header.previous_block_root == hash_tree_root(state.latest_partial_block)`.
+* Let `previous_block = state.latest_partial_block`.
+* Set `previous_block.header.state_root = get_state_root(state, state.slot - 1)`.
+* Verify that `block.header.previous_block_root == hash_tree_root(previous_block)`.
 * Set `state.latest_block_roots[(state.slot - 1) % SLOTS_PER_BATCHING] = block.header.previous_block_root`.
 * Set `state.latest_partial_block = block`.
 * Set `state.latest_partial_block.header.state_root = ZERO_ROOT`.

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -535,7 +535,7 @@ The following data structures are defined as [SimpleSerialize (SSZ)](https://git
     'latest_active_index_roots': ['bytes32'],
     'latest_slashed_balances': ['uint64'],  # Balances slashed at every withdrawal period
     'latest_attestations': [PendingAttestation],
-    'latest_partial_header': BeaconBlockHeader,
+    'latest_partial_block': BeaconBlock,
     'historical_batchings': ['bytes32'],
 
     # Ethereum 1.0 chain data
@@ -1613,11 +1613,11 @@ Below are the processing steps that happen at every `block`.
 
 * Verify that `block.header.slot == state.slot`.
 * Verify that `block.header.block_body_root == hash_tree_root(block.body)`.
-* Set `state.latest_partial_header.state_root = get_state_root(state, state.slot - 1)`.
-* Verify that `block.header.previous_block_root == hash_tree_root(state.latest_partial_header)`.
+* Set `state.latest_partial_block.state_root = get_state_root(state, state.slot - 1)`.
+* Verify that `block.header.previous_block_root == hash_tree_root(block)`.
 * Set `state.latest_block_roots[(state.slot - 1) % SLOTS_PER_BATCHING] = block.header.previous_block_root`.
-* Set `state.latest_partial_header = block.header`.
-* Set `state.latest_partial_header.state_root = ZERO_ROOT`.
+* Set `state.latest_partial_block = block`.
+* Set `state.latest_partial_block.header.state_root = ZERO_ROOT`.
 * Let `proposer = state.validator_registry[get_beacon_proposer_index(state, state.slot)]`.
 * Verify that `bls_verify(pubkey=proposer.pubkey, message_hash=signed_root(block.header, "signature"), signature=block.header.signature, domain=get_domain(state.fork, get_current_epoch(state), DOMAIN_BLOCK_HEADER))`.
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1448,8 +1448,8 @@ def get_genesis_beacon_block(state: BeaconState) -> BeaconBlock
 ```python
 def get_genesis_beacon_state(genesis_validator_deposits: List[Deposit],
                              genesis_time: int,
-                             latest_eth1_data: Eth1Data,
-                             genesis_block_root: Bytes32) -> BeaconState:
+                             genesis_block_root: Bytes32,
+                             latest_eth1_data: Eth1Data) -> BeaconState:
     """
     Get the genesis ``BeaconState``.
     """

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -275,12 +275,12 @@ Code snippets appearing in `this style` are to be interpreted as Python code.
 
 | Name | Value |
 | - | - |
-| `DOMAIN_DEPOSIT` | `0` |
-| `DOMAIN_ATTESTATION` | `1` |
-| `DOMAIN_HEADER` | `2` |
-| `DOMAIN_EXIT` | `3` |
-| `DOMAIN_RANDAO` | `4` |
-| `DOMAIN_TRANSFER` | `5` |
+| `DOMAIN_BLOCK_HEADER` | `0` |
+| `DOMAIN_RANDAO` | `2` |
+| `DOMAIN_ATTESTATION` | `3` |
+| `DOMAIN_DEPOSIT` | `4` |
+| `DOMAIN_VOLUNTARY_EXIT` | `5` |
+| `DOMAIN_TRANSFER` | `6` |
 
 ## Data structures
 
@@ -1632,7 +1632,7 @@ Below are the processing steps that happen at every `block`.
 * Verify that `block.header.block_root == hash_tree_root(block.body)`.
 * Set `state.latest_block_roots[state.slot % LATEST_BLOCK_ROOTS_LENGTH] = block.header.block_root`.
 * Let `proposer = state.validator_registry[get_beacon_proposer_index(state, state.slot)]`.
-* Verify that `bls_verify(pubkey=proposer.pubkey, message_hash=signed_root(block.header, "signature"), signature=block.header.signature, domain=get_domain(state.fork, get_current_epoch(state), DOMAIN_HEADER))`.
+* Verify that `bls_verify(pubkey=proposer.pubkey, message_hash=signed_root(block.header, "signature"), signature=block.header.signature, domain=get_domain(state.fork, get_current_epoch(state), DOMAIN_BLOCK_HEADER))`.
 
 #### RANDAO
 
@@ -1656,8 +1656,8 @@ For each `proposer_slashing` in `block.body.proposer_slashings`:
 * Verify that `proposer_slashing.header_1.slot == proposer_slashing.header_2.slot`.
 * Verify that `proposer_slashing.header_1.block_root != proposer_slashing.header_2.block_root`.
 * Verify that `proposer.slashed_epoch > get_current_epoch(state)`.
-* Verify that `bls_verify(pubkey=proposer.pubkey, message_hash=signed_root(proposer_slashing.header_1, "signature"), signature=proposer_slashing.header_1.signature, domain=get_domain(state.fork, slot_to_epoch(proposer_slashing.header_1.slot), DOMAIN_HEADER))`.
-* Verify that `bls_verify(pubkey=proposer.pubkey, message_hash=signed_root(proposer_slashing.header_2, "signature"), signature=proposer_slashing.header_2.signature, domain=get_domain(state.fork, slot_to_epoch(proposer_slashing.header_2.slot), DOMAIN_HEADER))`.
+* Verify that `bls_verify(pubkey=proposer.pubkey, message_hash=signed_root(proposer_slashing.header_1, "signature"), signature=proposer_slashing.header_1.signature, domain=get_domain(state.fork, slot_to_epoch(proposer_slashing.header_1.slot), DOMAIN_BLOCK_HEADER))`.
+* Verify that `bls_verify(pubkey=proposer.pubkey, message_hash=signed_root(proposer_slashing.header_2, "signature"), signature=proposer_slashing.header_2.signature, domain=get_domain(state.fork, slot_to_epoch(proposer_slashing.header_2.slot), DOMAIN_BLOCK_HEADER))`.
 * Run `slash_validator(state, proposer_slashing.proposer_index)`.
 
 ##### Attester slashings
@@ -1765,7 +1765,7 @@ For each `exit` in `block.body.voluntary_exits`:
 * Let `validator = state.validator_registry[exit.validator_index]`.
 * Verify that `validator.exit_epoch > get_entry_exit_effect_epoch(get_current_epoch(state))`.
 * Verify that `get_current_epoch(state) >= exit.epoch`.
-* Verify that `bls_verify(pubkey=validator.pubkey, message_hash=signed_root(exit, "signature"), signature=exit.signature, domain=get_domain(state.fork, exit.epoch, DOMAIN_EXIT))`.
+* Verify that `bls_verify(pubkey=validator.pubkey, message_hash=signed_root(exit, "signature"), signature=exit.signature, domain=get_domain(state.fork, exit.epoch, DOMAIN_VOLUNTARY_EXIT))`.
 * Run `initiate_validator_exit(state, exit.validator_index)`.
 
 ##### Transfers

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -540,7 +540,7 @@ The following data structures are defined as [SimpleSerialize (SSZ)](https://git
     'latest_active_index_roots': ['bytes32'],
     'latest_slashed_balances': ['uint64'],  # Balances slashed at every withdrawal period
     'latest_attestations': [PendingAttestation],
-    'latest_block_header': BeaconBlockHeader,
+    'latest_block_header': BeaconBlockHeader,  # Latest block header with `state_root` set to `ZERO_HASH`
     'historical_batchings': ['bytes32'],
 
     # Ethereum 1.0 chain data

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1608,7 +1608,7 @@ Below are the processing steps that happen at every `slot >= GENESIS_SLOT`.
 
 * Set `state.latest_state_roots[state.slot % SLOTS_PER_BATCHING] = hash_tree_root(state)`.
 * Set `state.latest_block_roots[state.slot % SLOTS_PER_BATCHING] = get_block_root(state, state.slot - 1)`.
-* Set `state.previous_block_header.state_root = get_state_root(state, state.slot)` if `state.previous_block_header.state_root == ZERO_HASH`.
+* Set `state.latest_block_header.state_root = get_state_root(state, state.slot)` if `state.latest_block_header.state_root == ZERO_HASH`.
 * Set `state.slot += 1`.
 * If `state.slot % SLOTS_PER_BATCHING == 0` append `merkle_root(state.latest_block_roots + state.latest_state_roots)` to `state.historical_batchings`.
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1435,7 +1435,6 @@ def get_empty_block() -> BeaconBlock:
         ),
         body=body,
     )
-}
 ```
 
 ```python

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -476,6 +476,7 @@ The following data structures are defined as [SimpleSerialize (SSZ)](https://git
 {
     'slot': 'uint64',
     'previous_block_root': 'bytes32',
+    'block_body_root': 'bytes32',
     'state_root': 'bytes32',
     'signature': 'bytes96',
 }
@@ -1403,6 +1404,7 @@ When enough full deposits have been made to the deposit contract a `Eth2Genesis`
     * `genesis_eth1_data.block_hash` is the hash of the block that emitted the `Eth2Genesis` log
 * Let `genesis_state = get_genesis_beacon_state(genesis_validator_deposits, genesis_time, genesis_eth1_data)`.
 * Let `genesis_block = get_empty_block()`.
+* Let `genesis_block.header.block_body_root = hash_tree_root(genesis_block.body)`.
 * Let `genesis_block.header.state_root = hash_tree_root(genesis_state)`.
 
 ```python
@@ -1414,6 +1416,7 @@ def get_empty_block() -> BeaconBlock:
         header=BeaconBlockHeader(
             slot=GENESIS_SLOT,
             previous_block_root=ZERO_HASH,
+            block_body_root=ZERO_HASH,
             state_root=ZERO_HASH,
             signature=EMPTY_SIGNATURE,
         ),
@@ -1609,6 +1612,7 @@ Below are the processing steps that happen at every `block`.
 #### Block header
 
 * Verify that `block.header.slot == state.slot`.
+* Verify that `block.header.block_body_root == hash_tree_root(block.body)`.
 * Set `state.latest_partial_header.state_root = get_state_root(state, state.slot - 1)`.
 * Verify that `block.header.previous_block_root == hash_tree_root(state.latest_partial_header)`.
 * Set `state.latest_block_roots[(state.slot - 1) % SLOTS_PER_BATCHING] = block.header.previous_block_root`.

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1607,7 +1607,7 @@ Below are the processing steps that happen at every `slot >= GENESIS_SLOT`.
 
 ### Per-block processing
 
-Below are the processing steps that happen at every `block`.
+Below are the processing steps that happen at every `block` except the genesis block.
 
 #### Block header
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1436,7 +1436,7 @@ def get_genesis_beacon_block(state: BeaconState) -> BeaconBlock
         header=Proposal(
             slot=GENESIS_SLOT,
             parent_root=ZERO_HASH,
-            block_root=tree_hash_root(block.body),
+            block_root=tree_hash_root(body),
             state_root=hash_tree_root(state),
             signature=EMPTY_SIGNATURE,
         ),

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -42,8 +42,8 @@
                 - [`Transfer`](#transfer)
         - [Beacon chain blocks](#beacon-chain-blocks)
             - [`BeaconBlock`](#beaconblock)
-            - [`BeaconBlockHeader`](#beaconblockheader)
             - [`BeaconBlockBody`](#beaconblockbody)
+            - [`Proposal`](#Proposal)
         - [Beacon chain state](#beacon-chain-state)
             - [`BeaconState`](#beaconstate)
             - [`Validator`](#validator)
@@ -299,9 +299,9 @@ The following data structures are defined as [SimpleSerialize (SSZ)](https://git
     # Proposer index
     'proposer_index': 'uint64',
     # First block header
-    'block_header_1': BeaconBlockHeader,
+    'proposal_1': Proposal,
     # Second block header
-    'block_header_2': BeaconBlockHeader,
+    'proposal_2': Proposal,
 }
 ```
 
@@ -467,19 +467,8 @@ The following data structures are defined as [SimpleSerialize (SSZ)](https://git
 
 #### `BeaconBlock`
 {
-    'header': BeaconBlockHeader,
+    'header': Proposal,
     'body': BeaconBlockBody,
-}
-```
-
-#### `BeaconBlockHeader`
-
-```python
-{
-    'slot': 'uint64',
-    'parent_root': 'bytes32',
-    'state_root': 'bytes32',
-    'signature': 'bytes96',
 }
 ```
 
@@ -495,6 +484,21 @@ The following data structures are defined as [SimpleSerialize (SSZ)](https://git
     'deposits': [Deposit],
     'voluntary_exits': [VoluntaryExit],
     'transfers': [Transfer],
+}
+```
+
+#### `Proposal`
+
+```python
+{
+    # Slot number
+    'slot': 'uint64',
+    # Parent root
+    'parent_root': 'bytes32',
+    # Block root
+    'state_root': 'bytes32',
+    # Signature
+    'signature': 'bytes96',
 }
 ```
 
@@ -1413,7 +1417,7 @@ def get_genesis_beacon_block(genesis_validator_deposits: List[Deposit],
     Get the genesis ``BeaconBlock``.
     """
     block = BeaconBlock(
-        header=BeaconBlockHeader(
+        header=Proposal(
             slot=GENESIS_SLOT,
             parent_root=ZERO_HASH,
             state_root=ZERO_HASH,
@@ -1652,11 +1656,11 @@ Verify that `len(block.body.proposer_slashings) <= MAX_PROPOSER_SLASHINGS`.
 For each `proposer_slashing` in `block.body.proposer_slashings`:
 
 * Let `proposer = state.validator_registry[proposer_slashing.proposer_index]`.
-* Verify that `proposer_slashing.block_header_1.slot == proposer_slashing.block_header_2.slot`.
-* Verify that `proposer_slashing.block_header_1.block_root != proposer_slashing.block_header_2.block_root`.
+* Verify that `proposer_slashing.proposal_1.slot == proposer_slashing.proposal_2.slot`.
+* Verify that `proposer_slashing.proposal_1.block_root != proposer_slashing.proposal_2.block_root`.
 * Verify that `proposer.slashed_epoch > get_current_epoch(state)`.
-* Verify that `bls_verify(pubkey=proposer.pubkey, message_hash=signed_root(proposer_slashing.block_header_1, "signature"), signature=proposer_slashing.block_header_1.signature, domain=get_domain(state.fork, slot_to_epoch(proposer_slashing.block_header_1.slot), DOMAIN_PROPOSAL))`.
-* Verify that `bls_verify(pubkey=proposer.pubkey, message_hash=signed_root(proposer_slashing.block_header_2, "signature"), signature=proposer_slashing.block_header_2.signature, domain=get_domain(state.fork, slot_to_epoch(proposer_slashing.block_header_2.slot), DOMAIN_PROPOSAL))`.
+* Verify that `bls_verify(pubkey=proposer.pubkey, message_hash=signed_root(proposer_slashing.proposal_1, "signature"), signature=proposer_slashing.proposal_1.signature, domain=get_domain(state.fork, slot_to_epoch(proposer_slashing.proposal_1.slot), DOMAIN_PROPOSAL))`.
+* Verify that `bls_verify(pubkey=proposer.pubkey, message_hash=signed_root(proposer_slashing.proposal_2, "signature"), signature=proposer_slashing.proposal_2.signature, domain=get_domain(state.fork, slot_to_epoch(proposer_slashing.proposal_2.slot), DOMAIN_PROPOSAL))`.
 * Run `slash_validator(state, proposer_slashing.proposer_index)`.
 
 ##### Attester slashings


### PR DESCRIPTION
This PR introduces three significant changes:

1. **Parent root reconstruction**: Instead of relying on a parent root "oracle" in the state transition function, the state transition function now only has two argument: (current) `state` and (latest) `block`.
2. **Granular state roots**: To be more friendly to clients we expose granular state roots at every slot independently of block production. Having the state roots at every epoch boundary is especially helpful.
3. **Body/header segregation**: This follows the discussion [here](https://github.com/ethereum/eth2.0-specs/pull/633#discussion_r257070067), and allows us to remove `Proposal` and related things.