### PR TITLE
Dead link fix in rpc-interface.md

### DIFF
--- a/specs/networking/rpc-interface.md
+++ b/specs/networking/rpc-interface.md
@@ -9,7 +9,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL", NOT", "SHOULD", 
 
 # Dependencies
 
-This specification assumes familiarity with the [Messaging](./messaging.md), [Node Identification](./node-identification), and [Beacon Chain](../core/0_beacon-chain.md) specifications.
+This specification assumes familiarity with the [Messaging](./messaging.md), [Node Identification](./node-identification.md), and [Beacon Chain](../core/0_beacon-chain.md) specifications.
 
 # Specification
 


### PR DESCRIPTION
(https://github.com/ethereum/eth2.0-specs/blob/dev/specs/networking/node-identification) is now a dead link. The live link is (https://github.com/ethereum/eth2.0-specs/blob/dev/specs/networking/node-identification.md).