### PR TITLE
Replace custody challenge game with JABS

### DIFF
--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -1,4 +1,4 @@
-# Ethereum 2.0 Phase 1 -- Shard Data Chains
+# Ethereum 2.0 Phase 1 -- Shards Data Chains
 
 __NOTICE__: This document is a work-in-progress for researchers and implementers.
 
@@ -6,7 +6,7 @@ __NOTICE__: This document is a work-in-progress for researchers and implementers
 
 <!-- TOC -->
 
-- [Ethereum 2.0 Phase 1 -- Shard Data Chains](#ethereum-20-phase-1----shard-data-chains)
+- [Ethereum 2.0 Phase 1 -- Shards Data Chains](#ethereum-20-phase-1----shard-data-chains)
     - [Table of Contents](#table-of-contents)
     - [Introduction](#introduction)
     - [Constants](#constants)
@@ -28,7 +28,7 @@ __NOTICE__: This document is a work-in-progress for researchers and implementers
 
 ## Introduction
 
-This document represents the expected behavior of an "honest validator" with respect to Phase 1 of the Ethereum 2.0 protocol.
+This document document the shard fork choice rule in Phase 1 of Ethereum 2.0.
 
 ## Constants
 

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -155,7 +155,7 @@ def get_shuffled_committee(state: BeaconState,
         shard * committee_count + index + 1,
     )
     return [
-        active_validator_indices[get_permuted_index(i, length, seed)]
+        active_validator_indices[get_permuted_index(index, length, seed)]
         for i in range(start_offset, end_offset)
     ]
 ```
@@ -185,10 +185,7 @@ def get_persistent_committee(state: BeaconState,
     later_committee = get_shuffled_committee(state, shard, later_start_epoch, index, committee_count)
 
     def get_switchover_epoch(index):
-        return (
-            bytes_to_int(hash(earlier_seed + bytes3(index))[0:8]) %
-            PERSISTENT_COMMITTEE_PERIOD
-        )
+        return bytes_to_int(hash(earlier_seed + bytes3(index))[0:8]) % PERSISTENT_COMMITTEE_PERIOD
 
     # Take not-yet-cycled-out validators from earlier committee and already-cycled-in validators from
     # later committee; return a sorted list of the union of the two, deduplicated

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -1,141 +1,45 @@
-# Ethereum 2.0 Phase 1 -- Shard Data Chains
+# Ethereum 2.0 Phase 1 -- Shards Data Chains
 
-**NOTICE**: This document is a work-in-progress for researchers and implementers. It reflects recent spec changes and takes precedence over the [Python proof-of-concept implementation](https://github.com/ethereum/beacon_chain).
+__NOTICE__: This document is a work-in-progress for researchers and implementers.
 
-At the current stage, Phase 1, while fundamentally feature-complete, is still subject to change. Development teams with spare resources may consider starting on the "Shard chains and crosslink data" section; at least basic properties, such as the fact that a shard block can get created every slot and is dependent on both a parent block in the same shard and a beacon chain block at or before that same slot, are unlikely to change, though details are likely to undergo similar kinds of changes to what Phase 0 has undergone since the start of the year.
-
-## Table of contents
+## Table of Contents
 
 <!-- TOC -->
 
-- [Ethereum 2.0 Phase 1 -- Shard Data Chains](#ethereum-20-phase-1----shard-data-chains)
-    - [Table of contents](#table-of-contents)
+- [Ethereum 2.0 Phase 1 -- Shards Data Chains](#ethereum-20-phase-1----shard-data-chains)
+    - [Table of Contents](#table-of-contents)
     - [Introduction](#introduction)
     - [Constants](#constants)
-        - [Misc](#misc)
         - [Time parameters](#time-parameters)
-        - [Max transactions per block](#max-transactions-per-block)
-        - [Signature domains](#signature-domains)
     - [Data structures](#data-structures)
-        - [Phase 0 object updates](#phase-0-object-updates)
-            - [`Validator`](#validator)
-            - [`BeaconBlockBody`](#beaconblockbody)
-            - [`BeaconState`](#beaconstate)
-        - [Shard blocks](#shard-blocks)
-            - [`ShardBlock`](#shardblock)
-            - [`ShardBlockHeader`](#shardblockheader)
-            - [`ShardAttestation`](#shardattestation)
-        - [Custody objects](#custody-objects)
-            - [`DataChallenge`](#datachallenge)
-            - [`DataChallengeRecord`](#datachallengerecord)
-            - [`CustodyChallenge`](#custodychallenge)
-            - [`CustodyChallengeRecord`](#custodychallengerecord)
-            - [`BranchResponse`](#branchresponse)
-            - [`SubkeyReveal`](#subkeyreveal)
-    - [Shard chains and crosslink data](#shard-chains-and-crosslink-data)
-        - [Helper functions](#helper-functions)
-            - [`get_period_committee`](#get_period_committee)
-            - [`get_persistent_committee`](#get_persistent_committee)
-            - [`get_shard_proposer_index`](#get_shard_proposer_index)
-        - [Shard fork choice rule](#shard-fork-choice-rule)
-        - [Shard attestation processing](#shard-attestation-processing)
-    - [Updates to the beacon chain](#updates-to-the-beacon-chain)
-        - [Helpers](#helpers)
-            - [`get_attestation_crosslink_length`](#get_attestation_crosslink_length)
-            - [`get_mix_length_from_attestation`](#get_mix_length_from_attestation)
-            - [`epoch_to_custody_period`](#epoch_to_custody_period)
-            - [`slot_to_custody_period`](#slot_to_custody_period)
-            - [`get_current_custody_period`](#get_current_custody_period)
-            - [`verify_custody_subkey_reveal`](#verify_custody_subkey_reveal)
-            - [`slash_validator`](#slash_validator)
-        - [Per-block processing](#per-block-processing)
-            - [Transactions](#transactions)
-                - [Data challenges](#data-challenges)
-                - [Subkey reveals](#subkey-reveals)
-                - [Custody challenges](#custody-challenges)
-                - [Branch responses](#branch-responses)
-        - [Per-epoch processing](#per-epoch-processing)
-        - [One-time phase 1 initiation transition](#one-time-phase-1-initiation-transition)
+        - [`ShardBlock`](#shardblock)
+        - [`ShardBlockHeader`](#shardblockheader)
+        - [`ShardAttestation`](#shardattestation)
+    - [Helper functions](#helper-functions)
+        - [`get_period_committee`](#get_period_committee)
+        - [`get_persistent_committee`](#get_persistent_committee)
+        - [`get_shard_proposer_index`](#get_shard_proposer_index)
+    - [Crosslink data root](#crosslink-data-root)
+    - [Shard fork choice rule](#shard-fork-choice-rule)
+    - [Shard attestation processing](#shard-attestation-processing)
 
 <!-- /TOC -->
 
 ## Introduction
 
-This document represents the specification for Phase 1 of Ethereum 2.0 -- Shard Data Chains, building upon the [phase 0](0_beacon-chain.md) specification.
-
-Ethereum 2.0 consists of a central beacon chain along with `SHARD_COUNT` shards. Phase 1 is primarily concerned with the construction, validity, and consensus on the _data_ of these shard chains. Phase 1 does not specify shard chain state execution or account balances. This is left for future phases.
+This document represents the expected behavior of an "honest validator" with respect to Phase 1 of the Ethereum 2.0 protocol.
 
 ## Constants
-
-### Misc
-
-| Name | Value |
-| - | - |
-| `BYTES_PER_SHARD_BLOCK` | `2**14` (= 16,384) |
-| `BYTES_PER_MIX_CHUNK` | `2**9` (= 512) |
-| `MINOR_REWARD_QUOTIENT` | `2**8` (= 256) |
-| `EMPTY_PUBKEY` | `int_to_bytes48(0)` |
 
 ### Time parameters
 
 | Name | Value | Unit | Duration |
 | - | - | :-: | :-: |
-| `MAX_DATA_CHALLENGE_DELAY` | 2**11 (= 2,048) | epochs | ~9 days |
-| `CUSTODY_PERIOD_LENGTH` | 2**11 (= 2,048) | epochs | ~9 days |
-| `PERSISTENT_COMMITTEE_PERIOD` | 2**11 (= 2,048) | epochs | ~9 days |
-| `CHALLENGE_RESPONSE_DEADLINE` | 2**14 (= 16,384) | epochs | ~73 days |
-
-### Max transactions per block
-
-| Name | Value |
-| - | - |
-| `MAX_DATA_CHALLENGES` | `2**2` (= 4) |
-| `MAX_CUSTODY_CHALLENGES` | `2**1` (= 2) |
-| `MAX_BRANCH_RESPONSES` | `2**5` (= 32) |
-| `MAX_EARLY_SUBKEY_REVEALS` | `2**4` (= 16) |
-
-### Signature domains
-
-| Name | Value |
-| - | - |
-| `DOMAIN_SHARD_PROPOSER` | `129` |
-| `DOMAIN_SHARD_ATTESTER` | `130` |
-| `DOMAIN_CUSTODY_SUBKEY` | `131` |
-| `DOMAIN_CUSTODY_CHALLENGE` | `132` |
+| `CROSSLINK_LOOKBACK` | 2**5 (= 32) | slots  | 3.2 minutes |
 
 ## Data structures
 
-### Phase 0 object updates
-
-Add the following fields to the end of the specified container objects.
-
-#### `Validator`
-
-```python
-    'next_subkey_to_reveal': 'uint64',
-    'max_reveal_lateness': 'uint64',
-```
-
-#### `BeaconBlockBody`
-
-```python
-    'data_challenges': [DataChallenge],
-    'custody_challenges': [CustodyChallenge],
-    'branch_responses': [BranchResponse],
-    'subkey_reveals': [SubkeyReveal],
-```
-
-#### `BeaconState`
-
-```python
-    'data_challenge_records': [DataChallengeRecord],
-    'custody_challenge_records': [CustodyChallengeRecord],
-    'challenge_index': 'uint64',
-```
-
-### Shard blocks
-
-#### `ShardBlock`
+### `ShardBlock`
 
 ```python
 {
@@ -149,7 +53,7 @@ Add the following fields to the end of the specified container objects.
 }
 ```
 
-#### `ShardBlockHeader`
+### `ShardBlockHeader`
 
 ```python
 {
@@ -163,7 +67,7 @@ Add the following fields to the end of the specified container objects.
 }
 ```
 
-#### `ShardAttestation`
+### `ShardAttestation`
 
 ```python
 {
@@ -173,87 +77,9 @@ Add the following fields to the end of the specified container objects.
 }
 ```
 
-### Custody objects
+## Helper functions
 
-#### `DataChallenge`
-
-```python
-{
-    'responder_index': 'uint64',
-    'data_index': 'uint64',
-    'attestation': SlashableAttestation,
-}
-```
-
-#### `DataChallengeRecord`
-
-```python
-{
-    'challenge_id': 'uint64',
-    'challenger_index': 'uint64',
-    'responder_index': 'uint64',
-    'data_root': 'bytes32',
-    'deadline': 'uint64',
-    'depth': 'uint64',
-    'data_index': 'uint64',
-}
-```
-
-#### `CustodyChallenge`
-
-```python
-{
-    'attestation': SlashableAttestation,
-    'challenger_index': 'uint64',
-    'responder_index': 'uint64',
-    'responder_subkey': 'bytes96',
-    'mix': 'bytes',
-    'signature': 'bytes96',
-}
-```
-
-#### `CustodyChallengeRecord`
-
-```python
-{
-    'challenge_id': 'uint64',
-    'challenger_index': 'uint64',
-    'responder_index': 'uint64',
-    'data_root': 'bytes32',
-    'deadline': 'uint64',
-    'challenge_mix': 'bytes',
-    'responder_subkey': 'bytes96',
-}
-```
-
-#### `BranchResponse`
-
-```python
-{
-    'challenge_id': 'uint64',
-    'data': ['byte', BYTES_PER_MIX_CHUNK],
-    'branch': ['bytes32'],
-    'data_index': 'uint64',
-}
-```
-
-#### `SubkeyReveal`
-
-```python
-{
-    'revealer_index': 'uint64',
-    'period': 'uint64',
-    'subkey': 'bytes96',
-    'masker_index': 'uint64'
-    'mask': 'bytes32',
-}
-```
-
-## Shard chains and crosslink data
-
-### Helper functions
-
-#### `get_period_committee`
+### `get_period_committee`
 
 ```python
 def get_period_committee(state: BeaconState,
@@ -269,7 +95,7 @@ def get_period_committee(state: BeaconState,
     return compute_committee(active_validator_indices, seed, shard * committee_count + index, SHARD_COUNT * committee_count)
 ```
 
-#### `get_persistent_committee`
+### `get_persistent_committee`
 
 ```python
 def get_persistent_committee(state: BeaconState,
@@ -303,7 +129,7 @@ def get_persistent_committee(state: BeaconState,
     )))
 ```
 
-#### `get_shard_proposer_index`
+### `get_shard_proposer_index`
 
 ```python
 def get_shard_proposer_index(state: BeaconState,
@@ -324,7 +150,49 @@ def get_shard_proposer_index(state: BeaconState,
     return None
 ```
 
-### Shard fork choice rule
+## Crosslink data root
+
+A node should only sign an `attestation` if `attestation.crosslink_data_root` has been reccursively verified for availability using `attestation.previous_crosslink.crosslink_data_root` up to genesis where `crosslink_data_root == ZERO_HASH`.
+
+Let `store` be the store of observed block headers and bodies and let `get_shard_block_header(store, slot)` and `get_shard_block_body(store, slot)` return the canonical shard block header and body at the specified `slot`. The expected `get_shard_block_body` is then computed as:
+
+```python
+def compute_crosslink_data_root(state: BeaconState, store: Store) -> Bytes32:
+    start_slot = state.latest_crosslinks[shard].epoch * SLOTS_PER_EPOCH + SLOTS_PER_EPOCH - CROSSLINK_LOOKBACK
+    end_slot = attestation.data.slot - attestation.data.slot % SLOTS_PER_EPOCH - CROSSLINK_LOOKBACK
+
+    headers = []
+    bodies = []
+    for slot in range(start_slot, end_slot):
+        headers = get_shard_block_header(store, slot)
+        bodies = get_shard_block_body(store, slot)
+
+    return hash(
+        merkle_root(pad_to_power_of_2([
+            merkle_root_of_bytes(zpad(serialize(header), BYTES_PER_SHARD_BLOCK)) for header in headers
+        ])) +
+        merkle_root(pad_to_power_of_2([
+                merkle_root_of_bytes(body) for body in bodies
+        ]))
+    )
+```
+
+using the following helpers:
+
+```python
+def is_power_of_two(value: int) -> bool:
+    return (value > 0) and (value & (value - 1) == 0)
+
+def pad_to_power_of_2(values: List[bytes]) -> List[bytes]:
+    while not is_power_of_two(len(values)):
+        values += [b'\x00' * BYTES_PER_SHARD_BLOCK]
+    return values
+
+def merkle_root_of_bytes(data: bytes) -> bytes:
+    return merkle_root([data[i:i + 32] for i in range(0, len(data), 32)])
+```
+
+## Shard fork choice rule
 
 For a `ShardBlockHeader` object `header` to be processed by a node the following conditions must be met:
 
@@ -335,7 +203,7 @@ For a `ShardBlockHeader` object `header` to be processed by a node the following
 
 The fork choice rule for any shard is LMD GHOST using the shard chain attestations of the persistent committee and the beacon chain attestations of the crosslink committee currently assigned to that shard, but instead of being rooted in the genesis it is rooted in the block referenced in the most recent accepted crosslink (i.e. `state.crosslinks[shard].shard_block_root`). Only blocks whose `beacon_chain_root` is the block in the main beacon chain at the specified `slot` should be considered. (If the beacon chain skips a slot, then the block at that slot is considered to be the block in the beacon chain at the highest slot lower than a slot.)
 
-### Shard attestation processing
+## Shard attestation processing
 
 Given a `shard_attestation` let `state` be the `BeaconState` referred to by `shard_attestation.header.beacon_chain_root` and run `verify_shard_attestation(state, shard_attestation)`.
 
@@ -368,363 +236,4 @@ def verify_shard_attestation(state: BeaconState, shard_attestation: ShardAttesta
         signature=shard_attestation.aggregate_signature,
         domain=get_domain(state, slot_to_epoch(header.slot), DOMAIN_SHARD_ATTESTER)
     )
-```
-
-## Updates to the beacon chain
-
-### Helpers
-
-#### `get_attestation_crosslink_length`
-
-```python
-def get_attestation_crosslink_length(attestation: Attestation) -> int:
-    start_epoch = attestation.data.latest_crosslink.epoch
-    end_epoch = slot_to_epoch(attestation.data.slot)
-    return min(MAX_CROSSLINK_EPOCHS, end_epoch - start_epoch)
-```
-
-#### `get_mix_length_from_attestation`
-
-```python
-def get_mix_length_from_attestation(attestation: Attestation) -> int:
-    chunks_per_slot = BYTES_PER_SHARD_BLOCK // BYTES_PER_MIX_CHUNK
-    return get_attestation_crosslink_length(attestation) * EPOCH_LENGTH * chunks_per_slot
-```
-
-#### `epoch_to_custody_period`
-
-```python
-def epoch_to_custody_period(epoch: Epoch) -> int:
-    return epoch // CUSTODY_PERIOD_LENGTH
-```
-
-#### `slot_to_custody_period`
-
-```python
-def slot_to_custody_period(slot: Slot) -> int:
-    return epoch_to_custody_period(slot_to_epoch(slot))
-```
-
-#### `get_current_custody_period`
-
-```python
-def get_current_custody_period(state: BeaconState) -> int:
-    return epoch_to_custody_period(get_current_epoch(state))
-```
-
-#### `verify_custody_subkey_reveal`
-
-```python
-def verify_custody_subkey_reveal(state: BeaconState,
-                                 reveal: SubkeyReveal) -> bool
-    # Case 1: legitimate reveal
-    pubkeys = [state.validator_registry[reveal.revealer_index].pubkey]
-    message_hashes = [hash_tree_root(reveal.period)]
-
-    # Case 2: masked punitive early reveal
-    # Masking prevents proposer stealing the whistleblower reward
-    # Secure under the aggregate extraction infeasibility assumption
-    # See pages 11-12 of https://crypto.stanford.edu/~dabo/pubs/papers/aggreg.pdf
-    if reveal.mask != ZERO_HASH:
-        pubkeys.append(state.validator_registry[reveal.masker_index].pubkey)
-        message_hashes.append(reveal.mask)
-
-    return bls_verify_multiple(
-        pubkeys=pubkeys,
-        message_hashes=message_hashes,
-        signature=reveal.subkey,
-        domain=get_domain(
-            fork=state.fork,
-            epoch=reveal.period * CUSTODY_PERIOD_LENGTH,
-            domain_type=DOMAIN_CUSTODY_SUBKEY,
-        ),
-    )
-```
-
-#### `slash_validator`
-
-Change the definition of `slash_validator` as follows:
-
-```python
-def slash_validator(state: BeaconState, index: ValidatorIndex, whistleblower_index :ValidatorIndex=None) -> None:
-    """
-    Slash the validator of the given ``index``.
-    Note that this function mutates ``state``.
-    """
-    exit_validator(state, index)
-    validator = state.validator_registry[index]
-    state.latest_slashed_balances[get_current_epoch(state) % LATEST_PENALIZED_EXIT_LENGTH] += get_effective_balance(state, index)
-    
-    proposer_index = get_beacon_proposer_index(state, state.slot)
-    whistleblower_reward = get_effective_balance(state, index) // WHISTLEBLOWER_REWARD_QUOTIENT
-    if whistleblower_index is None:
-        increase_balance(state, proposer_index, whistleblower_reward)
-    else:
-        proposer_share = whistleblower_reward // INCLUDER_REWARD_QUOTIENT  # TODO: Define INCLUDER_REWARD_QUOTIENT
-        increase_balance(state, proposer_index, proposer_share)
-        increase_balance(state, whistleblower_index, whistleblower_reward - proposer_share)
-
-    decrease_balance(state, index, whistleblower_reward)        
-    validator.slashed_epoch = get_current_epoch(state)
-    validator.withdrawable_epoch = get_current_epoch(state) + LATEST_PENALIZED_EXIT_LENGTH
-```
-
-The only change is that this introduces the possibility of a penalization where the "whistleblower" that takes credit is NOT the block proposer.
-
-### Per-block processing
-
-#### Transactions
-
-Add the following transactions to the per-block processing, in order the given below and after all other transactions in phase 0.
-
-##### Data challenges
-
-Verify that `len(block.body.data_challenges) <= MAX_DATA_CHALLENGES`.
-
-For each `challenge` in `block.body.data_challenges`, run the following function:
-
-```python
-def process_data_challenge(state: BeaconState,
-                           challenge: DataChallenge) -> None:
-    # Check it is not too late to challenge
-    assert slot_to_epoch(challenge.attestation.data.slot) >= get_current_epoch(state) - MAX_DATA_CHALLENGE_DELAY
-    assert state.validator_registry[responder_index].exit_epoch >= get_current_epoch(state) - MAX_DATA_CHALLENGE_DELAY
-    # Check the attestation is valid
-    assert verify_slashable_attestation(state, challenge.attestation)
-    # Check the responder participated
-    assert challenger.responder_index in challenge.attestation.validator_indices
-    # Check the challenge is not a duplicate
-    for c in state.data_challenge_records:
-        assert c.data_root != challenge.attestation.data.crosslink_data_root or c.data_index == challenge.data_index
-    # Check validity of depth
-    depth = log2(next_power_of_two(get_mix_length_from_attestation(challenge.attestation)))
-    assert challenge.data_index < 2**depth
-    # Add new data challenge record
-    state.data_challenge_records.append(DataChallengeRecord(
-        challenge_id=state.challenge_index,
-        challenger_index=get_beacon_proposer_index(state, state.slot),
-        data_root=challenge.attestation.data.compute_crosslink_data_root,
-        depth=depth,
-        deadline=get_current_epoch(state) + CHALLENGE_RESPONSE_DEADLINE,
-        data_index=challenge.data_index,
-    ))
-    state.challenge_index += 1
-```
-
-##### Subkey reveals
-
-Verify that `len(block.body.early_subkey_reveals) <= MAX_EARLY_SUBKEY_REVEALS`.
-
-For each `reveal` in `block.body.early_subkey_reveals`, run the following function:
-
-```python
-def process_subkey_reveal(state: BeaconState,
-                          reveal: SubkeyReveal) -> None:
-    assert verify_custody_subkey_reveal(reveal)
-    revealer = state.validator_registry[reveal.revealer_index]
-
-    # Case 1: non-early non-punitive non-masked reveal
-    if reveal.mask == ZERO_HASH:
-        assert reveal.period == revealer.next_subkey_to_reveal
-        # Revealer is active or exited
-        assert is_active_validator(revealer) or revealer.exit_epoch > get_current_epoch(state)
-        revealer.next_subkey_to_reveal += 1
-        revealer.max_reveal_lateness = max(revealer.max_reveal_lateness, get_current_period(state) - reveal.period)
-
-    # Case 2: Early punitive masked reveal
-    else:
-        assert reveal.period > get_current_custody_period(state)
-        assert revealer.slashed is False
-        slash_validator(state, reveal.revealer_index, reveal.masker_index)
-        increase_balance(state, reveal.masker_index, base_reward(state, index) // MINOR_REWARD_QUOTIENT)
-
-    proposer_index = get_beacon_proposer_index(state, state.slot)
-    increase_balance(state, proposer_index, base_reward(state, index) // MINOR_REWARD_QUOTIENT)
-
-```
-
-##### Custody challenges
-
-Verify that `len(block.body.custody_challenges) <= MAX_CUSTODY_CHALLENGES`.
-
-For each `challenge` in `block.body.custody_challenges`, run the following function:
-
-```python
-def process_custody_challenge(state: BeaconState,
-                      challenge: CustodyChallenge) -> None:
-    challenger = state.validator_registry[challenge.challenger_index]
-    responder = state.validator_registry[challenge.responder_index]
-    # Verify the challenge signature
-    assert bls_verify(
-        message_hash=signed_root(challenge),
-        pubkey=challenger.pubkey,
-        signature=challenge.signature,
-        domain=get_domain(state, get_current_epoch(state), DOMAIN_CUSTODY_CHALLENGE)
-    )
-    # Verify the challenged attestation
-    assert verify_slashable_attestation(challenge.attestation, state)
-    # Check the responder participated in the attestation
-    assert challenge.responder_index in attestation.validator_indices
-    # A validator can be the challenger or responder for at most one challenge at a time
-    for challenge_record in state.custody_challenge_records:
-        assert challenge_record.challenger_index != challenge.challenger_index
-        assert challenge_record.responder_index != challenge.responder_index
-    # Cannot challenge if slashed
-    assert challenger.slashed is False
-    # Verify the revealed subkey
-    assert verify_custody_subkey_reveal(SubkeyReveal(
-        revealer_index=challenge.responder_index,
-        period=slot_to_custody_period(attestation.data.slot),
-        subkey=challenge.responder_subkey,
-    ))
-    # Verify that the attestation is still eligible for challenging
-    min_challengeable_epoch = responder.exit_epoch - CUSTODY_PERIOD_LENGTH * (1 + responder.max_reveal_lateness)
-    assert min_challengeable_epoch <= slot_to_epoch(challenge.attestation.data.slot) 
-    # Verify the mix's length and that its last bit is the opposite of the custody bit
-    mix_length = get_mix_length_from_attestation(challenge.attestation)
-    verify_bitfield(challenge.mix, mix_length)
-    custody_bit = get_bitfield_bit(attestation.custody_bitfield, attestation.validator_indices.index(responder_index))
-    assert custody_bit != get_bitfield_bit(challenge.mix, mix_length - 1)
-    # Create a new challenge record
-    state.custody_challenge_records.append(CustodyChallengeRecord(
-        challenge_id=state.challenge_index,
-        challenger_index=challenge.challenger_index,
-        responder_index=challenge.responder_index,
-        data_root=challenge.attestation.crosslink_data_root,
-        challenge_mix=challenge.mix,
-        responder_subkey=responder_subkey,
-        deadline=get_current_epoch(state) + CHALLENGE_RESPONSE_DEADLINE
-    ))
-    state.challenge_index += 1
-    # Postpone responder withdrawability
-    state.validator_registry[responder_index].withdrawable_epoch = FAR_FUTURE_EPOCH
-```
-
-##### Branch responses
-
-Verify that `len(block.body.branch_responses) <= MAX_BRANCH_RESPONSES`.
-
-For each `response` in `block.body.branch_responses`, run the following function:
-
-```python
-def process_branch_response(state: BeaconState,
-                            response: BranchResponse) -> None:
-    data_challenge = next(c for c in state.data_challenge_records if c.challenge_id == response.challenge_id, None)
-    if data_challenge is not None:
-        return process_data_challenge_response(state, response, data_challenge)
-
-    custody_challenge = next(c for c in state.custody_challenge_records if c.challenge_id == response.challenge_id, None)
-    if custody_challenge is not None:
-        return process_custody_challenge_response(state, response, custody_challenge)
-
-    assert False
-```
-
-```python
-def process_data_challenge_response(state: BeaconState,
-                                    response: BranchResponse,
-                                    challenge: DataChallengeRecord) -> None:
-    assert verify_merkle_branch(
-        leaf=hash_tree_root(response.data),
-        branch=response.branch,
-        depth=challenge.depth,
-        index=challenge.data_index,
-        root=challenge.data_root,
-    )
-    # Check data index
-    assert response.data_index == challenge.data_index
-    # Must wait at least ENTRY_EXIT_DELAY before responding to a branch challenge
-    assert get_current_epoch(state) >= challenge.inclusion_epoch + ENTRY_EXIT_DELAY
-    state.data_challenge_records.remove(challenge)
-    # Reward the proposer
-    proposer_index = get_beacon_proposer_index(state, state.slot)
-    increase_balance(state, proposer_index, base_reward(state, index) // MINOR_REWARD_QUOTIENT)
-```
-
-A response to a custody challenge proves that a challenger's mix is invalid by pointing to an index where the mix is incorrect.
-
-```python
-def process_custody_challenge_response(state: BeaconState,
-                                       response: BranchResponse,
-                                       challenge: CustodyChallengeRecord) -> None:
-    responder = state.validator_registry[challenge.responder_index]
-    # Check the data index is valid
-    assert response.data_index < len(challenge.mix)
-    # Check the provided data is part of the attested data
-    assert verify_merkle_branch(
-        leaf=hash_tree_root(response.data),
-        branch=response.branch,
-        depth=log2(next_power_of_two(len(challenge.mix))),
-        index=response.data_index,
-        root=challenge.data_root,
-    )
-    # Check the mix bit (assert the response identified an invalid data index in the challenge)
-    mix_bit = get_bitfield_bit(hash(challenge.responder_subkey + response.data), 0)
-    previous_bit = 0 if response.data_index == 0 else get_bitfield_bit(challenge.mix, response.data_index - 1)
-    next_bit = get_bitfield_bit(challenge.mix, response.data_index)
-    assert previous_bit ^ mix_bit != next_bit
-    # Resolve the challenge in the responder's favor
-    slash_validator(state, challenge.challenger_index, challenge.responder_index)
-    state.custody_challenge_records.remove(challenge)
-```
-
-### Per-epoch processing
-
-Add the following loop immediately below the `process_ejections` loop:
-
-```python
-def process_challenge_deadlines(state: BeaconState) -> None:
-    """
-    Iterate through the challenges and slash validators that missed their deadline.
-    """
-    for challenge in state.data_challenge_records:
-        if get_current_epoch(state) > challenge.deadline:
-            slash_validator(state, challenge.responder_index, challenge.challenger_index)
-            state.data_challenge_records.remove(challenge)
-
-    for challenge in state.custody_challenge_records:
-        if get_current_epoch(state) > challenge.deadline:
-            slash_validator(state, challenge.responder_index, challenge.challenger_index)
-            state.custody_challenge_records.remove(challenge)
-        elif get_current_epoch(state) > state.validator_registry[challenge.responder_index].withdrawable_epoch:
-            slash_validator(state, challenge.challenger_index, challenge.responder_index)
-            state.custody_challenge_records.remove(challenge)
-```
-
-In `process_penalties_and_exits`, change the definition of `eligible` to the following (note that it is not a pure function because `state` is declared in the surrounding scope):
-
-```python
-def eligible(index):
-    validator = state.validator_registry[index]
-    # Cannot exit if there are still open data challenges
-    if len([c for c in state.data_challenge_records if c.responder_index == index]) > 0:
-        return False
-    # Cannot exit if you have not revealed all of your subkeys
-    elif validator.next_subkey_to_reveal <= epoch_to_custody_period(validator.exit_epoch):
-        return False
-    # Cannot exit if you already have
-    elif validator.withdrawable_epoch < FAR_FUTURE_EPOCH:
-        return False
-    # Return minimum time
-    else:
-        return current_epoch >= validator.exit_epoch + MIN_VALIDATOR_WITHDRAWAL_EPOCHS
-```
-
-### One-time phase 1 initiation transition
-
-Run the following on the fork block after per-slot processing and before per-block and per-epoch processing.
-
-For all `validator` in `ValidatorRegistry`, update it to the new format and fill the new member values with:
-
-```python
-    'next_subkey_to_reveal': get_current_custody_period(state),
-    'max_reveal_lateness': 0,
-```
-
-Update the `BeaconState` to the new format and fill the new member values with:
-
-```python
-    'data_challenge_records': [],
-    'custody_challenge_records': [],
-    'challenge_index': 0,
 ```

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -297,10 +297,13 @@ def is_valid_shard_block(beacon_blocks: List[BeaconBlock],
     if block.slot == PHASE_1_GENESIS_SLOT:
         assert candidate.previous_block_root == ZERO_HASH
     else:
-        parent = next(block for block in valid_shard_blocks if signed_root(block) == candidate.previous_block_root, None)
-        assert parent != None
-        assert parent.shard == block.shard and parent.slot < block.slot
-        assert signed_root(beacon_blocks[parent.slot]) == parent.beacon_chain_root
+        parent_block = next(
+            block for block in valid_shard_blocks if
+            signed_root(block) == candidate.previous_block_root
+        , None)
+        assert parent_block != None
+        assert parent_block.shard == block.shard and parent_block.slot < block.slot
+        assert signed_root(beacon_blocks[parent_block.slot]) == parent_block.beacon_chain_root
 
     # Check attestations
     assert len(block.attestations) <= MAX_SHARD_ATTESTIONS
@@ -335,10 +338,13 @@ def is_valid_shard_attestation(valid_shard_blocks: List[ShardBlock],
                                beacon_state: BeaconState,
                                candidate: Attestation) -> bool:
     # Check shard block
-    block = next(block for block in valid_shard_blocks if signed_root(block) == candidate.attestation.data.shard_block_root, None)
-    assert block != None
-    assert block.slot == attestation.data.slot
-    assert block.shard == attestation.data.shard
+    shard_block = next(
+        block for block in valid_shard_blocks if
+        signed_root(block) == candidate.attestation.data.shard_block_root
+    , None)
+    assert shard_block != None
+    assert shard_block.slot == attestation.data.slot
+    assert shard_block.shard == attestation.data.shard
 
     # Check signature
     verify_shard_attestation_signature(beacon_state, attestation)

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -34,7 +34,6 @@ At the current stage, Phase 1, while fundamentally feature-complete, is still su
             - [`SubkeyReveal`](#subkeyreveal)
     - [Shard chains and crosslink data](#shard-chains-and-crosslink-data)
         - [Helper functions](#helper-functions)
-            - [`get_split_offset`](#get_split_offset)
             - [`get_period_committee`](#get_period_committee)
             - [`get_persistent_committee`](#get_persistent_committee)
             - [`get_shard_proposer_index`](#get_shard_proposer_index)
@@ -255,17 +254,6 @@ Add the following fields to the end of the specified container objects.
 ## Shard chains and crosslink data
 
 ### Helper functions
-
-#### `get_split_offset`
-
-````python
-def get_split_offset(list_size: int, chunks: int, index: int) -> int:
-    """
-    Returns a value such that for a list L, chunk count k and index i,
-    split(L, k)[i] == L[get_split_offset(len(L), k, i): get_split_offset(len(L), k, i + 1)]
-    """
-    return (list_size * index) // chunks
-````
 
 #### `get_period_committee`
 

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -38,7 +38,6 @@ At the current stage, Phase 1, while fundamentally feature-complete, is still su
         - [`BranchResponse`](#branchresponse)
         - [`BranchChallengeRecord`](#branchchallengerecord)
         - [`InteractiveCustodyChallengeRecord`](#interactivecustodychallengerecord)
-        - [`InteractiveCustodyChallengeInitiation`](#interactivecustodychallengeinitiation)
         - [`InteractiveCustodyChallengeResponse`](#interactivecustodychallengeresponse)
         - [`SubkeyReveal`](#subkeyreveal)
     - [Helpers](#helpers)

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -102,9 +102,8 @@ Phase 1 depends upon all of the constants defined in [Phase 0](0_beacon-chain.md
 | `MAX_BRANCH_CHALLENGES`                            | 2**2 (= 4)    |
 | `MAX_BRANCH_RESPONSES`                             | 2**4 (= 16)   |
 | `MAX_EARLY_SUBKEY_REVEALS`                         | 2**4 (= 16)   |
-| `MAX_INTERACTIVE_CUSTODY_CHALLENGE_INITIATIONS`    | 2             |
+| `MAX_INTERACTIVE_CUSTODY_CHALLENGE_CHS`    | 2             |
 | `MAX_INTERACTIVE_CUSTODY_CHALLENGE_RESPONSES`      | 16            |
-| `MAX_INTERACTIVE_CUSTODY_CHALLENGE_CONTINUTATIONS` | 16            |
 
 #### Signature domains
 
@@ -676,7 +675,7 @@ For each `reveal` in `block.body.early_subkey_reveals`:
 
 In case (i):
 
-* Verify that `state.validator_registry[reveal.validator_index].penalized_epoch > get_current_epoch(state).
+* Verify that `state.validator_registry[reveal.validator_index].penalized_epoch > get_current_epoch(state)`.
 * Run `penalize_validator(state, reveal.validator_index, reveal.revealer_index)`.
 * Set `state.validator_balances[reveal.revealer_index] += base_reward(state, index) // MINOR_REWARD_QUOTIENT`
 

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -40,7 +40,6 @@ At the current stage, Phase 1, while fundamentally feature-complete, is still su
         - [`InteractiveCustodyChallengeRecord`](#interactivecustodychallengerecord)
         - [`InteractiveCustodyChallengeInitiation`](#interactivecustodychallengeinitiation)
         - [`InteractiveCustodyChallengeResponse`](#interactivecustodychallengeresponse)
-        - [`InteractiveCustodyChallengeContinuation`](#interactivecustodychallengecontinuation)
         - [`SubkeyReveal`](#subkeyreveal)
     - [Helpers](#helpers)
         - [`get_branch_challenge_record_by_id`](#get_branch_challenge_record_by_id)
@@ -58,7 +57,6 @@ At the current stage, Phase 1, while fundamentally feature-complete, is still su
             - [Subkey reveals](#subkey-reveals)
             - [Interactive custody challenge initiations](#interactive-custody-challenge-initiations)
             - [Interactive custody challenge responses](#interactive-custody-challenge-responses)
-            - [Interactive custody challenge continuations](#interactive-custody-challenge-continuations)
     - [Per-epoch processing](#per-epoch-processing)
     - [One-time phase 1 initiation transition](#one-time-phase-1-initiation-transition)
 
@@ -363,8 +361,6 @@ Add member values to the `BeaconBlockBody` structure:
     'subkey_reveals': [SubkeyReveal],
     'interactive_custody_challenges': [InteractiveCustodyChallenge],
     'interactive_custody_challenge_responses': [InteractiveCustodyChallengeResponse],
-    'interactive_custody_challenge_continuations': [InteractiveCustodyChallengeContinuation],
-
 ```
 
 And initialize to the following:

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -302,7 +302,8 @@ def is_valid_shard_block(beacon_blocks: List[BeaconBlock],
             signed_root(block) == candidate.previous_block_root
         , None)
         assert parent_block != None
-        assert parent_block.shard == block.shard and parent_block.slot < block.slot
+        assert parent_block.shard == block.shard
+        assert parent_block.slot < block.slot
         assert signed_root(beacon_blocks[parent_block.slot]) == parent_block.beacon_chain_root
 
     # Check attestations
@@ -310,6 +311,7 @@ def is_valid_shard_block(beacon_blocks: List[BeaconBlock],
     for _, attestation in enumerate(block.attestations):
         assert max(GENESIS_SHARD_SLOT, block.slot - SLOTS_PER_EPOCH) <= attestation.data.slot
         assert attesation.data.slot <= block.slot - MIN_ATTESTATION_INCLUSION_DELAY
+        assert attetation.data.shart == block.shard
         verify_shard_attestation_signature(beacon_state, attestation)
 
     # Check signature

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -390,7 +390,7 @@ def verify_shard_attestation(state: BeaconState, shard_attestation: ShardAttesta
 
 ```python
 def get_data_challenge_record(state: BeaconState, id: int) -> DataChallengeRecord:
-    records = [c for c in state.data_challenges if c.challenge_id == id]
+    records = [c for c in state.data_challenge_records if c.challenge_id == id]
     return records[0] if len(records) > 0 else None
 ```
 
@@ -398,7 +398,7 @@ def get_data_challenge_record(state: BeaconState, id: int) -> DataChallengeRecor
 
 ```python
 def get_custody_challenge_record(state: BeaconState, id: int) -> CustodyChallengeRecord:
-    records = [c for c in state.custody_challenges if c.challenge_id == id]
+    records = [c for c in state.custody_challenge_records if c.challenge_id == id]
     return records[0] if len(records) > 0 else None
 ```
 

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -102,8 +102,8 @@ Phase 1 depends upon all of the constants defined in [Phase 0](0_beacon-chain.md
 | `MAX_BRANCH_CHALLENGES`                            | 2**2 (= 4)    |
 | `MAX_BRANCH_RESPONSES`                             | 2**4 (= 16)   |
 | `MAX_EARLY_SUBKEY_REVEALS`                         | 2**4 (= 16)   |
-| `MAX_INTERACTIVE_CUSTODY_CHALLENGE_CHS`    | 2             |
-| `MAX_INTERACTIVE_CUSTODY_CHALLENGE_RESPONSES`      | 16            |
+| `MAX_INTERACTIVE_CUSTODY_CHALLENGES`               | 2**1 (= 2)    |
+| `MAX_INTERACTIVE_CUSTODY_CHALLENGE_RESPONSES`      | 2**4 (= 16)   |
 
 #### Signature domains
 

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -25,9 +25,9 @@ At the current stage, Phase 1, while fundamentally feature-complete, is still su
             - [`ShardBlock`](#shardblock)
             - [`ShardAttestation`](#shardattestation)
         - [Custody objects](#custody-objects)
-            - [`BranchChallenge`](#branchchallenge)
+            - [`DataChallenge`](#datachallenge)
             - [`BranchResponse`](#branchresponse)
-            - [`BranchChallengeRecord`](#branchchallengerecord)
+            - [`DataChallengeRecord`](#datachallengerecord)
             - [`CustodyChallengeRecord`](#custodychallengerecord)
             - [`CustodyChallenge`](#custodychallenge)
             - [`SubkeyReveal`](#subkeyreveal)
@@ -182,7 +182,7 @@ Add the following fields to the end of the specified container objects.
 
 ### Custody objects
 
-#### `BranchChallenge`
+#### `DataChallenge`
 
 ```python
 {
@@ -451,7 +451,7 @@ The `shard_chain_commitment` is only valid if it equals `compute_commitment(head
 #### `get_data_challenge_record`
 
 ```python
-def get_data_challenge_record(state: BeaconState, id: int) -> BranchChallengeRecord:
+def get_data_challenge_record(state: BeaconState, id: int) -> DataChallengeRecord:
     records = [c for c in state.data_challenges if c.challenge_id == id]
     return records[0] if len(records) > 0 else None
 ```
@@ -579,7 +579,7 @@ For each `challenge` in `block.body.data_challenges`, run:
 
 ```python
 def process_data_challenge(state: BeaconState,
-                           challenge: BranchChallenge) -> None:
+                           challenge: DataChallenge) -> None:
     # Check it is not too late to challenge
     assert slot_to_epoch(challenge.attestation.data.slot) >= get_current_epoch(state) - MAX_DATA_CHALLENGE_DELAY
     assert state.validator_registry[responder_index].exit_epoch >= get_current_epoch(state) - MAX_DATA_CHALLENGE_DELAY

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -1,4 +1,4 @@
-# Ethereum 2.0 Phase 1 -- Shards Data Chains
+# Ethereum 2.0 Phase 1 -- Shard Data Chains
 
 __NOTICE__: This document is a work-in-progress for researchers and implementers.
 
@@ -6,11 +6,12 @@ __NOTICE__: This document is a work-in-progress for researchers and implementers
 
 <!-- TOC -->
 
-- [Ethereum 2.0 Phase 1 -- Shards Data Chains](#ethereum-20-phase-1----shard-data-chains)
+- [Ethereum 2.0 Phase 1 -- Shard Data Chains](#ethereum-20-phase-1----shard-data-chains)
     - [Table of Contents](#table-of-contents)
     - [Introduction](#introduction)
     - [Constants](#constants)
         - [Time parameters](#time-parameters)
+        - [Signature domains](#signature-domains)
     - [Data structures](#data-structures)
         - [`ShardBlock`](#shardblock)
         - [`ShardBlockHeader`](#shardblockheader)
@@ -36,6 +37,14 @@ This document represents the expected behavior of an "honest validator" with res
 | Name | Value | Unit | Duration |
 | - | - | :-: | :-: |
 | `CROSSLINK_LOOKBACK` | 2**5 (= 32) | slots  | 3.2 minutes |
+| `PERSISTENT_COMMITTEE_PERIOD` | 2**11 (= 2,048) | epochs | ~9 days |
+
+### Signature domains
+
+| Name | Value |
+| - | - |
+| `DOMAIN_SHARD_PROPOSER` | `128` |
+| `DOMAIN_SHARD_ATTESTER` | `129` |
 
 ## Data structures
 


### PR DESCRIPTION
Replace the existing proof of custody game with a new game ("Justin's Awesome Bit Sum" or JABS) that works as follows:

* The data `D` is split up into 512-byte chunks `D[0] .... D[n-1]`, and use a mix function `mix(subkey, data) -> {0,1}` (currently the first bit of the hash of `subkey+data`). We calculate `M[i] = (mix(D[0]) + ... + mix(D[i-1])) % 2`, and set the custody bit to `M[n-1]`
* Anyone can challenge by providing the full `M` where `M[n-1]` is not equal to the custody bit
* Anyone can respond to a challenge by providing a specific position in `M` along with a branch of the data where `M[i-1] ^ mix(D[i]) != M[i]`

The maximum size of data is now `2**6` epochs *  `2**6` blocks * `2**14` bytes = `2**26` bytes, so assuming 512-byte mix chunks the maximum mix size is `2**17` bits or `2**14` bytes. The average mix size is `2**8` bytes.