### PR TITLE
fix committee assignment bugs

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -55,6 +55,7 @@
     - [Helper functions](#helper-functions)
         - [`hash`](#hash)
         - [`hash_tree_root`](#hash_tree_root)
+        - [`signed_root`](#signed_root)
         - [`slot_to_epoch`](#slot_to_epoch)
         - [`get_previous_epoch`](#get_previous_epoch)
         - [`get_current_epoch`](#get_current_epoch)
@@ -879,19 +880,19 @@ def get_crosslink_committees_at_slot(state: BeaconState,
         epochs_since_last_registry_update = current_epoch - state.validator_registry_update_epoch
         if registry_change:
             committees_per_epoch = get_next_epoch_committee_count(state)
-            shuffling_epoch = next_epoch
             seed = generate_seed(state, next_epoch)
+            shuffling_epoch = next_epoch
             current_committees_per_epoch = get_current_epoch_committee_count(state)
             shuffling_start_shard = (state.current_shuffling_start_shard + current_committees_per_epoch) % SHARD_COUNT
         elif epochs_since_last_registry_update > 1 and is_power_of_two(epochs_since_last_registry_update):
             committees_per_epoch = get_next_epoch_committee_count(state)
-            shuffling_epoch = next_epoch
             seed = generate_seed(state, next_epoch)
+            shuffling_epoch = next_epoch
             shuffling_start_shard = state.current_shuffling_start_shard
         else:
             committees_per_epoch = get_current_epoch_committee_count(state)
-            shuffling_epoch = state.current_shuffling_epoch
             seed = state.current_shuffling_seed
+            shuffling_epoch = state.current_shuffling_epoch
             shuffling_start_shard = state.current_shuffling_start_shard
 
     shuffling = get_shuffling(

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -876,18 +876,21 @@ def get_crosslink_committees_at_slot(state: BeaconState,
         shuffling_epoch = state.previous_shuffling_epoch
         shuffling_start_shard = state.previous_shuffling_start_shard
     elif epoch == next_epoch:
-        current_committees_per_epoch = get_current_epoch_committee_count(state)
-        committees_per_epoch = get_next_epoch_committee_count(state)
-        shuffling_epoch = next_epoch
-
         epochs_since_last_registry_update = current_epoch - state.validator_registry_update_epoch
         if registry_change:
+            committees_per_epoch = get_next_epoch_committee_count(state)
+            shuffling_epoch = next_epoch
             seed = generate_seed(state, next_epoch)
+            current_committees_per_epoch = get_current_epoch_committee_count(state)
             shuffling_start_shard = (state.current_shuffling_start_shard + current_committees_per_epoch) % SHARD_COUNT
         elif epochs_since_last_registry_update > 1 and is_power_of_two(epochs_since_last_registry_update):
+            committees_per_epoch = get_next_epoch_committee_count(state)
+            shuffling_epoch = next_epoch
             seed = generate_seed(state, next_epoch)
             shuffling_start_shard = state.current_shuffling_start_shard
         else:
+            committees_per_epoch = get_current_epoch_committee_count(state)
+            shuffling_epoch = state.current_shuffling_epoch
             seed = state.current_shuffling_seed
             shuffling_start_shard = state.current_shuffling_start_shard
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1978,8 +1978,8 @@ def update_validator_registry(state: BeaconState) -> None:
 
 and perform the following updates:
 
-* Set `state.current_shuffling_epoch = next_epoch`
 * Set `state.current_shuffling_start_shard = (state.current_shuffling_start_shard + get_current_epoch_committee_count(state)) % SHARD_COUNT`
+* Set `state.current_shuffling_epoch = next_epoch`
 * Set `state.current_shuffling_seed = generate_seed(state, state.current_shuffling_epoch)`
 
 If a validator registry update does _not_ happen do the following:


### PR DESCRIPTION

2 bugs:
* We were modifying `current_shuffling_epoch` and then calling `get_current_epoch_committee_count` expecting that it was still getting the committee count from the previous value of `current_shuffling_epoch`. Switch operations to prevent this error
* when getting next epoch committee assignments, we were sometimes modifying `committees_per_epoch` and `shuffling_epoch` when these things should have remained constant.