### PR TITLE
Include recently slashed churn in exit churn queue

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -595,6 +595,7 @@ The types are defined topologically to aid in facilitating an executable version
     'validator_registry': [Validator],
     'validator_balances': ['uint64'],
     'validator_registry_update_epoch': 'uint64',
+    'validator_registry_update_slashed_balances': 'uint64',
 
     # Randomness and committees
     'latest_randao_mixes': ['bytes32', LATEST_RANDAO_MIXES_LENGTH],
@@ -2116,6 +2117,7 @@ def update_validator_registry(state: BeaconState) -> None:
             exit_validator(state, index)
 
     state.validator_registry_update_epoch = current_epoch
+    state.validator_registry_update_slashed_balances = total_at_end
 ```
 
 Run the following function:
@@ -2164,7 +2166,7 @@ def process_slashings(state: BeaconState) -> None:
     total_balance = get_total_balance(state, active_validator_indices)
 
     # Compute `total_penalties`
-    total_at_start = state.latest_slashed_balances[(current_epoch + 1) % LATEST_SLASHED_EXIT_LENGTH]
+    total_at_start = state.validator_registry_update_slashed_balances
     total_at_end = state.latest_slashed_balances[current_epoch % LATEST_SLASHED_EXIT_LENGTH]
     total_penalties = total_at_end - total_at_start
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -2089,7 +2089,7 @@ def update_validator_registry(state: BeaconState) -> None:
             activate_validator(state, index, is_genesis=False)
 
     # Exit validators within the allowable balance churn
-    if state.current_epoch < state.validator_registry_update_epoch + LATEST_SLASHED_EXIT_LENGTH:
+    if current_epoch < state.validator_registry_update_epoch + LATEST_SLASHED_EXIT_LENGTH:
         balance_churn = (
             state.latest_slashed_balances[state.validator_registry_update_epoch % LATEST_SLASHED_EXIT_LENGTH] -
             state.latest_slashed_balances[current_epoch % LATEST_SLASHED_EXIT_LENGTH]

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -2102,7 +2102,9 @@ def update_validator_registry(state: BeaconState) -> None:
             activate_validator(state, index, is_genesis=False)
 
     # Exit validators within the allowable balance churn
-    balance_churn = 0
+    total_at_start = state.latest_slashed_balances[(current_epoch + 1) % LATEST_SLASHED_EXIT_LENGTH]
+    total_at_end = state.latest_slashed_balances[current_epoch % LATEST_SLASHED_EXIT_LENGTH]
+    balance_churn = total_at_end - total_at_start
     for index, validator in enumerate(state.validator_registry):
         if validator.exit_epoch == FAR_FUTURE_EPOCH and validator.initiated_exit:
             # Check the balance churn would be within the allowance

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -2103,7 +2103,7 @@ def update_validator_registry(state: BeaconState) -> None:
             activate_validator(state, index, is_genesis=False)
 
     # Exit validators within the allowable balance churn
-    total_at_start = state.latest_slashed_balances[(current_epoch + 1) % LATEST_SLASHED_EXIT_LENGTH]
+    total_at_start = state.validator_registry_update_slashed_balances
     total_at_end = state.latest_slashed_balances[current_epoch % LATEST_SLASHED_EXIT_LENGTH]
     balance_churn = total_at_end - total_at_start
     for index, validator in enumerate(state.validator_registry):
@@ -2166,7 +2166,7 @@ def process_slashings(state: BeaconState) -> None:
     total_balance = get_total_balance(state, active_validator_indices)
 
     # Compute `total_penalties`
-    total_at_start = state.validator_registry_update_slashed_balances
+    total_at_start = state.latest_slashed_balances[(current_epoch + 1) % LATEST_SLASHED_EXIT_LENGTH]
     total_at_end = state.latest_slashed_balances[current_epoch % LATEST_SLASHED_EXIT_LENGTH]
     total_penalties = total_at_end - total_at_start
 

--- a/tests/phase0/test_sanity.py
+++ b/tests/phase0/test_sanity.py
@@ -316,12 +316,18 @@ def test_attestation(state, pubkeys, privkeys):
 
 def test_voluntary_exit(state, pubkeys, privkeys):
     pre_state = deepcopy(state)
-    validator_index = get_active_validator_indices(pre_state.validator_registry, get_current_epoch(pre_state))[-1]
+    validator_index = get_active_validator_indices(
+        pre_state.validator_registry,
+        get_current_epoch(pre_state)
+    )[-1]
 
     # move state forward PERSISTENT_COMMITTEE_PERIOD epochs to allow for exit
     pre_state.slot += spec.PERSISTENT_COMMITTEE_PERIOD * spec.SLOTS_PER_EPOCH
     # artificially trigger registry update at next epoch transition
-    pre_state.validator_registry_update_epoch -= 1
+    pre_state.finalized_epoch = get_current_epoch(pre_state) - 1
+    for crosslink in pre_state.latest_crosslinks:
+        crosslink.epoch = pre_state.finalized_epoch
+    pre_state.validator_registry_update_epoch = pre_state.finalized_epoch - 1
 
     post_state = deepcopy(pre_state)
 


### PR DESCRIPTION
Addresses #527 in combination with #784.

These changes were made to keep a tighter bound on validator churn to ensure adequate safety margins when changing v-sets

* add the recently slashed balances to the exit churn to prevent too much turn over in the case of slashed exits
* do not process exits at all if too long since last validator registry change to avoid counting errors wrt slashed balance array