### PR TITLE
cache justified roots in state/rename attestation fields

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -335,22 +335,19 @@ The types are defined topologically to aid in facilitating an executable version
 
 ```python
 {
-    # Slot number
+    # LMD GHOST vote
     'slot': 'uint64',
-    # Shard number
-    'shard': 'uint64',
-    # Root of the signed beacon block
     'beacon_block_root': 'bytes32',
-    # Root of the ancestor at the epoch boundary
-    'epoch_boundary_root': 'bytes32',
-    # Data from the shard since the last attestation
+
+    # FFG vote
+    'source_epoch': 'uint64',
+    'source_root': 'bytes32',
+    'target_root': 'bytes32',
+
+    # Crosslink vote
+    'shard': 'uint64',
+    'previous_crosslink': Crosslink,
     'crosslink_data_root': 'bytes32',
-    # Last crosslink
-    'latest_crosslink': Crosslink,
-    # Last justified epoch in the beacon state
-    'justified_epoch': 'uint64',
-    # Hash of the last justified beacon block
-    'justified_block_root': 'bytes32',
 }
 ```
 
@@ -612,9 +609,9 @@ The types are defined topologically to aid in facilitating an executable version
     'previous_epoch_attestations': [PendingAttestation],
     'current_epoch_attestations': [PendingAttestation],
     'previous_justified_epoch': 'uint64',
-    'justified_epoch': 'uint64',
+    'current_justified_epoch': 'uint64',
     'previous_justified_root': 'bytes32',
-    'justified_root': 'bytes32',
+    'current_justified_root': 'bytes32',
     'justification_bitfield': 'uint64',
     'finalized_epoch': 'uint64',
 
