### PR TITLE
Rework crosslink processing

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -354,7 +354,7 @@ The types are defined topologically to aid in facilitating an executable version
 
     # Crosslink vote
     'shard': 'uint64',
-    'previous_crosslink': Crosslink,
+    'source_crosslink': Crosslink,
     'crosslink_data_root': 'bytes32',
 }
 ```
@@ -1733,12 +1733,12 @@ def get_previous_epoch_matching_head_attestations(state: BeaconState) -> List[Pe
 
 ```python
 def get_winning_root_and_participants(state: BeaconState, shard: Shard, epoch: Epoch) -> Tuple[Bytes32, List[ValidatorIndex]]:
-    previous_crosslinks = state.current_epoch_crosslinks if epoch == slot_to_epoch(state.slot) else state.previous_epoch_crosslinks
+    source_crosslinks = state.current_epoch_crosslinks if epoch == slot_to_epoch(state.slot) else state.previous_epoch_crosslinks
     attestations = state.current_epoch_attestations if epoch == slot_to_epoch(state.slot) else state.previous_epoch_attestations
 
     valid_attestations = [
         a for a in attestations 
-        if a.data.shard == shard and a.data.previous_crosslink == previous_crosslinks[shard]
+        if a.data.shard == shard and a.data.source_crosslink == source_crosslinks[shard]
     ]
     all_roots = [a.data.crosslink_data_root for a in valid_attestations]
 
