### PR TITLE
bls: Use int_to_bytes8 to serialize domain

### DIFF
--- a/specs/bls_signature.md
+++ b/specs/bls_signature.md
@@ -71,8 +71,8 @@ q = 4002409555221667393417789825735904156556882819939007885332058136124031650490
 
 def hash_to_G2(message_hash: Bytes32, domain: uint64) -> [uint384]:
     # Initial candidate x coordinate
-    x_re = int.from_bytes(hash(message_hash + bytes8(domain) + b'\x01'), 'big')
-    x_im = int.from_bytes(hash(message_hash + bytes8(domain) + b'\x02'), 'big')
+    x_re = int.from_bytes(hash(message_hash + int_to_bytes8(domain) + b'\x01'), 'big')
+    x_im = int.from_bytes(hash(message_hash + int_to_bytes8(domain) + b'\x02'), 'big')
     x_coordinate = Fq2([x_re, x_im])  # x = x_re + i * x_im
     
     # Test candidate y coordinates until a one is found


### PR DESCRIPTION
The function `bytes8` does not exist in the spec. Using `int_to_bytes8`
has a clearer meaning: serialize into 8 bytes as little endian.