@@ -1225,8 +1222,8 @@ def is_surround_vote(attestation_data_1: AttestationData,
     """
     Check if ``attestation_data_1`` surrounds ``attestation_data_2``.
     """
-    source_epoch_1 = attestation_data_1.justified_epoch
-    source_epoch_2 = attestation_data_2.justified_epoch
+    source_epoch_1 = attestation_data_1.source_epoch
+    source_epoch_2 = attestation_data_2.source_epoch
     target_epoch_1 = slot_to_epoch(attestation_data_1.slot)
     target_epoch_2 = slot_to_epoch(attestation_data_2.slot)
 
@@ -1547,9 +1544,9 @@ def get_genesis_beacon_state(genesis_validator_deposits: List[Deposit],
         previous_epoch_attestations=[],
         current_epoch_attestations=[],
         previous_justified_epoch=GENESIS_EPOCH,
-        justified_epoch=GENESIS_EPOCH,
+        current_justified_epoch=GENESIS_EPOCH,
         previous_justified_root=ZERO_HASH,
-        justified_root=ZERO_HASH,
+        current_justified_root=ZERO_HASH,
         justification_bitfield=0,
         finalized_epoch=GENESIS_EPOCH,
 
@@ -1733,7 +1730,7 @@ def get_attesting_balance(state: BeaconState, attestations: List[PendingAttestat
 def get_current_epoch_boundary_attestations(state: BeaconState) -> List[PendingAttestation]:
     return [
         a for a in state.current_epoch_attestations
-        if a.data.epoch_boundary_root == get_block_root(state, get_epoch_start_slot(get_current_epoch(state)))
+        if a.data.target_root == get_block_root(state, get_epoch_start_slot(get_current_epoch(state)))
     ]
 ```
 
@@ -1741,7 +1738,7 @@ def get_current_epoch_boundary_attestations(state: BeaconState) -> List[PendingA
 def get_previous_epoch_boundary_attestations(state: BeaconState) -> List[PendingAttestation]:
     return [
         a for a in state.previous_epoch_attestations
-        if a.data.epoch_boundary_root == get_block_root(state, get_epoch_start_slot(get_previous_epoch(state)))
+        if a.data.target_root == get_block_root(state, get_epoch_start_slot(get_previous_epoch(state)))
     ]
 ```
 
@@ -1759,7 +1756,7 @@ def get_previous_epoch_matching_head_attestations(state: BeaconState) -> List[Pe
 def get_winning_root_and_participants(state: BeaconState, shard: Shard) -> Tuple[Bytes32, List[ValidatorIndex]]:
     all_attestations = state.current_epoch_attestations + state.previous_epoch_attestations
     valid_attestations = [
-        a for a in all_attestations if a.data.latest_crosslink == state.latest_crosslinks[shard]
+        a for a in all_attestations if a.data.previous_crosslink == state.latest_crosslinks[shard]
     ]
     all_roots = [a.data.crosslink_data_root for a in valid_attestations]
 
@@ -1802,7 +1799,7 @@ Run the following function:
 
 ```python
 def update_justification_and_finalization(state: BeaconState) -> None:
-    new_justified_epoch = state.justified_epoch
+    new_justified_epoch = state.current_justified_epoch
     # Rotate the justification bitfield up one epoch to make room for the current epoch
     state.justification_bitfield <<= 1
     # If the previous epoch gets justified, fill the second last bit
@@ -1826,18 +1823,18 @@ def update_justification_and_finalization(state: BeaconState) -> None:
     if (bitfield >> 1) % 4 == 0b11 and state.previous_justified_epoch == current_epoch - 2:
         state.finalized_epoch = state.previous_justified_epoch
     # The 1st/2nd/3rd most recent epochs are all justified, the 1st using the 3rd as source
-    if (bitfield >> 0) % 8 == 0b111 and state.justified_epoch == current_epoch - 2:
-        state.finalized_epoch = state.justified_epoch
+    if (bitfield >> 0) % 8 == 0b111 and state.current_justified_epoch == current_epoch - 2:
+        state.finalized_epoch = state.current_justified_epoch
     # The 1st/2nd most recent epochs are both justified, the 1st using the 2nd as source
-    if (bitfield >> 0) % 4 == 0b11 and state.justified_epoch == current_epoch - 1:
-        state.finalized_epoch = state.justified_epoch
+    if (bitfield >> 0) % 4 == 0b11 and state.current_justified_epoch == current_epoch - 1:
+        state.finalized_epoch = state.current_justified_epoch
 
     # Rotate justified epochs
-    state.previous_justified_epoch = state.justified_epoch
-    state.previous_justified_root = state.justified_root
-    if new_justified_epoch != state.justified_epoch:
-        state.justified_epoch = new_justified_epoch
-        state.justified_root = get_block_root(state, get_epoch_start_slot(new_justified_epoch))
+    state.previous_justified_epoch = state.current_justified_epoch
+    state.previous_justified_root = state.current_justified_root
+    if new_justified_epoch != state.current_justified_epoch:
+        state.current_justified_epoch = new_justified_epoch
+        state.current_justified_root = get_block_root(state, get_epoch_start_slot(new_justified_epoch))
 ```
 
 #### Crosslinks
@@ -2381,19 +2378,19 @@ def process_attestation(state: BeaconState, attestation: Attestation) -> None:
     assert state.slot <= attestation.data.slot + SLOTS_PER_EPOCH
     # Can't submit attestations too quickly
     assert attestation.data.slot + MIN_ATTESTATION_INCLUSION_DELAY <= state.slot
-    # Verify that the justified epoch/root is correct
+    # Verify that the justified epoch and root is correct
     if slot_to_epoch(attestation.data.slot) >= get_current_epoch(state):
         # Case 1: current epoch attestations
-        assert attestation.data.justified_epoch == state.justified_epoch
-        assert attestation.data.justified_block_root == state.justified_root
+        assert attestation.data.source_epoch == state.current_justified_epoch
+        assert attestation.data.source_root == state.current_justified_root
     else:
         # Case 2: previous epoch attestations
-        assert attestation.data.justified_epoch == state.previous_justified_epoch
-        assert attestation.data.justified_block_root == state.previous_justified_root
+        assert attestation.data.source_epoch == state.previous_justified_epoch
+        assert attestation.data.source_root == state.previous_justified_root
     # Check that the crosslink data is valid
     acceptable_crosslink_data = {
         # Case 1: Latest crosslink matches the one in the state
-        attestation.data.latest_crosslink,
+        attestation.data.previous_crosslink,
         # Case 2: State has already been updated, state's latest crosslink matches the crosslink
         # the attestation is trying to create
         Crosslink(

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1835,8 +1835,9 @@ def update_justification_and_finalization(state: BeaconState) -> None:
     # Rotate justified epochs
     state.previous_justified_epoch = state.justified_epoch
     state.previous_justified_root = state.justified_root
-    state.justified_epoch = new_justified_epoch
-    state.justified_root = get_block_root(state, get_epoch_start_slot(new_justified_epoch))
+    if new_justified_epoch != state.justified_epoch:
+        state.justified_epoch = new_justified_epoch
+        state.justified_root = get_block_root(state, get_epoch_start_slot(new_justified_epoch))
 ```
 
 #### Crosslinks

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -614,6 +614,7 @@ The types are defined topologically to aid in facilitating an executable version
     'current_justified_root': 'bytes32',
     'justification_bitfield': 'uint64',
     'finalized_epoch': 'uint64',
+    'finalized_root': 'bytes32',
 
     # Recent state
     'latest_crosslinks': [Crosslink, SHARD_COUNT],
@@ -1828,6 +1829,7 @@ def update_justification_and_finalization(state: BeaconState) -> None:
     # The 1st/2nd most recent epochs are both justified, the 1st using the 2nd as source
     if (bitfield >> 0) % 4 == 0b11 and state.current_justified_epoch == current_epoch - 1:
         state.finalized_epoch = state.current_justified_epoch
+    state.finalized_root = get_block_root(state, get_epoch_start_slot(finalized_epoch))
 
     # Rotate justified epochs
     state.previous_justified_epoch = state.current_justified_epoch


### PR DESCRIPTION
addresses #742

Two things:

### correct value for genesis justified roots
Right now, we just have `ZERO_HASH` for the genesis justified roots. This does not actually reflect the value of the root of the block at genesis. The value of the block at the genesis slot is looks like 

```python
block = get_empty_block()
genesis_state = get_genesis_state()
block.state_root = hash_tree_root(genesis_state)
```

Due to the normal chicken-and-egg state/block-root problem, we can't embed the genesis block root in as the initial justified roots when constructing the genesis state. If we want to enforce this, we can do the following in `cache_state`. This is nice because the value reflects an actual block root but it's not really necessary imo.

```python
if state.justified_root == ZERO_HASH:
    state.justified_root = hash_tree_root(state.latest_block_header)
    state.previous_justified_root = state.justified_root
```

### finalized root
Should we add another field `finalized_root` for symmetry? It is not needed in the state transition but might be nice to be available in state regardless of the number of slots since finality. (if greater than `HISTORICAL_ROOTS_LENGTH` you would no longer have it available in state)