### PR TITLE
Broken link fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Core specifications for eth2.0 client validation can be found in [specs/core](sp
 Accompanying documents can be found in [specs](specs) and include
 * [SimpleSerialize (SSZ) spec](specs/simple-serialize.md)
 * [BLS signature verification](specs/bls_signature.md)
-* [General test format](specs/test-format.md)
+* [General test format](specs/test_formats/README.md)
 * [Honest validator implementation doc](specs/validator/0_beacon-chain-validator.md)
 * [Merkle proof formats](specs/light_client/merkle_proofs.md)
 * [Light client syncing protocol](specs/light_client/sync_protocol.md)


### PR DESCRIPTION
[General test format] currently directs to (https://github.com/ethereum/eth2.0-specs/blob/dev/specs/test_format.md) which is a broken link. The file is located at (https://github.com/ethereum/eth2.0-specs/blob/dev/specs/test_formats/README.md).