### PR TITLE
Mandatory deposits

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -2448,7 +2448,7 @@ def process_attestation(state: BeaconState, attestation: Attestation) -> None:
 
 ##### Deposits
 
-Verify that `len(block.body.deposits) <= MAX_DEPOSITS`. If `state.latest_eth1_data.deposit_count > state.deposit_index`, verify that `len(block.body.deposits) >= 1`.
+Verify that `len(block.body.deposits) == min(MAX_DEPOSITS, latest_eth1_data.deposit_count - state.deposit_index)`.
 
 For each `deposit` in `block.body.deposits`, run `process_deposit(state, deposit)`.
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -315,6 +315,8 @@ The types are defined topologically to aid in facilitating an executable version
 {
     # Root of the deposit tree
     'deposit_root': 'bytes32',
+    # Total number of deposits
+    'deposit_count': 'uint64',
     # Block hash
     'block_hash': 'bytes32',
 }
@@ -1456,6 +1458,7 @@ When sufficiently many full deposits have been made the deposit contract emits t
 
 * `genesis_time` equals `time` in the `Eth2Genesis` log
 * `latest_eth1_data.deposit_root` equals `deposit_root` in the `Eth2Genesis` log
+* `latest_eth1_data.deposit_count` equals `deposit_count` in the `Eth2Genesis` log
 * `latest_eth1_data.block_hash` equals the hash of the block that included the log
 * `genesis_validator_deposits` is a list of `Deposit` objects built according to the `Deposit` logs up to the deposit that triggered the `Eth2Genesis` log, processed in the order in which they were emitted (oldest to newest)
 
