### PR TITLE
Replace previous_block_root with previous_block_signature

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -681,7 +681,7 @@ def get_temporary_block_header(block: BeaconBlock) -> BeaconBlockHeader:
     """
     return BeaconBlockHeader(
         slot=block.slot,
-        previous_block_signature=ZERO_SIGNATURE,
+        previous_block_signature=EMPTY_SIGNATURE,
         state_root=ZERO_HASH,
         block_body_root=hash_tree_root(block.body),
         signature=block.signature,

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -681,10 +681,10 @@ def get_temporary_block_header(block: BeaconBlock) -> BeaconBlockHeader:
     """
     return BeaconBlockHeader(
         slot=block.slot,
-        previous_block_signature=EMPTY_SIGNATURE,
+        previous_block_signature=block.previous_block_signature,
         state_root=ZERO_HASH,
         block_body_root=hash_tree_root(block.body),
-        signature=block.signature,
+        signature=EMPTY_SIGNATURE,
     )
 ```
 


### PR DESCRIPTION
Possible approach to fix #797. (Not lobbying for this, merely putting it up as an option.)

Note that the extra `bls_verify` can be optimised away by implementers.