### PR TITLE
update constants to match latest dev

### DIFF
--- a/configs/constant_presets/mainnet.yaml
+++ b/configs/constant_presets/mainnet.yaml
@@ -5,16 +5,16 @@
 
 # Misc
 # ---------------------------------------------------------------
-# 2**10 ` (= 1,024)
+# 2**10 (= 1,024)
 SHARD_COUNT: 1024
-# 2**7 ` (= 128)
+# 2**7 (= 128)
 TARGET_COMMITTEE_SIZE: 128
-# 2**5 ` (= 32)
-MAX_BALANCE_CHURN_QUOTIENT: 32
-# 2**12 ` (= 4,096)
+# 2**12 (= 4,096)
 MAX_ATTESTATION_PARTICIPANTS: 4096
-# 2**2 ` (= 4)
-MAX_EXIT_DEQUEUES_PER_EPOCH: 4
+# 2**2 (= 4)
+MIN_PER_EPOCH_CHURN_LIMIT: 4
+# 2**16 (= 65,536)
+CHURN_LIMIT_QUOTIENT: 65536
 # See issue 563
 SHUFFLE_ROUND_COUNT: 90
 
@@ -23,19 +23,19 @@ SHUFFLE_ROUND_COUNT: 90
 # ---------------------------------------------------------------
 # **TBD**
 DEPOSIT_CONTRACT_ADDRESS: 0x1234567890123456789012345678901234567890
-# 2**5 ` (= 32)
+# 2**5 (= 32)
 DEPOSIT_CONTRACT_TREE_DEPTH: 32
 
 
 # Gwei values
 # ---------------------------------------------------------------
-# 2**0 * 10**9 ` (= 1,000,000,000) Gwei
+# 2**0 * 10**9 (= 1,000,000,000) Gwei
 MIN_DEPOSIT_AMOUNT: 1000000000
-# 2**5 * 10**9 ` (= 32,000,000,000) Gwei
+# 2**5 * 10**9 (= 32,000,000,000) Gwei
 MAX_DEPOSIT_AMOUNT: 32000000000
-# 2**4 * 10**9 ` (= 16,000,000,000) Gwei
+# 2**4 * 10**9 (= 16,000,000,000) Gwei
 EJECTION_BALANCE: 16000000000
-# 2**0 * 10**9 ` (= 1,000,000,000) Gwei
+# 2**0 * 10**9 (= 1,000,000,000) Gwei
 HIGH_BALANCE_INCREMENT: 1000000000
 
 
@@ -54,63 +54,63 @@ BLS_WITHDRAWAL_PREFIX_BYTE: 0x00
 # ---------------------------------------------------------------
 # 6 seconds 6 seconds
 SECONDS_PER_SLOT: 6
-# 2**2 ` (= 4) slots 24 seconds
+# 2**2 (= 4) slots 24 seconds
 MIN_ATTESTATION_INCLUSION_DELAY: 4
-# 2**6 ` (= 64) slots 6.4 minutes
+# 2**6 (= 64) slots 6.4 minutes
 SLOTS_PER_EPOCH: 64
-# 2**0 ` (= 1) epochs 6.4 minutes
+# 2**0 (= 1) epochs 6.4 minutes
 MIN_SEED_LOOKAHEAD: 1
-# 2**2 ` (= 4) epochs 25.6 minutes
+# 2**2 (= 4) epochs 25.6 minutes
 ACTIVATION_EXIT_DELAY: 4
-# 2**4 ` (= 16) epochs ~1.7 hours
+# 2**4 (= 16) epochs ~1.7 hours
 EPOCHS_PER_ETH1_VOTING_PERIOD: 16
-# 2**13 ` (= 8,192) slots ~13 hours
+# 2**13 (= 8,192) slots ~13 hours
 SLOTS_PER_HISTORICAL_ROOT: 8192
-# 2**8 ` (= 256) epochs ~27 hours
+# 2**8 (= 256) epochs ~27 hours
 MIN_VALIDATOR_WITHDRAWABILITY_DELAY: 256
