### PR TITLE
Use `EMPTY_SIGNATURE` for temporary block header

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -684,7 +684,7 @@ def get_temporary_block_header(block: BeaconBlock) -> BeaconBlockHeader:
         previous_block_root=block.previous_block_root,
         state_root=ZERO_HASH,
         block_body_root=hash_tree_root(block.body),
-        signature=block.signature,
+        signature=EMPTY_SIGNATURE,
     )
 ```
 


### PR DESCRIPTION
## What

Changes `get_temporary_block_header(..)` to use `EMPTY_SIGNATURE` instead of `block.signature`.

## Why

`state.latest_block_header.signature` is different between producing and processing a block.

### Producing

When calling `per_block_processing`, `state.latest_block_header.signature` is `EMPTY_SIGNATURE`.

It's impossible to have the real block signature here as you need the output of `per_block_processing(..)` (the updated state root) before you can produce the `state.latest_block_header.signature` and the value of `state.latest_block_header.signature` changes the state root, which changes the signature, and so on.

### Processing

When calling `per_block_processing`, `state.latest_block_header.signature` is (hopefully) a real block signature.