@@ -2334,11 +2334,11 @@ def process_attestation(state: BeaconState, attestation: Attestation) -> None:
     # Check crosslink data
     assert attestation.data.crosslink_data_root == ZERO_HASH  # [to be removed in phase 1]
     valid_crosslinks = {
-        attestation.data.previous_crosslink,  # Case 1: latest crosslink matches previous crosslink
+        attestation.data.source_crosslink,    # Case 1: latest crosslink matches previous crosslink
         Crosslink(                            # Case 2: latest crosslink matches current crosslink
             crosslink_data_root=attestation.data.crosslink_data_root,
             epoch=min(slot_to_epoch(attestation.data.slot),
-                      attestation.data.previous_crosslink.epoch + MAX_CROSSLINK_EPOCHS)
+                      attestation.data.source_crosslink.epoch + MAX_CROSSLINK_EPOCHS)
         ),
     }
     assert (

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -276,7 +276,7 @@ A node should sign a crosslink only if the following conditions hold. **If a nod
 First, the conditions must recursively apply to the crosslink referenced in `last_crosslink_root` for the same shard (unless `last_crosslink_root` equals zero, in which case we are at the genesis).
 
 Second, we verify the `shard_chain_commitment`.
-* Let `start_slot = state.latest_crosslinks[shard].epoch * SLOTS_PER_EPOCH + SLOTS_PER_EPOCH - CROSSLINK_LOOKBACK`.
+* Let `start_slot = state.current_epoch_crosslinks[shard].epoch * SLOTS_PER_EPOCH + SLOTS_PER_EPOCH - CROSSLINK_LOOKBACK`.
 * Let `end_slot = attestation.data.slot - attestation.data.slot % SLOTS_PER_EPOCH - CROSSLINK_LOOKBACK`.
 * Let `length = end_slot - start_slot`, `headers[0] .... headers[length-1]` be the serialized block headers in the canonical shard chain from the verifer's point of view (note that this implies that `headers` and `bodies` have been checked for validity).
 * Let `bodies[0] ... bodies[length-1]` be the bodies of the blocks.

--- a/specs/validator/0_beacon-chain-validator.md
+++ b/specs/validator/0_beacon-chain-validator.md
@@ -273,7 +273,7 @@ _Note:_ This is a stub for phase 0.
 
 ##### Latest crosslink
 
-Set `attestation_data.previous_crosslink = head_state.current_epoch_crosslinks[shard]`.
+Set `attestation_data.source_crosslink = head_state.current_epoch_crosslinks[shard]`.
 
 ##### Source epoch
 

--- a/specs/validator/0_beacon-chain-validator.md
+++ b/specs/validator/0_beacon-chain-validator.md
@@ -273,7 +273,7 @@ _Note:_ This is a stub for phase 0.
 
 ##### Latest crosslink
 
-Set `attestation_data.previous_crosslink = head_state.latest_crosslinks[shard]`.
+Set `attestation_data.previous_crosslink = head_state.current_epoch_crosslinks[shard]`.
 
 ##### Source epoch
 

--- a/tests/phase0/block_processing/test_process_attestation.py
+++ b/tests/phase0/block_processing/test_process_attestation.py
@@ -120,7 +120,7 @@ def test_non_zero_crosslink_data_root(state):
     return pre_state, attestation, post_state
 
 
-def test_bad_previous_crosslink(state):
+def test_bad_source_crosslink(state):
     attestation = get_valid_attestation(state)
     state.slot += spec.MIN_ATTESTATION_INCLUSION_DELAY
 
@@ -132,7 +132,7 @@ def test_bad_previous_crosslink(state):
     return pre_state, attestation, post_state
 
 
-def test_previous_crosslink_is_outdated(state):
+def test_source_crosslink_is_outdated(state):
     attestation = get_valid_attestation(state)
     state.slot += spec.MIN_ATTESTATION_INCLUSION_DELAY
 

--- a/tests/phase0/block_processing/test_process_attestation.py
+++ b/tests/phase0/block_processing/test_process_attestation.py
@@ -55,7 +55,7 @@ def test_success(state):
     return pre_state, attestation, post_state
 
 
-def test_success_prevous_epoch(state):
+def test_success_previous_epoch(state):
     attestation = get_valid_attestation(state)
     block = build_empty_block_for_next_slot(state)
     block.slot = state.slot + spec.SLOTS_PER_EPOCH
@@ -124,9 +124,21 @@ def test_bad_previous_crosslink(state):
     attestation = get_valid_attestation(state)
     state.slot += spec.MIN_ATTESTATION_INCLUSION_DELAY
 
-    state.latest_crosslinks[attestation.data.shard].epoch += 10
+    state.previous_epoch_crosslinks[attestation.data.shard].epoch += 10
+    state.current_epoch_crosslinks[attestation.data.shard].epoch += 11
 
     pre_state, post_state = run_attestation_processing(state, attestation, False)
+
+    return pre_state, attestation, post_state
+
+
+def test_previous_crosslink_is_outdated(state):
+    attestation = get_valid_attestation(state)
+    state.slot += spec.MIN_ATTESTATION_INCLUSION_DELAY
+
+    state.current_epoch_crosslinks[attestation.data.shard].epoch += 10
+
+    pre_state, post_state = run_attestation_processing(state, attestation, True)
 
     return pre_state, attestation, post_state
 

--- a/tests/phase0/conftest.py
+++ b/tests/phase0/conftest.py
@@ -28,7 +28,8 @@ def overwrite_spec_config(config):
         if field == "LATEST_RANDAO_MIXES_LENGTH":
             spec.BeaconState.fields['latest_randao_mixes'][1] = config[field]
         elif field == "SHARD_COUNT":
-            spec.BeaconState.fields['latest_crosslinks'][1] = config[field]
+            spec.BeaconState.fields['previous_epoch_crosslinks'][1] = config[field]
+            spec.BeaconState.fields['current_epoch_crosslinks'][1] = config[field]
         elif field == "SLOTS_PER_HISTORICAL_ROOT":
             spec.BeaconState.fields['latest_block_roots'][1] = config[field]
             spec.BeaconState.fields['latest_state_roots'][1] = config[field]

--- a/tests/phase0/helpers.py
+++ b/tests/phase0/helpers.py
@@ -95,7 +95,7 @@ def create_genesis_state(num_validators, deposit_data_leaves=None):
 def force_registry_change_at_next_epoch(state):
     # artificially trigger registry update at next epoch transition
     state.finalized_epoch = get_current_epoch(state) - 1
-    for crosslink in state.latest_crosslinks:
+    for crosslink in state.current_epoch_crosslinks:
         crosslink.epoch = state.finalized_epoch
     state.validator_registry_update_epoch = state.finalized_epoch - 1
 
@@ -155,7 +155,7 @@ def build_attestation_data(state, slot, shard):
         source_root=justified_block_root,
         target_root=epoch_boundary_root,
         crosslink_data_root=spec.ZERO_HASH,
-        previous_crosslink=deepcopy(state.latest_crosslinks[shard]),
+        previous_crosslink=deepcopy(state.current_epoch_crosslinks[shard]),
     )
 
 

--- a/tests/phase0/helpers.py
+++ b/tests/phase0/helpers.py
@@ -155,7 +155,7 @@ def build_attestation_data(state, slot, shard):
         source_root=justified_block_root,
         target_root=epoch_boundary_root,
         crosslink_data_root=spec.ZERO_HASH,
