### PR TITLE
Fair proposer sampling

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1002,7 +1002,7 @@ def get_beacon_proposer_index(state: BeaconState,
     assert previous_epoch <= epoch <= next_epoch
 
     first_committee, _ = get_crosslink_committees_at_slot(state, slot, registry_change)[0]
-    return first_committee[slot % len(first_committee)]
+    return first_committee[epoch % len(first_committee)]
 ```
 
 ### `merkle_root`


### PR DESCRIPTION
I think we want `first_committee[epoch % len(first_committee)]` as opposed to `first_committee[slot % len(first_committee)]`. The reason is that if the shuffling happens infrequently and `len(first_committee)` is a multiple of `SLOTS_PER_EPOCH` then the proposers will not be sampled fairly.

Taking this logic further, we may want to avoiding always picking the proposer from `first_committee`, e.g.:

```
    validators_at_slot = []
    for crosslink_committee, _ in get_crosslink_committees_at_slot(state, slot, registry_change):
        validators_at_slot.append(crosslink_committee)

    return validators_at_slot[epoch % len(validators_at_slot)]
```