### PR TITLE
limit bit-length of justification bitfield to strict 64

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1817,10 +1817,8 @@ def update_justification_and_finalization(state: BeaconState) -> None:
     new_justified_epoch = state.current_justified_epoch
     new_finalized_epoch = state.finalized_epoch
 
-    # Rotate the justification bitfield up one epoch to make room for the current epoch
-    state.justification_bitfield <<= 1
-    # Python var length integers: justification bitfield is 64 bits, and may not be bigger (for SSZ serialization)
-    state.justification_bitfield &= (1 << 64) - 1
+    # Rotate the justification bitfield up one epoch to make room for the current epoch (and limit to 64 bits)
+    state.justification_bitfield = (state.justification_bitfield << 1) % 2**64
     # If the previous epoch gets justified, fill the second last bit
     previous_boundary_attesting_balance = get_attesting_balance(state, get_previous_epoch_boundary_attestations(state))
     if previous_boundary_attesting_balance * 3 >= get_previous_total_balance(state) * 2:

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1819,6 +1819,8 @@ def update_justification_and_finalization(state: BeaconState) -> None:
 
     # Rotate the justification bitfield up one epoch to make room for the current epoch
     state.justification_bitfield <<= 1
+    # Python var length integers: justification bitfield is 64 bits, and may not be bigger (for SSZ serialization)
+    state.justification_bitfield &= (1 << 64) - 1
     # If the previous epoch gets justified, fill the second last bit
     previous_boundary_attesting_balance = get_attesting_balance(state, get_previous_epoch_boundary_attestations(state))
     if previous_boundary_attesting_balance * 3 >= get_previous_total_balance(state) * 2:


### PR DESCRIPTION
Limit bit-length of justification bitfield to strict 64, prevent SSZ encoding crash due to too large integer size.

The pyspec crashed after running it for a long series of epochs because of this :(. It's not a pretty fix, but otherwise Python just grows the integer out of uint64 bounds, making it non-encodeable in 64 bits.

