### PR TITLE
Ensure order-of-operations for shuffling shard mod

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -2132,9 +2132,9 @@ def update_registry_and_shuffling_data(state: BeaconState) -> None:
         # If we update the registry, update the shuffling data and shards as well
         state.current_shuffling_epoch = next_epoch
         state.current_shuffling_start_shard = (
-            (state.current_shuffling_start_shard +
-            get_current_epoch_committee_count(state)) % SHARD_COUNT
-        )
+            state.current_shuffling_start_shard +
+            get_current_epoch_committee_count(state)
+        ) % SHARD_COUNT
         state.current_shuffling_seed = generate_seed(state, state.current_shuffling_epoch)
     else:
         # If processing at least one crosslink keeps failing, then reshuffle every power of two,

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -2132,8 +2132,8 @@ def update_registry_and_shuffling_data(state: BeaconState) -> None:
         # If we update the registry, update the shuffling data and shards as well
         state.current_shuffling_epoch = next_epoch
         state.current_shuffling_start_shard = (
-            state.current_shuffling_start_shard +
-            get_current_epoch_committee_count(state) % SHARD_COUNT
+            (state.current_shuffling_start_shard +
+            get_current_epoch_committee_count(state)) % SHARD_COUNT
         )
         state.current_shuffling_seed = generate_seed(state, state.current_shuffling_epoch)
     else:


### PR DESCRIPTION
## What

Add some brackets to `update_registry_and_shuffling_data` to ensure `shuffling_start_shard < SHARD_COUNT`.

## Why

The following [code](http://www.pythonsandbox.com/code/pythonsandbox_u169_03GfTXHz6XSp7Vtx1XN07cqd_v0.py) runs and prints "end"

```python
epoch_committee_count = 2047;
SHARD_COUNT = 1024;
old_shuffling_start = 1023;

current_shuffling_start_shard = (
	old_shuffling_start +
	epoch_committee_count % SHARD_COUNT
)

assert(current_shuffling_start_shard > SHARD_COUNT)

current_shuffling_start_shard = (
	(old_shuffling_start +
	epoch_committee_count) % SHARD_COUNT
)

assert(current_shuffling_start_shard < SHARD_COUNT)

print("end")
```