### PR TITLE
Replace committee exponential backoff with max progress

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -74,7 +74,6 @@
         - [`get_beacon_proposer_index`](#get_beacon_proposer_index)
         - [`verify_merkle_branch`](#verify_merkle_branch)
         - [`get_attestation_participants`](#get_attestation_participants)
-        - [`is_power_of_two`](#is_power_of_two)
         - [`int_to_bytes1`, `int_to_bytes2`, ...](#int_to_bytes1-int_to_bytes2-)
         - [`bytes_to_int`](#bytes_to_int)
         - [`get_effective_balance`](#get_effective_balance)
@@ -861,16 +860,12 @@ def get_crosslink_committees_at_slot(state: BeaconState,
     ))
 
     if epoch == current_epoch:
-        shuffling_start_shard = state.latest_start_shard
+        start_shard = state.latest_start_shard
     elif epoch == previous_epoch:
-        shuffling_start_shard = (
-            state.latest_start_shard - SLOTS_PER_EPOCH * committees_per_epoch
-        ) % SHARD_COUNT
+        start_shard = (state.latest_start_shard - SLOTS_PER_EPOCH * committees_per_epoch) % SHARD_COUNT
     elif epoch == next_epoch:
         current_epoch_committees = get_current_epoch_committee_count(state)
-        shuffling_start_shard = (
-            state.latest_start_shard + EPOCH_LENGTH * current_epoch_committees
-        ) % SHARD_COUNT
+        start_shard = (state.latest_start_shard + EPOCH_LENGTH * current_epoch_committees) % SHARD_COUNT
 
     shuffling = get_shuffling(
         generate_seed(state, epoch),
@@ -879,7 +874,7 @@ def get_crosslink_committees_at_slot(state: BeaconState,
     )
     offset = slot % SLOTS_PER_EPOCH
     committees_per_slot = committees_per_epoch // SLOTS_PER_EPOCH
-    slot_start_shard = (shuffling_start_shard + committees_per_slot * offset) % SHARD_COUNT
+    slot_start_shard = (start_shard + committees_per_slot * offset) % SHARD_COUNT
 
     return [
         (
@@ -1015,16 +1010,6 @@ def get_attestation_participants(state: BeaconState,
         if aggregation_bit == 0b1:
             participants.append(validator_index)
     return participants
-```
-
-### `is_power_of_two`
-
-```python
-def is_power_of_two(value: int) -> bool:
-    """
-    Check if ``value`` is a power of two integer.
-    """
-    return (value > 0) and (value & (value - 1) == 0)
 ```
 
 ### `int_to_bytes1`, `int_to_bytes2`, ...

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -64,9 +64,7 @@
         - [`split`](#split)
         - [`get_epoch_committee_count`](#get_epoch_committee_count)
         - [`get_shuffling`](#get_shuffling)
-        - [`get_previous_epoch_committee_count`](#get_previous_epoch_committee_count)
         - [`get_current_epoch_committee_count`](#get_current_epoch_committee_count)
-        - [`get_next_epoch_committee_count`](#get_next_epoch_committee_count)
         - [`get_crosslink_committees_at_slot`](#get_crosslink_committees_at_slot)
         - [`get_block_root`](#get_block_root)
         - [`get_state_root`](#get_state_root)
@@ -823,20 +821,6 @@ def get_shuffling(seed: Bytes32,
 
 **Note**: this definition and the next few definitions make heavy use of repetitive computing. Production implementations are expected to appropriately use caching/memoization to avoid redoing work.
 
-### `get_previous_epoch_committee_count`
-
-```python
-def get_previous_epoch_committee_count(state: BeaconState) -> int:
-    """
-    Return the number of committees in the previous epoch of the given ``state``.
-    """
-    previous_active_validators = get_active_validator_indices(
-        state.validator_registry,
-        state.previous_shuffling_epoch,
-    )
-    return get_epoch_committee_count(len(previous_active_validators))
-```
-
 ### `get_current_epoch_committee_count`
 
 ```python
@@ -849,20 +833,6 @@ def get_current_epoch_committee_count(state: BeaconState) -> int:
         get_current_epoch(state),
     )
     return get_epoch_committee_count(len(current_active_validators))
-```
-
-### `get_next_epoch_committee_count`
-
-```python
-def get_next_epoch_committee_count(state: BeaconState) -> int:
-    """
-    Return the number of committees in the next epoch of the given ``state``.
-    """
-    next_active_validators = get_active_validator_indices(
-        state.validator_registry,
-        get_current_epoch(state) + 1,
-    )
-    return get_epoch_committee_count(len(next_active_validators))
 ```
 
 ### `get_crosslink_committees_at_slot`
@@ -895,10 +865,7 @@ def get_crosslink_committees_at_slot(state: BeaconState,
             state.current_shuffling_start_shard - EPOCH_LENGTH * committees_per_epoch
         ) % SHARD_COUNT
     elif epoch == next_epoch:
-        current_epoch_committees = get_epoch_committee_count(get_active_validator_indices(
-            state.validator_registry,
-            current_epoch,
-        ))
+        current_epoch_committees = get_current_epoch_committee_count(state)
         shuffling_start_shard = (
             state.current_shuffling_start_shard + EPOCH_LENGTH * current_epoch_committees
         ) % SHARD_COUNT

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -905,21 +905,20 @@ def get_crosslink_committees_at_slot(state: BeaconState,
     next_epoch = current_epoch + 1
 
     assert previous_epoch <= epoch <= next_epoch
-    active_validator_indices = get_active_validator_indices(
+    indices = get_active_validator_indices(
         state.validator_registry,
         epoch,
     )
-    committees_per_epoch = get_epoch_committee_count(len(active_validator_indices))
+    committees_per_epoch = get_epoch_committee_count(len(indices))
 
     if epoch == current_epoch:
         start_shard = state.latest_start_shard
     elif epoch == previous_epoch:
-        start_shard = (state.latest_start_shard - SLOTS_PER_EPOCH * committees_per_epoch) % SHARD_COUNT
+        start_shard = (state.latest_start_shard - committees_per_epoch) % SHARD_COUNT
     elif epoch == next_epoch:
         current_epoch_committees = get_current_epoch_committee_count(state)
-        start_shard = (state.latest_start_shard + EPOCH_LENGTH * current_epoch_committees) % SHARD_COUNT
+        start_shard = (state.latest_start_shard + current_epoch_committees) % SHARD_COUNT
 
-    indices = get_active_validator_indices(state.validator_registry, epoch)
     committees_per_slot = committees_per_epoch // SLOTS_PER_EPOCH
     offset = slot % SLOTS_PER_EPOCH
     slot_start_shard = (start_shard + committees_per_slot * offset) % SHARD_COUNT
@@ -1830,7 +1829,7 @@ Run the following function:
 ```python
 def process_crosslinks(state: BeaconState) -> None:
     current_epoch = get_current_epoch(state)
-    previous_epoch = current_epoch - 1
+    previous_epoch = max(current_epoch - 1, GENESIS_EPOCH)
     next_epoch = current_epoch + 1
     for slot in range(get_epoch_start_slot(previous_epoch), get_epoch_start_slot(next_epoch)):
         for crosslink_committee, shard in get_crosslink_committees_at_slot(state, slot):

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -891,13 +891,9 @@ def get_current_epoch_committee_count(state: BeaconState) -> int:
 
 ```python
 def get_crosslink_committees_at_slot(state: BeaconState,
-                                     slot: Slot,
-                                     registry_change: bool=False) -> List[Tuple[List[ValidatorIndex], Shard]]:
+                                     slot: Slot) -> List[Tuple[List[ValidatorIndex], Shard]]:
     """
     Return the list of ``(committee, shard)`` tuples for the ``slot``.
-
-    Note: There are two possible shufflings for crosslink committees for a
-    ``slot`` in the next epoch -- with and without a `registry_change`
     """
     epoch = slot_to_epoch(slot)
     current_epoch = get_current_epoch(state)
@@ -2339,7 +2335,7 @@ def process_attestation(state: BeaconState, attestation: Attestation) -> None:
     # Check target epoch, source epoch, and source root
     target_epoch = slot_to_epoch(attestation.data.slot)
     assert (target_epoch, attestation.data.source_epoch, attestation.data.source_root) in {
-        (get_current_epoch(state), state.current_justified_epoch, state.current_justified_root), 
+        (get_current_epoch(state), state.current_justified_epoch, state.current_justified_root),
         (get_previous_epoch(state), state.previous_justified_epoch, state.previous_justified_root),
     }
 

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -17,41 +17,51 @@ At the current stage, Phase 1, while fundamentally feature-complete, is still su
             - [Time parameters](#time-parameters)
             - [Max operations per block](#max-operations-per-block)
             - [Signature domains](#signature-domains)
-    - [Shard chains and crosslink data](#shard-chains-and-crosslink-data)
-      - [Helper functions](#helper-functions)
+- [Shard chains and crosslink data](#shard-chains-and-crosslink-data)
+    - [Helper functions](#helper-functions)
             - [`get_split_offset`](#get_split_offset)
             - [`get_shuffled_committee`](#get_shuffled_committee)
             - [`get_persistent_committee`](#get_persistent_committee)
             - [`get_shard_proposer_index`](#get_shard_proposer_index)
-      - [Data Structures](#data-structures)
+    - [Data Structures](#data-structures)
         - [Shard chain blocks](#shard-chain-blocks)
-      - [Shard block processing](#shard-block-processing)
+    - [Shard block processing](#shard-block-processing)
         - [Verifying shard block data](#verifying-shard-block-data)
         - [Verifying a crosslink](#verifying-a-crosslink)
         - [Shard block fork choice rule](#shard-block-fork-choice-rule)
-    - [Updates to the beacon chain](#updates-to-the-beacon-chain)
-      - [Data structures](#data-structures)
+- [Updates to the beacon chain](#updates-to-the-beacon-chain)
+    - [Data structures](#data-structures)
         - [`Validator`](#validator)
         - [`BeaconBlockBody`](#beaconblockbody)
+        - [`BeaconState`](#beaconstate)
         - [`BranchChallenge`](#branchchallenge)
         - [`BranchResponse`](#branchresponse)
         - [`BranchChallengeRecord`](#branchchallengerecord)
+        - [`InteractiveCustodyChallengeRecord`](#interactivecustodychallengerecord)
+        - [`InteractiveCustodyChallengeInitiation`](#interactivecustodychallengeinitiation)
+        - [`InteractiveCustodyChallengeResponse`](#interactivecustodychallengeresponse)
+        - [`InteractiveCustodyChallengeContinuation`](#interactivecustodychallengecontinuation)
         - [`SubkeyReveal`](#subkeyreveal)
     - [Helpers](#helpers)
-        - [`get_attestation_data_merkle_depth`](#get_attestation_data_merkle_depth)
+        - [`get_branch_challenge_record_by_id`](#get_branch_challenge_record_by_id)
+        - [`get_custody_challenge_record_by_id`](#get_custody_challenge_record_by_id)
+        - [`get_attestation_merkle_depth`](#get_attestation_merkle_depth)
         - [`epoch_to_custody_period`](#epoch_to_custody_period)
         - [`slot_to_custody_period`](#slot_to_custody_period)
         - [`get_current_custody_period`](#get_current_custody_period)
         - [`verify_custody_subkey_reveal`](#verify_custody_subkey_reveal)
-        - [`prepare_validator_for_withdrawal`](#prepare_validator_for_withdrawal)
+        - [`verify_signed_challenge_message`](#verify_signed_challenge_message)
         - [`penalize_validator`](#penalize_validator)
-      - [Per-slot processing](#per-slot-processing)
+    - [Per-slot processing](#per-slot-processing)
         - [Operations](#operations)
             - [Branch challenges](#branch-challenges)
             - [Branch responses](#branch-responses)
             - [Subkey reveals](#subkey-reveals)
-      - [Per-epoch processing](#per-epoch-processing)
-      - [One-time phase 1 initiation transition](#one-time-phase-1-initiation-transition)
+            - [Interactive custody challenge initiations](#interactive-custody-challenge-initiations)
+            - [Interactive custody challenge responses](#interactive-custody-challenge-responses)
+            - [Interactive custody challenge continuations](#interactive-custody-challenge-continuations)
+    - [Per-epoch processing](#per-epoch-processing)
+    - [One-time phase 1 initiation transition](#one-time-phase-1-initiation-transition)
 
 <!-- /TOC -->
 
@@ -128,16 +138,27 @@ def get_split_offset(list_size: int, chunks: int, index: int) -> int:
 ```python
 def get_shuffled_committee(state: BeaconState,
                            shard: Shard,
-                           committee_start_epoch: Epoch) -> List[ValidatorIndex]:
+                           committee_start_epoch: Epoch,
+                           index: int,
+                           committee_count: int) -> List[ValidatorIndex]:
     """
     Return shuffled committee.
     """
-    validator_indices = get_active_validator_indices(state.validators, committee_start_epoch)
+    active_validator_indices = get_active_validator_indices(state.validator_registry, committee_start_epoch)
+    length = len(active_validator_indices)
     seed = generate_seed(state, committee_start_epoch)
-    start_offset = get_split_offset(len(validator_indices), SHARD_COUNT, shard)
-    end_offset = get_split_offset(len(validator_indices), SHARD_COUNT, shard + 1)
+    start_offset = get_split_offset(
+        length,
+        SHARD_COUNT * committee_count,
+        shard * committee_count + index,
+    )
+    end_offset = get_split_offset(
+        length,
+        SHARD_COUNT * committee_count,
+        shard * committee_count + index + 1,
+    )
     return [
-        validator_indices[get_permuted_index(i, len(validator_indices), seed)]
+        active_validator_indices[get_permuted_index(i, length, seed)]
         for i in range(start_offset, end_offset)
     ]
 ```
@@ -147,15 +168,24 @@ def get_shuffled_committee(state: BeaconState,
 ```python
 def get_persistent_committee(state: BeaconState,
                              shard: Shard,
-                             epoch: Epoch) -> List[ValidatorIndex]:
+                             slot: Slot) -> List[ValidatorIndex]:
     """
-    Return the persistent committee for the given ``shard`` at the given ``epoch``.
+    Return the persistent committee for the given ``shard`` at the given ``slot``.
     """
-    earlier_committee_start_epoch = epoch - (epoch % PERSISTENT_COMMITTEE_PERIOD) - PERSISTENT_COMMITTEE_PERIOD * 2
-    earlier_committee = get_shuffled_committee(state, shard, earlier_committee_start_epoch)
+        
+    earlier_start_epoch = epoch - (epoch % PERSISTENT_COMMITTEE_PERIOD) - PERSISTENT_COMMITTEE_PERIOD * 2
+    later_start_epoch = epoch - (epoch % PERSISTENT_COMMITTEE_PERIOD) - PERSISTENT_COMMITTEE_PERIOD
 
-    later_committee_start_epoch = epoch - (epoch % PERSISTENT_COMMITTEE_PERIOD) - PERSISTENT_COMMITTEE_PERIOD
-    later_committee = get_shuffled_committee(state, shard, later_committee_start_epoch)
+    committee_count = max(
+        len(get_active_validator_indices(state.validator_registry, earlier_start_epoch)) //
+        (SHARD_COUNT * TARGET_COMMITTEE_SIZE),
+        len(get_active_validator_indices(state.validator_registry, later_start_epoch)) //
+        (SHARD_COUNT * TARGET_COMMITTEE_SIZE),
+    ) + 1
+    
+    index = slot % committee_count
+    earlier_committee = get_shuffled_committee(state, shard, earlier_start_epoch, index, committee_count)
+    later_committee = get_shuffled_committee(state, shard, later_start_epoch, index, committee_count)
 
     def get_switchover_epoch(index):
         return (
@@ -170,6 +200,7 @@ def get_persistent_committee(state: BeaconState,
         [i for i in later_committee if epoch % PERSISTENT_COMMITTEE_PERIOD >= get_switchover_epoch(i)]
     )))
 ```
+
 #### `get_shard_proposer_index`
 
 ```python
@@ -181,14 +212,14 @@ def get_shard_proposer_index(state: BeaconState,
         int_to_bytes8(shard) +
         int_to_bytes8(slot)
     )
-    persistent_committee = get_persistent_committee(state, shard, slot_to_epoch(slot))
+    persistent_committee = get_persistent_committee(state, shard, slot)
     # Default proposer
     index = bytes_to_int(seed[0:8]) % len(persistent_committee)
     # If default proposer exits, try the other proposers in order; if all are exited
     # return None (ie. no block can be proposed)
     validators_to_try = persistent_committee[index:] + persistent_committee[:index]
     for index in validators_to_try:
-        if is_active_validator(state.validators[index], get_current_epoch(state)):
+        if is_active_validator(state.validator_registry[index], get_current_epoch(state)):
             return index
     return None
 ```
@@ -233,14 +264,14 @@ To validate a block header on shard `shard_block.shard_id`, compute as follows:
 * Verify that `shard_block.beacon_chain_ref` is the hash of a block in the (canonical) beacon chain with slot less than or equal to `slot`.
 * Verify that `shard_block.beacon_chain_ref` is equal to or a descendant of the `shard_block.beacon_chain_ref` specified in the `ShardBlock` pointed to by `shard_block.parent_root`.
 * Let `state` be the state of the beacon chain block referred to by `shard_block.beacon_chain_ref`.
-* Let `persistent_committee = get_persistent_committee(state, shard_block.shard_id, slot_to_epoch(shard_block.slot))`.
+* Let `persistent_committee = get_persistent_committee(state, shard_block.shard_id, shard_block.slot)`.
 * Assert `verify_bitfield(shard_block.participation_bitfield, len(persistent_committee))`
-* For every `i in range(len(persistent_committee))` where `is_active_validator(state.validators[persistent_committee[i]], get_current_epoch(state))` returns `False`, verify that `get_bitfield_bit(shard_block.participation_bitfield, i) == 0`
+* For every `i in range(len(persistent_committee))` where `is_active_validator(state.validator_registry[persistent_committee[i]], get_current_epoch(state))` returns `False`, verify that `get_bitfield_bit(shard_block.participation_bitfield, i) == 0`
 * Let `proposer_index = get_shard_proposer_index(state, shard_block.shard_id, shard_block.slot)`.
 * Verify that `proposer_index` is not `None`.
 * Let `msg` be the `shard_block` but with `shard_block.signature` set to `[0, 0]`.
 * Verify that `bls_verify(pubkey=validators[proposer_index].pubkey, message_hash=hash(msg), signature=shard_block.signature, domain=get_domain(state, slot_to_epoch(shard_block.slot), DOMAIN_SHARD_PROPOSER))` passes.
-* Let `group_public_key = bls_aggregate_pubkeys([state.validators[index].pubkey for i, index in enumerate(persistent_committee) if get_bitfield_bit(shard_block.participation_bitfield, i) is True])`.
+* Let `group_public_key = bls_aggregate_pubkeys([state.validator_registry[index].pubkey for i, index in enumerate(persistent_committee) if get_bitfield_bit(shard_block.participation_bitfield, i) is True])`.
 * Verify that `bls_verify(pubkey=group_public_key, message_hash=shard_block.parent_root, sig=shard_block.aggregate_signature, domain=get_domain(state, slot_to_epoch(shard_block.slot), DOMAIN_SHARD_ATTESTER))` passes.
 
 ### Verifying shard block data

--- a/specs/validator/0_beacon-chain-validator.md
+++ b/specs/validator/0_beacon-chain-validator.md
@@ -331,16 +331,15 @@ signed_attestation_data = bls_sign(
 
 ## Validator assignments
 
-A validator can get the current and previous epoch committee assignments using the following helper via `get_committee_assignment(state, epoch, validator_index)` where `previous_epoch <= epoch <= current_epoch`.
+A validator can get the current, previous, and next epoch committee assignments using the following helper via `get_committee_assignment(state, epoch, validator_index)` where `previous_epoch <= epoch <= next_epoch`.
 
 ```python
 def get_committee_assignment(
         state: BeaconState,
         epoch: Epoch,
-        validator_index: ValidatorIndex,
-        registry_change: bool=False) -> Tuple[List[ValidatorIndex], Shard, Slot]:
+        validator_index: ValidatorIndex) -> Tuple[List[ValidatorIndex], Shard, Slot]:
     """
-    Return the committee assignment in the ``epoch`` for ``validator_index`` and ``registry_change``.
+    Return the committee assignment in the ``epoch`` for ``validator_index``.
     ``assignment`` returned is a tuple of the following form:
         * ``assignment[0]`` is the list of validators in the committee
         * ``assignment[1]`` is the shard to which the committee is assigned
@@ -355,7 +354,6 @@ def get_committee_assignment(
         crosslink_committees = get_crosslink_committees_at_slot(
             state,
             slot,
-            registry_change=registry_change,
         )
         selected_committees = [
             committee  # Tuple[List[ValidatorIndex], Shard]
@@ -389,18 +387,9 @@ _Note_: If a validator is assigned to the 0th slot of an epoch, the validator mu
 
 The beacon chain shufflings are designed to provide a minimum of 1 epoch lookahead on the validator's upcoming committee assignments for attesting dictated by the shuffling and slot. Note that this lookahead does not apply to proposing which must checked during the epoch in question.
 
-There are three possibilities for the shuffling at the next epoch:
-1. The shuffling changes due to a "validator registry change".
-2. The shuffling changes due to `epochs_since_last_registry_update` being an exact power of 2 greater than 1.
-3. The shuffling remains the same (i.e. the validator is in the same shard committee).
+`get_committee_assignment` should be called at the start of each epoch to get the assignment for the next epoch (`current_epoch + 1`). A validator should plan for future assignments which involves noting at which future slot one will have to attest and also which shard one should begin syncing (in phase 1+).
 
-Either (2) or (3) occurs if (1) fails. The choice between (2) and (3) is deterministic based upon `epochs_since_last_registry_update`.
-
-When querying for assignments in the next epoch there are two options -- with and without a `registry_change` -- which is the optional fourth parameter of the `get_committee_assignment`.
-
-`get_committee_assignment` should be called at the start of each epoch to get the assignment for the next epoch (`current_epoch + 1`). A validator should always plan for assignments from both values of `registry_change` unless the validator can concretely eliminate one of the options. Planning for future assignments involves noting at which future slot one might have to attest and also which shard one should begin syncing (in phase 1+).
-
-Specifically, a validator should call both `get_committee_assignment(state, next_epoch, validator_index, registry_change=True)` and `get_committee_assignment(state, next_epoch, validator_index, registry_change=False)` when checking for next epoch assignments.
+Specifically, a validator should call `get_committee_assignment(state, next_epoch, validator_index)` when checking for next epoch assignments.
 
 ## How to avoid slashing
 

--- a/tests/phase0/block_processing/test_process_attestation.py
+++ b/tests/phase0/block_processing/test_process_attestation.py
@@ -1,0 +1,67 @@
+from copy import deepcopy
+import pytest
+
+import build.phase0.spec as spec
+
+from build.phase0.state_transition import (
+    state_transition,
+)
+from build.phase0.spec import (
+    ZERO_HASH,
+    get_current_epoch,
+    process_attestation,
+    slot_to_epoch,
+)
+from tests.phase0.helpers import (
+    build_empty_block_for_next_slot,
+    get_valid_attestation,
+)
+
+
+# mark entire file as 'attestations'
+pytestmark = pytest.mark.attestations
+
+
+def run_attestation_processing(state, attestation, valid=True):
+    """
+    Run ``process_attestation`` returning the pre and post state.
+    If ``valid == False``, run expecting ``AssertionError``
+    """
+    post_state = deepcopy(state)
+
+    if not valid:
+        with pytest.raises(AssertionError):
+            process_attestation(post_state, attestation)
+        return state, None
+
+    process_attestation(post_state, attestation)
+
+    current_epoch = get_current_epoch(state)
+    target_epoch = slot_to_epoch(attestation.data.slot)
+    if target_epoch == current_epoch:
+        assert len(post_state.current_epoch_attestations) == len(state.current_epoch_attestations) + 1
+    else:
+        assert len(post_state.previous_epoch_attestations) == len(state.previous_epoch_attestations) + 1
+
+
+    return state, post_state
+
+
+def test_success(state):
+    attestation = get_valid_attestation(state)
+    state.slot += spec.MIN_ATTESTATION_INCLUSION_DELAY
+
+    pre_state, post_state = run_attestation_processing(state, attestation)
+
+    return pre_state, attestation, post_state
+
+
+def test_success_prevous_epoch(state):
+    attestation = get_valid_attestation(state)
+    block = build_empty_block_for_next_slot(state)
+    block.slot = state.slot + spec.SLOTS_PER_EPOCH
+    state_transition(state, block)
+
+    pre_state, post_state = run_attestation_processing(state, attestation)
+
+    return pre_state, attestation, post_state

--- a/tests/phase0/block_processing/test_process_attestation.py
+++ b/tests/phase0/block_processing/test_process_attestation.py
@@ -43,7 +43,6 @@ def run_attestation_processing(state, attestation, valid=True):
     else:
         assert len(post_state.previous_epoch_attestations) == len(state.previous_epoch_attestations) + 1
 
-
     return state, post_state
 
 


### PR DESCRIPTION
Removes the mechanism that only rotates committees if blocks have been finalized and every shard has been crosslinked or at exponentially decreasing intervals, and replaces it with a rule that shard committees can only progress a maximum of 64 epochs at a time to preserve the invariant that maximum possible work required per epoch for a validator is O(1).

This also fixes a bug in `process_crosslink` regarding the use of `previous_epoch`.