### PR TITLE
Milder ejections

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -2050,7 +2050,7 @@ def process_ejections(state: BeaconState) -> None:
     """
     for index in get_active_validator_indices(state.validator_registry, get_current_epoch(state)):
         if state.validator_balances[index] < EJECTION_BALANCE:
-            exit_validator(state, index)
+            initiate_validator_exit(state, index)
 ```
 
 #### Validator registry and shuffling seed data

--- a/tests/phase0/test_sanity.py
+++ b/tests/phase0/test_sanity.py
@@ -433,7 +433,7 @@ def test_ejection(state):
     block.slot += spec.SLOTS_PER_EPOCH
     state_transition(post_state, block)
 
-    assert post_state.validator_registry[validator_index].exit_epoch < spec.FAR_FUTURE_EPOCH
+    assert post_state.validator_registry[validator_index].initiated_exit == True
 
     return pre_state, [block], post_state
 


### PR DESCRIPTION
See item 22 in https://github.com/ethereum/eth2.0-specs/issues/675.

Two reasons for this PR:

1) Send ejections to the exit churn mechanism (partially addressing https://github.com/ethereum/eth2.0-specs/issues/527).
2) Avoid sudden drops in the active validator count. (Somewhat related to 1.)