### PR TITLE
Minor fix: `messages` -> `message_hashes`

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1698,7 +1698,7 @@ For each `attestation` in `block.body.attestations`:
             bls_aggregate_pubkeys([state.validator_registry[i].pubkey for i in custody_bit_0_participants]),
             bls_aggregate_pubkeys([state.validator_registry[i].pubkey for i in custody_bit_1_participants]),
         ],
-        messages=[
+        message_hashes=[
             hash_tree_root(AttestationDataAndCustodyBit(data=attestation.data, custody_bit=0b0)),
             hash_tree_root(AttestationDataAndCustodyBit(data=attestation.data, custody_bit=0b1)),
         ],


### PR DESCRIPTION
Minor fix: `messages` -> `message_hashes` corresponding to https://github.com/ethereum/eth2.0-specs/blob/dev/specs/bls_signature.md#bls_verify_multiple.