### PR TITLE
Remove latest_block_header

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1683,7 +1683,7 @@ def cache_state(state: BeaconState) -> None:
     state.latest_state_roots[state.slot % SLOTS_PER_HISTORICAL_ROOT] = previous_slot_state_root
 
     # store latest known block for previous slot
-    state.latest_block_roots[state.slot % SLOTS_PER_HISTORICAL_ROOT] = state.latest_block_roots[(state.slot - 1) % SLOTS_PER_HISTORICAL_ROOT]
+    state.latest_block_roots[state.slot % SLOTS_PER_HISTORICAL_ROOT] = get_block_root(state, state.slot - 1)
 ```
 
 ### Per-epoch processing
@@ -2245,7 +2245,7 @@ def process_block_header(state: BeaconState, block: BeaconBlock) -> None:
     assert block.slot == state.slot
     # Verify the previous block root
     assert block.previous_block_root == get_block_root(state, state.slot - 1)
-    # Verify the signature
+    # Verify proposer signature
     proposer = state.validator_registry[get_beacon_proposer_index(state, state.slot)]
     assert bls_verify(
         pubkey=proposer.pubkey,

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -136,7 +136,7 @@
                 - [Deposits](#deposits)
                 - [Voluntary exits](#voluntary-exits)
                 - [Transfers](#transfers)
-            - [Final updates](#final-updates-1)
+            - [Final processing](#final-processing)
 - [References](#references)
     - [Normative](#normative)
     - [Informative](#informative)
@@ -2523,12 +2523,12 @@ def process_transfer(state: BeaconState, transfer: Transfer) -> None:
     state.validator_balances[get_beacon_proposer_index(state, state.slot)] += transfer.fee
 ```
 
-#### Final updates
+#### Final processing
 
 Verify the block's `state_root` by running the following function:
 
 ```python
-def final_updates(state: BeaconState, block: BeaconBlock) -> None:
+def final_processing(state: BeaconState, block: BeaconBlock) -> None:
     # Check state root
     assert block.state_root == hash_tree_root(state)
     # Cache block root

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1475,18 +1475,13 @@ When enough full deposits have been made to the deposit contract, an `Eth2Genesi
     * `genesis_eth1_data.deposit_root` is the `deposit_root` contained in the `Eth2Genesis` log.
     * `genesis_eth1_data.block_hash` is the hash of the Ethereum 1.0 block that emitted the `Eth2Genesis` log.
 * Let `genesis_state = get_genesis_beacon_state(genesis_validator_deposits, genesis_time, genesis_eth1_data)`.
-* Let `genesis_block = get_empty_block()`.
-* Set `genesis_block.state_root = hash_tree_root(genesis_state)`.
+* Let `genesis_block` equal
 
 ```python
-def get_empty_block() -> BeaconBlock:
-    """
-    Get an empty ``BeaconBlock``.
-    """
-    return BeaconBlock(
+    BeaconBlock(
         slot=GENESIS_SLOT,
         previous_block_root=ZERO_HASH,
-        state_root=ZERO_HASH,
+        state_root=hash_tree_root(genesis_state),
         body=BeaconBlockBody(
             randao_reveal=EMPTY_SIGNATURE,
             eth1_data=Eth1Data(


### PR DESCRIPTION
Fix #797:

* Remove `latest_block_header`
* Maintain `(pre_state, block) -> (post_state, error)` state transition function by caching the block root *after* checking the state root

```python
def final_updates(state: BeaconState, block: BeaconBlock) -> None:
    # Check state root
    assert block.state_root == hash_tree_root(state)
    # Cache block root
    state.latest_block_roots[state.slot % SLOTS_PER_HISTORICAL_ROOT] = hash_tree_root(block)
```