### PR TITLE
Update 0_beacon-chain.md

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1950,7 +1950,7 @@ Run the following function:
 ```python
 def update_registry(state: BeaconState) -> None:
     activation_queue = sorted([
-        validator for validator in state.validator_registry if
+        index for index, validator in enumerate(state.validator_registry) if
         validator.activation_eligibility_epoch != FAR_FUTURE_EPOCH and
         validator.activation_epoch >= get_delayed_activation_exit_epoch(state.finalized_epoch)
     ], key=lambda index: state.validator_registry[index].activation_eligibility_epoch)


### PR DESCRIPTION
Fix another typo w/ the withdrawal ~> exit queue PR

Specifically: the rest of this code expects the index, not the validator object so we collect the index in the list comprehension in lieu of the validator object