### PR TITLE
SSZ hash: error in Container hashing function

### DIFF
--- a/specs/simple-serialize.md
+++ b/specs/simple-serialize.md
@@ -394,7 +394,7 @@ Where the inner `hash_tree_root_internal` is a recursive application of the tree
 Recursively tree hash the values in the container in the same order as the fields, and Merkle hash the results.
 
 ```python
-return merkle_hash([hash_tree_root_internal(getattr(x, field)) for field in value.fields])
+return merkle_hash([hash_tree_root(getattr(x, field)) for field in value.fields])
 ```
 
 ### Signed roots


### PR DESCRIPTION
## What's wrong  
PR https://github.com/ethereum/eth2.0-specs/pull/595 that changed usage of regular `hash` to `merkle_hash` for Containers adds an error, because container fields are not of homogeneous length if you follow the spec. Let me point it:

1) Container

Recursively tree hash the values in the container in the same order as the fields, and Merkle hash the results.
```python
return merkle_hash([hash_tree_root_internal(getattr(x, field)) for field in value.fields])
```

2) The below `hash_tree_root_internal` algorithm is defined recursively in the case of lists and containers, and it outputs a value equal to **or less than 32 bytes** in size.

3)
```python
 # Merkle tree hash of a list of **homogenous**, non-empty items
def merkle_hash(lst):
```

## Proposal  
Use `hash_tree_root` instead of `hash_tree_root_internal` in Container function, so fields are homogenous.