@@ -1479,6 +1482,7 @@ When enough full deposits have been made to the deposit contract, an `Eth2Genesi
 * Let `genesis_time` be the timestamp specified in the `Eth2Genesis` log.
 * Let `genesis_eth1_data` be the `Eth1Data` object where:
     * `genesis_eth1_data.deposit_root` is the `deposit_root` contained in the `Eth2Genesis` log.
+    * `genesis_eth1_data.deposit_count` is the `deposit_count` contained in the `Eth2Genesis` log.
     * `genesis_eth1_data.block_hash` is the hash of the Ethereum 1.0 block that emitted the `Eth2Genesis` log.
 * Let `genesis_state = get_genesis_beacon_state(genesis_validator_deposits, genesis_time, genesis_eth1_data)`.
 * Let `genesis_block = get_empty_block()`.
@@ -1497,6 +1501,7 @@ def get_empty_block() -> BeaconBlock:
             randao_reveal=EMPTY_SIGNATURE,
             eth1_data=Eth1Data(
                 deposit_root=ZERO_HASH,
+                deposit_count=0,
                 block_hash=ZERO_HASH,
             ),
             proposer_slashings=[],
@@ -2443,7 +2448,7 @@ def process_attestation(state: BeaconState, attestation: Attestation) -> None:
 
 ##### Deposits
 
-Verify that `len(block.body.deposits) <= MAX_DEPOSITS`.
+Verify that `len(block.body.deposits) <= MAX_DEPOSITS`. If `state.latest_eth1_data.deposit_count > state.deposit_index`, verify that `len(block.body.deposits) >= 1`.
 
 For each `deposit` in `block.body.deposits`, run `process_deposit(state, deposit)`.
 

--- a/tests/phase0/block_processing/test_process_deposit.py
+++ b/tests/phase0/block_processing/test_process_deposit.py
@@ -1,0 +1,132 @@
+from copy import deepcopy
+import pytest
+
+import build.phase0.spec as spec
+
+from build.phase0.spec import (
+    Deposit,
+    process_deposit,
+)
+from tests.phase0.helpers import (
+    build_deposit,
+)
+
+
+# mark entire file as 'voluntary_exits'
+pytestmark = pytest.mark.voluntary_exits
+
+
+def test_success(state, deposit_data_leaves, pubkeys, privkeys):
+    pre_state = deepcopy(state)
+
+    index = len(deposit_data_leaves)
+    pubkey = pubkeys[index]
+    privkey = privkeys[index]
+    deposit, root, deposit_data_leaves = build_deposit(
+        pre_state,
+        deposit_data_leaves,
+        pubkey,
+        privkey,
+        spec.MAX_DEPOSIT_AMOUNT,
+    )
+
+    pre_state.latest_eth1_data.deposit_root = root
+    pre_state.latest_eth1_data.deposit_count = len(deposit_data_leaves)
+
+    post_state = deepcopy(pre_state)
+
+    process_deposit(post_state, deposit)
+
+    assert len(post_state.validator_registry) == len(state.validator_registry) + 1
+    assert len(post_state.validator_balances) == len(state.validator_balances) + 1
+    assert post_state.validator_registry[index].pubkey == pubkeys[index]
+    assert post_state.deposit_index == post_state.latest_eth1_data.deposit_count
+
+    return pre_state, deposit, post_state
+
+
+def test_success_top_up(state, deposit_data_leaves, pubkeys, privkeys):
+    pre_state = deepcopy(state)
+
+    validator_index = 0
+    amount = spec.MAX_DEPOSIT_AMOUNT // 4
+    pubkey = pubkeys[validator_index]
+    privkey = privkeys[validator_index]
+    deposit, root, deposit_data_leaves = build_deposit(
+        pre_state,
+        deposit_data_leaves,
+        pubkey,
+        privkey,
+        amount,
+    )
+
+    pre_state.latest_eth1_data.deposit_root = root
+    pre_state.latest_eth1_data.deposit_count = len(deposit_data_leaves)
+    pre_balance = pre_state.validator_balances[validator_index]
+
+    post_state = deepcopy(pre_state)
+
+    process_deposit(post_state, deposit)
+
+    assert len(post_state.validator_registry) == len(state.validator_registry)
+    assert len(post_state.validator_balances) == len(state.validator_balances)
+    assert post_state.deposit_index == post_state.latest_eth1_data.deposit_count
+    assert post_state.validator_balances[validator_index] == pre_balance + amount
+
+    return pre_state, deposit, post_state
+
+
+def test_wrong_index(state, deposit_data_leaves, pubkeys, privkeys):
+    pre_state = deepcopy(state)
+
+    index = len(deposit_data_leaves)
+    pubkey = pubkeys[index]
+    privkey = privkeys[index]
+    deposit, root, deposit_data_leaves = build_deposit(
+        pre_state,
+        deposit_data_leaves,
+        pubkey,
+        privkey,
+        spec.MAX_DEPOSIT_AMOUNT,
+    )
+
+    # mess up deposit_index
+    deposit.index = pre_state.deposit_index + 1
+
+    pre_state.latest_eth1_data.deposit_root = root
+    pre_state.latest_eth1_data.deposit_count = len(deposit_data_leaves)
+
+    post_state = deepcopy(pre_state)
+
+    with pytest.raises(AssertionError):
+        process_deposit(post_state, deposit)
+
+    return pre_state, deposit, None
+
+
+def test_bad_merkle_proof(state, deposit_data_leaves, pubkeys, privkeys):
+    pre_state = deepcopy(state)
+
+    index = len(deposit_data_leaves)
+    pubkey = pubkeys[index]
+    privkey = privkeys[index]
+    deposit, root, deposit_data_leaves = build_deposit(
+        pre_state,
+        deposit_data_leaves,
+        pubkey,
+        privkey,
+        spec.MAX_DEPOSIT_AMOUNT,
+    )
+
+    # mess up merkle branch
+    deposit.proof[-1] = spec.ZERO_HASH
+
+    pre_state.latest_eth1_data.deposit_root = root
+    pre_state.latest_eth1_data.deposit_count = len(deposit_data_leaves)
+
+    post_state = deepcopy(pre_state)
+
+    with pytest.raises(AssertionError):
+        process_deposit(post_state, deposit)
+
+    return pre_state, deposit, None

--- a/tests/phase0/block_processing/test_voluntary_exit.py
+++ b/tests/phase0/block_processing/test_voluntary_exit.py
@@ -13,6 +13,10 @@ from tests.phase0.helpers import (
 )
 
 
+# mark entire file as 'voluntary_exits'
+pytestmark = pytest.mark.voluntary_exits
+
+
 def test_success(state, pub_to_priv):
     pre_state = deepcopy(state)
     #

--- a/tests/phase0/test_sanity.py
+++ b/tests/phase0/test_sanity.py
@@ -196,6 +196,7 @@ def test_deposit_in_block(state, deposit_data_leaves, pubkeys, privkeys):
     )
 
     pre_state.latest_eth1_data.deposit_root = root
+    pre_state.latest_eth1_data.deposit_count = len(test_deposit_data_leaves)
     post_state = deepcopy(pre_state)
     block = build_empty_block_for_next_slot(post_state)
     block.body.deposits.append(deposit)
@@ -233,6 +234,7 @@ def test_deposit_top_up(state, pubkeys, privkeys, deposit_data_leaves):
     )
 
     pre_state.latest_eth1_data.deposit_root = root
+    pre_state.latest_eth1_data.deposit_count = len(test_deposit_data_leaves)
     block = build_empty_block_for_next_slot(pre_state)
     block.body.deposits.append(deposit)
 


### PR DESCRIPTION
Resolves #675 point 5.
Depends on https://github.com/ethereum/deposit_contract/pull/22.

_motivation_:
This ensures that proposers are unable to stall incoming deposits if there is consensus on a new deposit root. It also more forcefully requires validators to be eth1 light clients listening for deposits, otherwise they won't be able to create valid beacon blocks and might miss significant reward.