-# 2**11 ` (= 2,048) epochs 9 days
+# 2**11 (= 2,048) epochs 9 days
 PERSISTENT_COMMITTEE_PERIOD: 2048
-# 2**6 ` (= 64)
+# 2**6 (= 64) epochs ~7 hours
 MAX_CROSSLINK_EPOCHS: 64
 
 
 # State list lengths
 # ---------------------------------------------------------------
-# 2**13 ` (= 8,192) epochs ~36 days
+# 2**13 (= 8,192) epochs ~36 days
 LATEST_RANDAO_MIXES_LENGTH: 8192
-# 2**13 ` (= 8,192) epochs ~36 days
+# 2**13 (= 8,192) epochs ~36 days
 LATEST_ACTIVE_INDEX_ROOTS_LENGTH: 8192
-# 2**13 ` (= 8,192) epochs ~36 days
+# 2**13 (= 8,192) epochs ~36 days
 LATEST_SLASHED_EXIT_LENGTH: 8192
 
 
 # Reward and penalty quotients
 # ---------------------------------------------------------------
-# 2**5 ` (= 32)
+# 2**5 (= 32)
 BASE_REWARD_QUOTIENT: 32
-# 2**9 ` (= 512)
+# 2**9 (= 512)
 WHISTLEBLOWING_REWARD_QUOTIENT: 512
-# 2**3 ` (= 8)
+# 2**3 (= 8)
 PROPOSER_REWARD_QUOTIENT: 8
-# 2**24 ` (= 16,777,216)
+# 2**24 (= 16,777,216)
 INACTIVITY_PENALTY_QUOTIENT: 16777216
 
 
 # Max operations per block
 # ---------------------------------------------------------------
-# 2**5 ` (= 32)
+# 2**5 (= 32)
 MIN_PENALTY_QUOTIENT: 32
-# 2**4 ` (= 16)
+# 2**4 (= 16)
 MAX_PROPOSER_SLASHINGS: 16
-# 2**0 ` (= 1)
+# 2**0 (= 1)
 MAX_ATTESTER_SLASHINGS: 1
-# 2**7 ` (= 128)
+# 2**7 (= 128)
 MAX_ATTESTATIONS: 128
-# 2**4 ` (= 16)
+# 2**4 (= 16)
 MAX_DEPOSITS: 16
-# 2**4 ` (= 16)
+# 2**4 (= 16)
 MAX_VOLUNTARY_EXITS: 16
-# 2**4 ` (= 16)
+# 2**4 (= 16)
 MAX_TRANSFERS: 16
 
 

--- a/configs/constant_presets/minimal.yaml
+++ b/configs/constant_presets/minimal.yaml
@@ -9,13 +9,13 @@ SHARD_COUNT: 8
 
 # [customized] unsecure, but fast
 TARGET_COMMITTEE_SIZE: 4
-# 2**5 ` (= 32)
-MAX_BALANCE_CHURN_QUOTIENT: 32
-# 2**12 ` (= 4,096)
+# 2**12 (= 4,096)
 MAX_ATTESTATION_PARTICIPANTS: 4096
-# 2**2 ` (= 4)
-MAX_EXIT_DEQUEUES_PER_EPOCH: 4
-# See issue 563
+# 2**2 (= 4)
+MIN_PER_EPOCH_CHURN_LIMIT: 4
+# 2**16 (= 65,536)
+CHURN_LIMIT_QUOTIENT: 65536
+# [customized] Faster, but unsecure.
 SHUFFLE_ROUND_COUNT: 10
 
 
@@ -23,19 +23,19 @@ SHUFFLE_ROUND_COUNT: 10
 # ---------------------------------------------------------------
 # **TBD**
 DEPOSIT_CONTRACT_ADDRESS: 0x1234567890123456789012345678901234567890
-# 2**5 ` (= 32)
+# 2**5 (= 32)
 DEPOSIT_CONTRACT_TREE_DEPTH: 32
 
 
 # Gwei values
 # ---------------------------------------------------------------
