### PR TITLE
fix randao mixes type, bytes32 like in function and state spec

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1451,7 +1451,7 @@ def get_genesis_beacon_state(genesis_validator_deposits: List[Deposit],
         validator_registry_update_epoch=GENESIS_EPOCH,
 
         # Randomness and committees
-        latest_randao_mixes=[EMPTY_SIGNATURE for _ in range(LATEST_RANDAO_MIXES_LENGTH)],
+        latest_randao_mixes=[ZERO_HASH for _ in range(LATEST_RANDAO_MIXES_LENGTH)],
         previous_shuffling_start_shard=GENESIS_START_SHARD,
         current_shuffling_start_shard=GENESIS_START_SHARD,
         previous_shuffling_epoch=GENESIS_EPOCH,


### PR DESCRIPTION
Simple fix: looks like the state container definition and function say `latest_randao_mixes` should be a `Bytes32`:

```python
'latest_randao_mixes': ['bytes32'],

...

def get_randao_mix(state: BeaconState,
                   epoch: Epoch) -> Bytes32:
```

But the genesis list was initialized with empty signatures (96 bytes).
