### PR TITLE
Stricter slashing criteria

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -2315,8 +2315,8 @@ def process_proposer_slashing(state: BeaconState,
     assert slot_to_epoch(proposer_slashing.header_1.slot) == slot_to_epoch(proposer_slashing.header_2.slot)
     # But the headers are different
     assert proposer_slashing.header_1 != proposer_slashing.header_2
-    # Proposer is not yet slashed
-    assert proposer.slashed is False
+    # Proposer is active and not already slashed
+    assert is_active_validator(proposer) and proposer.slashed is False
     # Signatures are valid
     for header in (proposer_slashing.header_1, proposer_slashing.header_2):
         assert bls_verify(
@@ -2355,6 +2355,7 @@ def process_attester_slashing(state: BeaconState,
         index for index in attestation1.validator_indices
         if (
             index in attestation2.validator_indices and
+            is_active_validator(state.validator_registry[index]) and
             state.validator_registry[index].slashed is False
         )
     ]

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1412,7 +1412,6 @@ def slash_validator(state: BeaconState, index: ValidatorIndex) -> None:
     Note that this function mutates ``state``.
     """
     validator = state.validator_registry[index]
-    assert state.slot < get_epoch_start_slot(validator.withdrawable_epoch)  # [TO BE REMOVED IN PHASE 2]
     exit_validator(state, index)
     state.latest_slashed_balances[get_current_epoch(state) % LATEST_SLASHED_EXIT_LENGTH] += get_effective_balance(state, index)
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -2328,7 +2328,7 @@ def process_proposer_slashing(state: BeaconState,
     # But the headers are different
     assert proposer_slashing.header_1 != proposer_slashing.header_2
     # Check proposer is slashable
-    assert is_slashable_validator(proposer)
+    assert is_slashable_validator(proposer, get_current_epoch(state))
     # Signatures are valid
     for header in (proposer_slashing.header_1, proposer_slashing.header_2):
         assert bls_verify(
@@ -2367,7 +2367,7 @@ def process_attester_slashing(state: BeaconState,
         index for index in attestation1.validator_indices
         if (
             index in attestation2.validator_indices and
-            is_slashable_validator(state.validator_registry[index])
+            is_slashable_validator(state.validator_registry[index], get_current_epoch(state))
         )
     ]
     assert len(slashable_indices) >= 1

--- a/tests/phase0/block_processing/test_process_proposer_slashing.py
+++ b/tests/phase0/block_processing/test_process_proposer_slashing.py
@@ -1,0 +1,97 @@
+from copy import deepcopy
+import pytest
+
+import build.phase0.spec as spec
+from build.phase0.spec import (
+    get_balance,
+    get_current_epoch,
+    process_proposer_slashing,
+)
+from tests.phase0.helpers import (
+    get_valid_proposer_slashing,
+)
+
+# mark entire file as 'header'
+pytestmark = pytest.mark.proposer_slashings
+
+
+def run_proposer_slashing_processing(state, proposer_slashing, valid=True):
+    """
+    Run ``process_proposer_slashing`` returning the pre and post state.
+    If ``valid == False``, run expecting ``AssertionError``
+    """
+    post_state = deepcopy(state)
+
+    if not valid:
+        with pytest.raises(AssertionError):
+            process_proposer_slashing(post_state, proposer_slashing)
+        return state, None
+
+    process_proposer_slashing(post_state, proposer_slashing)
+
+    slashed_validator = post_state.validator_registry[proposer_slashing.proposer_index]
+    assert not slashed_validator.initiated_exit
+    assert slashed_validator.slashed
+    assert slashed_validator.exit_epoch < spec.FAR_FUTURE_EPOCH
+    assert slashed_validator.withdrawable_epoch < spec.FAR_FUTURE_EPOCH
+    # lost whistleblower reward
+    assert (
+        get_balance(post_state, proposer_slashing.proposer_index) <
+        get_balance(state, proposer_slashing.proposer_index)
+    )
+
+    return state, post_state
+
+
+def test_success(state):
+    proposer_slashing = get_valid_proposer_slashing(state)
+
+    pre_state, post_state = run_proposer_slashing_processing(state, proposer_slashing)
+
+    return pre_state, proposer_slashing, post_state
+
+
+def test_epochs_are_different(state):
+    proposer_slashing = get_valid_proposer_slashing(state)
+
+    # set slots to be in different epochs
+    proposer_slashing.header_2.slot += spec.SLOTS_PER_EPOCH
+
+    pre_state, post_state = run_proposer_slashing_processing(state, proposer_slashing, False)
+
+    return pre_state, proposer_slashing, post_state
+
+
+def test_headers_are_same(state):
+    proposer_slashing = get_valid_proposer_slashing(state)
+
+    # set headers to be the same
+    proposer_slashing.header_2 = proposer_slashing.header_1
+
+    pre_state, post_state = run_proposer_slashing_processing(state, proposer_slashing, False)
+
+    return pre_state, proposer_slashing, post_state
+
+
+def test_proposer_is_slashed(state):
+    proposer_slashing = get_valid_proposer_slashing(state)
+
+    # set proposer to slashed
+    state.validator_registry[proposer_slashing.proposer_index].slashed = True
+
+    pre_state, post_state = run_proposer_slashing_processing(state, proposer_slashing, False)
+
+    return pre_state, proposer_slashing, post_state
+
+
+def test_proposer_is_withdrawn(state):
+    proposer_slashing = get_valid_proposer_slashing(state)
+
+    # set proposer withdrawable_epoch in past
+    current_epoch = get_current_epoch(state)
+    proposer_index = proposer_slashing.proposer_index
+    state.validator_registry[proposer_index].withdrawable_epoch = current_epoch - 1
+
+    pre_state, post_state = run_proposer_slashing_processing(state, proposer_slashing, False)
+
+    return pre_state, proposer_slashing, post_state


### PR DESCRIPTION
This is to prevent a spam/DoS attack where validators with zero balance get "slashed" but no validator loses any balance.