### PR TITLE
use signed_root for block id purposes in blocks/state

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -684,7 +684,8 @@ def get_temporary_block_header(block: BeaconBlock) -> BeaconBlockHeader:
         previous_block_root=block.previous_block_root,
         state_root=ZERO_HASH,
         block_body_root=hash_tree_root(block.body),
-        signature=block.signature,
+        # signed_root(block) is used for block id purposes so signature is a stub
+        signature=EMPTY_SIGNATURE,
     )
 ```
 
@@ -1689,7 +1690,7 @@ def cache_state(state: BeaconState) -> None:
         state.latest_block_header.state_root = previous_slot_state_root
 
     # store latest known block for previous slot
-    state.latest_block_roots[state.slot % SLOTS_PER_HISTORICAL_ROOT] = hash_tree_root(state.latest_block_header)
+    state.latest_block_roots[state.slot % SLOTS_PER_HISTORICAL_ROOT] = signed_root(state.latest_block_header)
 ```
 
 ### Per-epoch processing
@@ -2250,7 +2251,7 @@ def process_block_header(state: BeaconState, block: BeaconBlock) -> None:
     # Verify that the slots match
     assert block.slot == state.slot
     # Verify that the parent matches
-    assert block.previous_block_root == hash_tree_root(state.latest_block_header)
+    assert block.previous_block_root == signed_root(state.latest_block_header)
     # Save current block as the new latest block
     state.latest_block_header = get_temporary_block_header(block)
     # Verify proposer signature

--- a/tests/phase0/helpers.py
+++ b/tests/phase0/helpers.py
@@ -88,7 +88,7 @@ def build_empty_block_for_next_slot(state):
     previous_block_header = deepcopy(state.latest_block_header)
     if previous_block_header.state_root == spec.ZERO_HASH:
         previous_block_header.state_root = state.hash_tree_root()
-    empty_block.previous_block_root = previous_block_header.hash_tree_root()
+    empty_block.previous_block_root = signed_root(previous_block_header)
     return empty_block
 
 


### PR DESCRIPTION
_Note:_ This PR is directly to master. I would like to release this ASAP as a v0.5.1 release.

Addresses #797 by using `signed_root` when caching block headers in state and when assessing validity of `block.previous_block_root`.

When discussing a blocks "hash" or "root" it should be considered as the `signed_root(block)` to truncate off the signature which avoids an external dependency in the state transition function.