### PR TITLE
2 quick fixes for the test_formats readme (1 dead link, 1 typo)

### DIFF
--- a/specs/test_formats/README.md
+++ b/specs/test_formats/README.md
@@ -7,7 +7,7 @@ This document defines the YAML format and structure used for ETH 2.0 testing.
 * [About](#about)
 * [Glossary](#glossary)
 * [Test format philosophy](#test-format-philosophy)
-* [Test Suite](#yaml-suite)
+* [Test Suite](#test-suite)
 * [Config](#config)
 * [Fork-timeline](#fork-timeline)
 * [Config sourcing](#config-sourcing)
@@ -28,7 +28,7 @@ The particular formats of specific types of tests (test suites) are defined in s
 - `suite`: a YAML file with:
   - a header: describes the `suite`, and defines what the `suite` is for
   - a list of test cases
-- `runner`: where a generator is a *"producer"*, this is the *"consumer"**.
+- `runner`: where a generator is a *"producer"*, this is the *"consumer"*.
   - A `runner` focuses on *only one* `type`, and each type has *only one* `runner`.
 - `handler`: a `runner` may be too limited sometimes, you may have a `suite` with a specific focus that requires a different format.
   To facilitate this, you specify a `handler`: the runner can deal with the format by using the specified handler.


### PR DESCRIPTION
Link: (https://github.com/ethereum/eth2.0-specs/blob/dev/specs/test_formats/README.md#yaml-suite) in the ToC is now a dead link. The live link for that section is (https://github.com/ethereum/eth2.0-specs/blob/dev/specs/test_formats/README.md#test-suite).

Typo: Extra asterisk after *"consumer"** removed so that it can be italicized as intended like *"producer"*
Note: (asterisk)(asterisk)(word)(asterisk) renders as (italicized word)(asterisk) here, but on the spec itself it just shows up as (asterisk)(asterisk)(word)(asterisk). I don't think (italicized word)(asterisk) was the intention either since there is no corresponding footnote below.