### PR TITLE
Move to SHA256

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -660,7 +660,7 @@ def xor(bytes1: Bytes32, bytes2: Bytes32) -> Bytes32:
 
 ### `hash`
 
-The hash function is denoted by `hash`. In Phase 0 the beacon chain is deployed with the same hash function as Ethereum 1.0, i.e. Keccak-256 (also incorrectly known as SHA3).
+The `hash` function is SHA256.
 
 Note: We aim to migrate to a S[T/N]ARK-friendly hash function in a future Ethereum 2.0 deployment phase.
 

--- a/utils/phase0/hash_function.py
+++ b/utils/phase0/hash_function.py
@@ -1,7 +1,6 @@
-# from hashlib import sha256
-from eth_utils import keccak
+from hashlib import sha256
+# from eth_utils import keccak
 
 
-# def hash(x): return sha256(x).digest()
-def hash(x):
-    return keccak(x)
+def hash(x): return sha256(x).digest()
+# def hash(x):  return keccak(x)


### PR DESCRIPTION
SHA256 is de facto blockchain standard. Standardisation of the hash function is a prerequisite for [full standardisation of BLS12-381 signatures](https://github.com/ethereum/eth2.0-specs/issues/605). Blockchain projects are likely to provide a cheap SHA256 opcode/precompile, and unlikely to provide a Keccak256 equivalent. (Even WASM-enabled blockchains are likely to provide a SHA256 opcode/precompile since WASM does *not* natively support optimised SHA256 CPU instructions.) With Ethereum 2.0 embracing SHA256 the wider industry is more likely to converge towards a unified cross-blockchain communication scheme via Merkle receipts.

There are no security blockers with SHA256 (see comments by Dan Boneh [here](https://github.com/ethereum/eth2.0-specs/issues/612#issuecomment-470452562)).