### PR TITLE
Create an block header struct

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -463,15 +463,23 @@ The following data structures are defined as [SimpleSerialize (SSZ)](https://git
 
 ```python
 {
+    'header': BeaconBlockHeader,
+
+    # Body
+    'body': BeaconBlockBody,
+}
+```
+
+#### `BeaconBlockHeader`
+
+```python
+{
     # Header
     'slot': 'uint64',
     'parent_root': 'bytes32',
     'state_root': 'bytes32',
     'randao_reveal': 'bytes96',
     'eth1_data': Eth1Data,
-
-    # Body
-    'body': BeaconBlockBody,
     # Signature
     'signature': 'bytes96',
 }


### PR DESCRIPTION
This is so we can implement light client transporting block headers only.