-        previous_crosslink=deepcopy(state.current_epoch_crosslinks[shard]),
+        source_crosslink=deepcopy(state.current_epoch_crosslinks[shard]),
     )
 
 

--- a/utils/phase0/state_transition.py
+++ b/utils/phase0/state_transition.py
@@ -91,9 +91,10 @@ def process_block(state: BeaconState,
 
 def process_epoch_transition(state: BeaconState) -> None:
     spec.update_justification_and_finalization(state)
-    spec.process_crosslinks(state)
+    latest_crosslinks = spec.get_latest_crosslinks(state)
     spec.maybe_reset_eth1_period(state)
     spec.apply_rewards(state)
+    spec.apply_crosslinks(state, latest_crosslinks)
     spec.process_ejections(state)
     spec.update_registry(state)
     spec.process_slashings(state)


### PR DESCRIPTION
## What was wrong?
Addresses a number of issues in crosslink processing encountered during update to v0.5.1:
1. Attestation created in one epoch but not included into any block of that epoch had a chance to eventually become invalid. It happened because of crosslink update on the closest epoch transition which made `previous_crosslink` in the attestation outdated. This PR, also, adds a test to a spec that covers this case. Described in this issue https://github.com/ethereum/eth2.0-specs/issues/845.
2. Penalties and rewards for crosslinks were calculated _after_ crosslinks have been processed, therefore `get_winning_root_and_participants` returned empty participation lists for crosslinks of updated shards as this update made `previous_crosslink` in attestations out of date.
3. There is a case when two attestations for a same shard, i.e. for previous and current epoch, are included into a state during _current_ epoch. In this case attestation from _previous_ epoch had a chance to win cause epoch was not counted in the comparison of crosslink data roots. Mentioned here: https://github.com/ethereum/eth2.0-specs/issues/845#issuecomment-477482090.
4. Shard was not counted in attestation filtering. Supplants https://github.com/ethereum/eth2.0-specs/pull/841.
5. An edge case with `GENESIS_EPOCH` caused incorrect crosslink processing. Mentioned here: https://github.com/ethereum/eth2.0-specs/pull/841#issuecomment-476732037.

## How it was fixed.
1. Outdated `previous_crosslink` was fixed by breaking crosslinks down to `previous_epoch_crosslinks` and `current_epoch_crosslinks`. Now attestation is checked against both lists which prevents it from being spoiled. There was another solution of this issue, to process crosslinks only for previous epoch. But this approach adds a delay to a shard crosslinking, IMO, a speed of crosslinking process is invariant that is not desired to be broken.
2. To work around rewards issue crosslinks are calculated and stored in memory _before_ rewards calculation and got applied _after_ `apply_reward` has been called during the epoch processing. It preserves an invariant of calculating voting balances _before_ validator balances get changed.
3. Other issues have been fixed by adding a strict order to crosslink processing: current epoch is processed after previous one.

### Crosslinks processing flow
This is how this PR affects epoch processing:
```python
def process_epoch_transition(state: BeaconState) -> None:
    spec.update_justification_and_finalization(state)
    
    # calculating crosslinks:
    latest_crosslinks = spec.get_latest_crosslinks(state)
    
    spec.maybe_reset_eth1_period(state)

    # applying rewards and crosslinks after them
    spec.apply_rewards(state)
    spec.apply_crosslinks(state, latest_crosslinks)
    ...
```

### Complexity
This PR adds a certain degree of complexity to crosslink and epoch processing. This complexity has been added in order to preserve invariants that from my perspective are important for the beacon chain processing. It may be there are other ways of solving these issues, would be happy to discuss them here.

### Naming and types
**Disclaimer:** I am not pythonist. In this PR you can meet bad namings, not that idiomatic function decomposition alongside with inappropriate type usage (esp. `Vector`).

### Testing
These changes have been tested in our simulator. It works well for ideal case when all attestations are included in the next coming block, but I believe those are good for sophisticated cases as well. Corresponding commit https://github.com/harmony-dev/beacon-chain-java/commit/a1ee101f135a20e89303087a3adb7d05be2e25eb

### Misc
This PR a bit affects Phase 1 spec. There is also renaming of `previous_crosslink` in attestation data to `source_crosslink`; this is done because `previous_crosslink` name started to clash with `previous_epoch_crosslinks`. Not sure that I like `source_crosslink` but gave up on picking something else.

### Related issues and PRs
Addresses https://github.com/ethereum/eth2.0-specs/issues/845, supplants https://github.com/ethereum/eth2.0-specs/pull/841.
