### PR TITLE
Updated BASE_REWARD_QUOTIENT

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -250,7 +250,7 @@ Code snippets appearing in `this style` are to be interpreted as Python code.
 
 | Name | Value |
 | - | - |
-| `BASE_REWARD_QUOTIENT` | `2**5` (= 32) |
+| `BASE_REWARD_QUOTIENT` | `2**10` (= 1024) |
 | `WHISTLEBLOWER_REWARD_QUOTIENT` | `2**9` (= 512) |
 | `ATTESTATION_INCLUSION_REWARD_QUOTIENT` | `2**3` (= 8) |
 | `INACTIVITY_PENALTY_QUOTIENT` | `2**24` (= 16,777,216) |


### PR DESCRIPTION
The BASE_REWARD_QUOTIENT appears to have been set for 1024, but this was not reflected in the spec as it still showed it as 32.