### PR TITLE
handle when no attestations available for crosslinking

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -2056,12 +2056,16 @@ def get_winning_root_and_participants(state: BeaconState, shard: Shard) -> Tuple
         a for a in all_attestations if a.data.latest_crosslink == state.latest_crosslinks[shard]
     ]
     all_roots = [a.data.crosslink_data_root for a in valid_attestations]
-    
+
+    # handle when no attestations for shard available
+    if len(all_roots) == 0:
+        return ZERO_HASH, []
+
     def get_attestations_for(root) -> List[PendingAttestation]:
         return [a for a in valid_attestations if a.data.crosslink_data_root == root]
-        
+
     winning_root = max(all_roots, key=lambda r: get_attesting_balance(state, get_attestations_for(r)))
-    
+
     return winning_root, get_attesting_indices(state, get_attestations_for(winning_root))
 ```
 


### PR DESCRIPTION
`max` fails when input list is empty. This is one possible way to handle when no attestations for an expected shard during an epoch transition. This turns into a no-op wherever `get_winning_root_and_participants` is called.