### PR TITLE
Rounded effective balance

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -2004,7 +2004,7 @@ def process_ejections(state: BeaconState) -> None:
     and eject active validators with balance below ``EJECTION_BALANCE``.
     """
     for index in get_active_validator_indices(state.validator_registry, get_current_epoch(state)):
-        if get_effective_balance(state, index) < EJECTION_BALANCE:
+        if get_effective_balance(state, index) <= EJECTION_BALANCE:
             initiate_validator_exit(state, index)
 ```
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -2004,7 +2004,7 @@ def process_ejections(state: BeaconState) -> None:
     and eject active validators with balance below ``EJECTION_BALANCE``.
     """
     for index in get_active_validator_indices(state.validator_registry, get_current_epoch(state)):
-        if get_effective_balance(state, index) <= EJECTION_BALANCE:
+        if get_effective_balance(state, index) < EJECTION_BALANCE:
             initiate_validator_exit(state, index)
 ```
 


### PR DESCRIPTION
Use the rounded balance for the effective balance to homogenise the on-onchain finality and crosslink gadgets with the fork choice rule and the light client logic.

Minor cleanups:

* Use `increase_balance` and `decrease_balance` in `apply_rewards` instead of `set_balance`.
* Use `get_effective_balance` for activations and ejections.
* Rename `high_balance` to `rounded_balance` (we no longer have `high_balance` and `low_balance`).