### PR TITLE
Weaken criterion for attestation inclusion

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -2370,7 +2370,7 @@ def process_attestation(state: BeaconState, attestation: Attestation) -> None:
     """
     # Can't submit attestations that are too far in history (or in prehistory) 
     assert attestation.data.slot >= GENESIS_SLOT
-    assert state.slot < attestation.data.slot + SLOTS_PER_EPOCH
+    assert state.slot <= attestation.data.slot + SLOTS_PER_EPOCH
     # Can't submit attestations too quickly
     assert attestation.data.slot + MIN_ATTESTATION_INCLUSION_DELAY <= state.slot
     # Verify that the justified epoch is correct, case 1: current epoch attestations


### PR DESCRIPTION
The invariant that `get_current_epoch(state) in [get_current_epoch(state), get_previous_epoch(state)]` is preserved, as well as symmetry/fairness across slots.

(Also `<=`/`>=` is used for all three comparisons involving `attestation.data.slot`, slight simplification.)