-# 2**0 * 10**9 ` (= 1,000,000,000) Gwei
+# 2**0 * 10**9 (= 1,000,000,000) Gwei
 MIN_DEPOSIT_AMOUNT: 1000000000
-# 2**5 * 10**9 ` (= 32,000,000,000) Gwei
+# 2**5 * 10**9 (= 32,000,000,000) Gwei
 MAX_DEPOSIT_AMOUNT: 32000000000
-# 2**4 * 10**9 ` (= 16,000,000,000) Gwei
+# 2**4 * 10**9 (= 16,000,000,000) Gwei
 EJECTION_BALANCE: 16000000000
-# 2**0 * 10**9 ` (= 1,000,000,000) Gwei
+# 2**0 * 10**9 (= 1,000,000,000) Gwei
 HIGH_BALANCE_INCREMENT: 1000000000
 
 
@@ -58,19 +58,19 @@ SECONDS_PER_SLOT: 6
 MIN_ATTESTATION_INCLUSION_DELAY: 2
 # [customized] fast epochs
 SLOTS_PER_EPOCH: 8
-# 2**0 ` (= 1) epochs 6.4 minutes
+# 2**0 (= 1) epochs 6.4 minutes
 MIN_SEED_LOOKAHEAD: 1
-# 2**2 ` (= 4) epochs 25.6 minutes
+# 2**2 (= 4) epochs 25.6 minutes
 ACTIVATION_EXIT_DELAY: 4
 # [customized] higher frequency new deposits from eth1 for testing
 EPOCHS_PER_ETH1_VOTING_PERIOD: 2
 # [customized] smaller state
 SLOTS_PER_HISTORICAL_ROOT: 64
-# 2**8 ` (= 256) epochs ~27 hours
+# 2**8 (= 256) epochs ~27 hours
 MIN_VALIDATOR_WITHDRAWABILITY_DELAY: 256
-# 2**11 ` (= 2,048) epochs 9 days
+# 2**11 (= 2,048) epochs 9 days
 PERSISTENT_COMMITTEE_PERIOD: 2048
-# 2**6 ` (= 64)
+# 2**6 (= 64) epochs ~7 hours
 MAX_CROSSLINK_EPOCHS: 64
 
 
@@ -86,31 +86,31 @@ LATEST_SLASHED_EXIT_LENGTH: 64
 
 # Reward and penalty quotients
 # ---------------------------------------------------------------
-# 2**5 ` (= 32)
+# 2**5 (= 32)
 BASE_REWARD_QUOTIENT: 32
-# 2**9 ` (= 512)
+# 2**9 (= 512)
 WHISTLEBLOWING_REWARD_QUOTIENT: 512
-# 2**3 ` (= 8)
+# 2**3 (= 8)
 PROPOSER_REWARD_QUOTIENT: 8
-# 2**24 ` (= 16,777,216)
+# 2**24 (= 16,777,216)
 INACTIVITY_PENALTY_QUOTIENT: 16777216
 
 
 # Max operations per block
 # ---------------------------------------------------------------
-# 2**5 ` (= 32)
+# 2**5 (= 32)
 MIN_PENALTY_QUOTIENT: 32
-# 2**4 ` (= 16)
+# 2**4 (= 16)
 MAX_PROPOSER_SLASHINGS: 16
-# 2**0 ` (= 1)
+# 2**0 (= 1)
 MAX_ATTESTER_SLASHINGS: 1
-# 2**7 ` (= 128)
+# 2**7 (= 128)
 MAX_ATTESTATIONS: 128
-# 2**4 ` (= 16)
+# 2**4 (= 16)
 MAX_DEPOSITS: 16
-# 2**4 ` (= 16)
+# 2**4 (= 16)
 MAX_VOLUNTARY_EXITS: 16
-# 2**4 ` (= 16)
+# 2**4 (= 16)
 MAX_TRANSFERS: 16
 
 


### PR DESCRIPTION
Small change to get the constants configurations up to date with the spec. Missed it in the testing PR.
Also fixed formatting of the comments in the configurations.
