### PR TITLE
Five quick fixes for simple-serialize.md (2 dead links, 1 update, 2 edits)

### DIFF
--- a/specs/simple-serialize.md
+++ b/specs/simple-serialize.md
@@ -115,10 +115,10 @@ Let `value` be a self-signed container object. The convention is that the signat
 | Language | Project | Maintainer | Implementation |
 |-|-|-|-|
 | Python | Ethereum 2.0 | Ethereum Foundation | [https://github.com/ethereum/py-ssz](https://github.com/ethereum/py-ssz) |
-| Rust | Lighthouse | Sigma Prime | [https://github.com/sigp/lighthouse/tree/master/beacon_chain/utils/ssz](https://github.com/sigp/lighthouse/tree/master/beacon_chain/utils/ssz) |
+| Rust | Lighthouse | Sigma Prime | [https://github.com/sigp/lighthouse/tree/master/eth2/utils/ssz](https://github.com/sigp/lighthouse/tree/master/eth2/utils/ssz) |
 | Nim | Nimbus | Status | [https://github.com/status-im/nim-beacon-chain/blob/master/beacon_chain/ssz.nim](https://github.com/status-im/nim-beacon-chain/blob/master/beacon_chain/ssz.nim) |
 | Rust | Shasper | ParityTech | [https://github.com/paritytech/shasper/tree/master/util/ssz](https://github.com/paritytech/shasper/tree/master/util/ssz) |
-| Javascript | Lodestart | Chain Safe Systems | [https://github.com/ChainSafeSystems/ssz-js/blob/master/src/index.js](https://github.com/ChainSafeSystems/ssz-js/blob/master/src/index.js) |
+| TypeScript | Lodestar | ChainSafe Systems | [https://github.com/ChainSafe/ssz-js](https://github.com/ChainSafe/ssz-js) |
 | Java | Cava | ConsenSys | [https://www.github.com/ConsenSys/cava/tree/master/ssz](https://www.github.com/ConsenSys/cava/tree/master/ssz) |
 | Go | Prysm | Prysmatic Labs | [https://github.com/prysmaticlabs/prysm/tree/master/shared/ssz](https://github.com/prysmaticlabs/prysm/tree/master/shared/ssz) |
 | Swift | Yeeth | Dean Eigenmann | [https://github.com/yeeth/SimpleSerialize.swift](https://github.com/yeeth/SimpleSerialize.swift) |


### PR DESCRIPTION
Link 1. (https://github.com/sigp/lighthouse/tree/master/beacon_chain/utils/ssz) is now a dead link. The live link is (https://github.com/sigp/lighthouse/tree/master/eth2/utils/ssz).

Link 2. (https://github.com/ChainSafe/ssz-js/blob/master/src/index.js) is now a dead link. The live link is (https://github.com/ChainSafe/ssz-js/blob/master/src/index.ts). However, the other implementations listed link to general SSZ pages, which for ChainSafe is (https://github.com/ChainSafe/ssz-js).

Update 1. “Javascript” → “TypeScript”

Edit 1. “Lodestart” → “Lodestar”

Edit 2. “Chain Safe Systems” → “ChainSafe Systems”

(Obviously, the last one is very minute, just including it since there’s other updates here.)
