### PR TITLE
Check proposer is not slashed

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -2247,8 +2247,10 @@ def process_block_header(state: BeaconState, block: BeaconBlock) -> None:
     assert block.previous_block_root == hash_tree_root(state.latest_block_header)
     # Save current block as the new latest block
     state.latest_block_header = get_temporary_block_header(block)
-    # Verify proposer signature
+    # Verify proposer
     proposer = state.validator_registry[get_beacon_proposer_index(state, state.slot)]
+    assert not proposer.slashed
+    # Verify proposer signature
     assert bls_verify(
         pubkey=proposer.pubkey,
         message_hash=signed_root(block),

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -2247,7 +2247,7 @@ def process_block_header(state: BeaconState, block: BeaconBlock) -> None:
     assert block.previous_block_root == hash_tree_root(state.latest_block_header)
     # Save current block as the new latest block
     state.latest_block_header = get_temporary_block_header(block)
-    # Verify proposer
+    # Verify proposer is not slashed
     proposer = state.validator_registry[get_beacon_proposer_index(state, state.slot)]
     assert not proposer.slashed
     # Verify proposer signature

--- a/tests/phase0/test_process_block_header.py
+++ b/tests/phase0/test_process_block_header.py
@@ -1,0 +1,26 @@
+from copy import deepcopy
+import pytest
+
+
+from build.phase0.spec import (
+    get_beacon_proposer_index,
+    process_block_header,
+)
+from tests.phase0.helpers import (
+    build_empty_block_for_next_slot,
+)
+
+# mark entire file as 'sanity' and 'header'
+pytestmark = [pytest.mark.sanity, pytest.mark.header]
+
+
+def test_proposer_slashed(state):
+    pre_state = deepcopy(state)
+
+    block = build_empty_block_for_next_slot(pre_state)
+    proposer_index = get_beacon_proposer_index(pre_state, block.slot)
+    pre_state.validator_registry[proposer_index].slashed = True
+    with pytest.raises(AssertionError):
+        process_block_header(pre_state, block)
+
+    return state, [block], None


### PR DESCRIPTION
Prevent slashed validator from being able to propose beacon blocks. accomplishes two things:
- prevent them from making money on what is a profitable activity until they are fully removed from v-set
- prevent them from trying to conduct additional attacks that might involve short range forks