### PR TITLE
Missed filter condition in get_winning_root_and_participants

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1800,7 +1800,8 @@ def get_previous_epoch_matching_head_attestations(state: BeaconState) -> List[Pe
 def get_winning_root_and_participants(state: BeaconState, shard: Shard) -> Tuple[Bytes32, List[ValidatorIndex]]:
     all_attestations = state.current_epoch_attestations + state.previous_epoch_attestations
     valid_attestations = [
-        a for a in all_attestations if a.data.previous_crosslink == state.latest_crosslinks[shard]
+        a for a in all_attestations 
+        if a.data.shard == shard and a.data.previous_crosslink == state.latest_crosslinks[shard]
     ]
     all_roots = [a.data.crosslink_data_root for a in valid_attestations]
 


### PR DESCRIPTION
### What's done
Adds an extra condition to filter attesters by `shard` passed to `get_winning_root_and_participants`.

### Why
Otherwise `get_winning_root_and_participants` may return validator indices that were not assigned to the committee of given `shard`.

Spec v0.4.0 has that condition either:
> Let `attesting_validator_indices(crosslink_committee, crosslink_data_root)` be the union of the validator index sets given by `[get_attestation_participants(state, a.data, a.aggregation_bitfield) for a in current_epoch_attestations + previous_epoch_attestations if a.data.shard == shard and a.data.crosslink_data_root == crosslink_data_root]`.