### PR TITLE
fix up previous epoch logic around genesis

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1497,7 +1497,6 @@ def get_genesis_beacon_state(genesis_validator_deposits: List[Deposit],
     for index in range(LATEST_ACTIVE_INDEX_ROOTS_LENGTH):
         state.latest_active_index_roots[index] = genesis_active_index_root
     state.current_shuffling_seed = generate_seed(state, GENESIS_EPOCH)
-    state.previous_shuffling_seed = state.current_shuffling_seed
 
     return state
 ```


### PR DESCRIPTION
#655 introduced a change in `get_previous_epoch` calculation that would have caused a number of separate exceptional case handling in epoch processing. This PR reverts this change and patches up a couple of other issues

* Revert change to `get_previous_epoch` in #655
* fix #639
* prevent attestations from committees/slots before genesis