### PR TITLE
Homogenised start shard

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -2082,10 +2082,12 @@ def update_registry(state: BeaconState) -> None:
     # Check if we should update, and if so, update
     if state.finalized_epoch > state.validator_registry_update_epoch:
         update_validator_registry(state)
-    state.latest_start_shard = (
-        state.latest_start_shard +
-        get_current_epoch_committee_count(state)
-    ) % SHARD_COUNT
+
+    if get_current_epoch_committee_count(state) == SHARD_COUNT:
+        state.latest_start_shard += SHARD_COUNT // SLOTS_PER_EPOCH  # Homogenizing offset
+    else:
+        state.latest_start_shard += get_current_epoch_committee_count(state)
+    state.latest_start_shard %= SHARD_COUNT
 ```
 
 **Invariant**: the active index root that is hashed into the shuffling seed actually is the `hash_tree_root` of the validator set that is used for that epoch.

--- a/tests/phase0/block_processing/test_process_proposer_slashing.py
+++ b/tests/phase0/block_processing/test_process_proposer_slashing.py
@@ -11,7 +11,7 @@ from tests.phase0.helpers import (
     get_valid_proposer_slashing,
 )
 
-# mark entire file as 'header'
+# mark entire file as 'proposer_slashings'
 pytestmark = pytest.mark.proposer_slashings
 
 


### PR DESCRIPTION
When the committee count equals `SHARD_COUNT`, add an offset. Fix item 28 in #675.

<img width="398" alt="Screenshot 2019-04-07 at 10 47 39" src="https://user-images.githubusercontent.com/731743/55676978-bf9cdf80-5922-11e9-9196-d55f5ba1455e.png">

(Went with a slightly improved approach which still allows for committee count to equal `SHARD_COUNT`.)