### PR TITLE
Generalise `slash_validator` for phase 1

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -252,8 +252,7 @@ Code snippets appearing in `this style` are to be interpreted as Python code.
 | - | - |
 | `BASE_REWARD_QUOTIENT` | `2**5` (= 32) |
 | `WHISTLEBLOWING_REWARD_QUOTIENT` | `2**9` (= 512) |
-| `PROPOSER_REWARD_QUOTIENT` | `2**4` (= 16) |
-| `ATTESTATION_INCLUSION_REWARD_QUOTIENT` | `2**3` (= 8) |
+| `PROPOSER_REWARD_QUOTIENT` | `2**3` (= 8) |
 | `INACTIVITY_PENALTY_QUOTIENT` | `2**24` (= 16,777,216) |
 | `MIN_PENALTY_QUOTIENT` | `2**5` (= 32) |
 
@@ -2016,7 +2015,7 @@ def compute_normal_justification_and_finalization_deltas(state: BeaconState) -> 
         # Proposer bonus
         if index in get_attesting_indices(state, state.previous_epoch_attestations):
             proposer_index = get_beacon_proposer_index(state, inclusion_slot(state, index))
-            deltas[0][proposer_index] += get_base_reward(state, index) // ATTESTATION_INCLUSION_REWARD_QUOTIENT
+            deltas[0][proposer_index] += get_base_reward(state, index) // PROPOSER_REWARD_QUOTIENT
     return deltas
 ```
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1467,7 +1467,7 @@ def slash_validator(state: BeaconState, slashed_index: ValidatorIndex, whistlebl
     proposer_reward = whistleblowing_reward // PROPOSER_REWARD_QUOTIENT
     increase_balance(state, proposer_index, proposer_reward)
     increase_balance(state, whistleblower_index, whistleblowing_reward - proposer_reward)
-    decrease_balance(state, slashed_index, whistleblower_reward)
+    decrease_balance(state, slashed_index, whistleblowing_reward)
 ```
 
 #### `prepare_validator_for_withdrawal`

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1449,7 +1449,7 @@ def exit_validator(state: BeaconState, index: ValidatorIndex) -> None:
 #### `slash_validator`
 
 ```python
-def slash_validator(state: BeaconState, slashed_index: ValidatorIndex, whitleblower_index: ValidatorIndex=None) -> None:
+def slash_validator(state: BeaconState, slashed_index: ValidatorIndex, whistleblower_index: ValidatorIndex=None) -> None:
     """
     Slash the validator with index ``slashed_index``.
     Note that this function mutates ``state``.
@@ -1461,12 +1461,12 @@ def slash_validator(state: BeaconState, slashed_index: ValidatorIndex, whitleblo
     state.latest_slashed_balances[get_current_epoch(state) % LATEST_SLASHED_EXIT_LENGTH] += slashed_balance
 
     proposer_index = get_beacon_proposer_index(state, state.slot)
-    if whileblower_index is None:
-        whileblower_index = proposer_index
+    if whistleblower_index is None:
+        whistleblower_index = proposer_index
     whistleblowing_reward = slashed_balance // WHISTLEBLOWING_REWARD_QUOTIENT
     proposer_reward = whistleblowing_reward // PROPOSER_REWARD_QUOTIENT
     increase_balance(state, proposer_index, proposer_reward)
-    increase_balance(state, whitleblower_index, whistleblowing_reward - proposer_reward)
+    increase_balance(state, whistleblower_index, whistleblowing_reward - proposer_reward)
     decrease_balance(state, slashed_index, whistleblower_reward)
 ```
 


### PR DESCRIPTION
Make `slash_validator` friendly to phase 1 so that it can be used in a context in which the whistleblower and block proposer might be distinct.

This is a cosmetic change in the context of phase 0.