### PR TITLE
Stagger reveal slots

### DIFF
--- a/specs/core/1_custody-game.md
+++ b/specs/core/1_custody-game.md
@@ -283,7 +283,7 @@ def process_custody_reveal(state: BeaconState,
             EPOCHS_PER_CUSTODY_PERIOD * reveal.period +
             get_switchover_epoch(state, get_current_epoch(state), reveal.revealer_index)
         )
-        assert state.slot >= min_reveal_slot
+        assert get_current_epoch(state) >= min_reveal_epoch
         # Revealer is active or exited
         assert is_active_validator(revealer, get_current_epoch(state)) or revealer.exit_epoch > get_current_epoch(state)
         revealer.custody_reveal_index += 1

--- a/specs/core/1_custody-game.md
+++ b/specs/core/1_custody-game.md
@@ -279,7 +279,7 @@ def process_custody_reveal(state: BeaconState,
     # Case 1: non-masked non-punitive non-early reveal
     if reveal.mask == ZERO_HASH:
         assert reveal.period == epoch_to_custody_period(revealer.activation_epoch) + revealer.custody_reveal_index
-        min_reveal_slot = (
+        min_reveal_epoch = (
             EPOCHS_PER_CUSTODY_PERIOD * reveal.period +
             get_switchover_epoch(state, get_current_epoch(state), reveal.revealer_index)
         )

--- a/specs/core/1_custody-game.md
+++ b/specs/core/1_custody-game.md
@@ -293,7 +293,7 @@ def process_custody_reveal(state: BeaconState,
 
     # Case 2: masked punitive early reveal
     else:
-        assert reveal.period >= current_custody_period
+        assert reveal.period >= current_custody_period and is_active_validator(revealer, get_current_epoch(state)) 
         assert revealer.slashed is False
         slash_validator(state, reveal.revealer_index, reveal.masker_index)
 ```

--- a/specs/core/1_custody-game.md
+++ b/specs/core/1_custody-game.md
@@ -279,6 +279,11 @@ def process_custody_reveal(state: BeaconState,
     # Case 1: non-masked non-punitive non-early reveal
     if reveal.mask == ZERO_HASH:
         assert reveal.period == epoch_to_custody_period(revealer.activation_epoch) + revealer.custody_reveal_index
+        min_reveal_slot = (
+            EPOCHS_PER_CUSTODY_PERIOD * reveal.period +
+            get_switchover_epoch(state, get_current_epoch(state), reveal.revealer_index)
+        )
+        assert state.slot >= min_reveal_slot
         # Revealer is active or exited
         assert is_active_validator(revealer, get_current_epoch(state)) or revealer.exit_epoch > get_current_epoch(state)
         revealer.custody_reveal_index += 1
@@ -288,7 +293,7 @@ def process_custody_reveal(state: BeaconState,
 
     # Case 2: masked punitive early reveal
     else:
-        assert reveal.period > current_custody_period
+        assert reveal.period >= current_custody_period
         assert revealer.slashed is False
         slash_validator(state, reveal.revealer_index, reveal.masker_index)
 ```


### PR DESCRIPTION
Depends on #868 for `get_switchover_epoch`.

Also changes the condition for punitive reveals to `assert reveal.period >= current_custody_period and is_active_validator(revealer, get_current_epoch(state))` because revealing a subkey during the period that it is being used to make custody bits should also count as punitive.