### PR TITLE
Simplify Eth1Data voting

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -2052,9 +2052,8 @@ def process_randao(state: BeaconState, block: BeaconBlock) -> None:
 ```python
 def process_eth1_data(state: BeaconState, block: BeaconBlock) -> None:
     state.eth1_data_votes.append(block.body.eth1_data)
-    for eth1_data in state.eth1_data_votes:
-        if state.eth1_data_votes.count(eth1_data) * 2 > SLOTS_PER_ETH1_VOTING_PERIOD:
-            state.latest_eth1_data = eth1_data
+    if state.eth1_data_votes.count(block.body.eth1_data) * 2 > SLOTS_PER_ETH1_VOTING_PERIOD:
+        state.latest_eth1_data = block.body.eth1_data
 ```
 
 #### Operations

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1773,19 +1773,6 @@ def process_crosslinks(state: BeaconState) -> None:
                 )
 ```
 
-#### Eth1 data
-
-Run the following function:
-
-```python
-def maybe_reset_eth1_period(state: BeaconState) -> None:
-    if state.slot % SLOTS_PER_ETH1_VOTING_PERIOD == 0:
-        for eth1_data in state.eth1_data_votes:
-            if state.eth_data_votes.count(eth1_data) * 2 > SLOTS_PER_ETH1_VOTING_PERIOD:
-                state.latest_eth1_data = eth1_data
-        state.eth1_data_votes = []
-```
-
 #### Rewards and penalties
 
 First, we define some additional helpers:
@@ -1981,6 +1968,9 @@ Run the following function:
 def finish_epoch_update(state: BeaconState) -> None:
     current_epoch = get_current_epoch(state)
     next_epoch = current_epoch + 1
+    # Reset eth1 data votes
+    if state.slot % SLOTS_PER_ETH1_VOTING_PERIOD == 0:
+        state.eth1_data_votes = []
     # Set active index root
     index_root_position = (next_epoch + ACTIVATION_EXIT_DELAY) % LATEST_ACTIVE_INDEX_ROOTS_LENGTH
     state.latest_active_index_roots[index_root_position] = hash_tree_root(
@@ -2063,6 +2053,9 @@ def process_randao(state: BeaconState, block: BeaconBlock) -> None:
 ```python
 def process_eth1_data(state: BeaconState, block: BeaconBlock) -> None:
     state.eth1_data_votes.append(block.body.eth1_data)
+    for eth1_data in state.eth1_data_votes:
+        if state.eth_data_votes.count(eth1_data) * 2 > SLOTS_PER_ETH1_VOTING_PERIOD:
+            state.latest_eth1_data = eth1_data
 ```
 
 #### Operations

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1781,7 +1781,7 @@ Run the following function:
 def maybe_reset_eth1_period(state: BeaconState) -> None:
     if state.slot % SLOTS_PER_ETH1_VOTING_PERIOD == 0:
         for eth1_data in state.eth1_data_votes:
-            if eth1_data != Eth1Data() and state.eth_data_votes.count(eth1_data) * 2 > SLOTS_PER_ETH1_VOTING_PERIOD:
+            if state.eth_data_votes.count(eth1_data) * 2 > SLOTS_PER_ETH1_VOTING_PERIOD:
                 state.latest_eth1_data = eth1_data
         state.eth1_data_votes = []
 ```
@@ -2062,7 +2062,7 @@ def process_randao(state: BeaconState, block: BeaconBlock) -> None:
 
 ```python
 def process_eth1_data(state: BeaconState, block: BeaconBlock) -> None:
-    state.eth1_data_votes[state.slot % SLOTS_PER_ETH1_VOTING_PERIOD] = block.body.eth1_data
+    state.eth1_data_votes.append(block.body.eth1_data)
 ```
 
 #### Operations

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -603,7 +603,7 @@ The types are defined topologically to aid in facilitating an executable version
 
     # Ethereum 1.0 chain data
     'latest_eth1_data': Eth1Data,
-    'eth1_data_votes': ['bytes32', SLOTS_PER_ETH1_VOTING_PERIOD],
+    'eth1_data_votes': [Eth1Data, SLOTS_PER_ETH1_VOTING_PERIOD],
     'deposit_index': 'uint64',
 }
 ```
@@ -1473,7 +1473,7 @@ def get_genesis_beacon_state(genesis_validator_deposits: List[Deposit],
 
         # Ethereum 1.0 chain data
         latest_eth1_data=genesis_eth1_data,
-        eth1_data_votes=Vector([ZERO_HASH for _ in range(SLOTS_PER_ETH1_VOTING_PERIOD)]),
+        eth1_data_votes=Vector([Eth1Data() for _ in range(SLOTS_PER_ETH1_VOTING_PERIOD)]),
         deposit_index=0,
     )
 
@@ -1781,8 +1781,9 @@ Run the following function:
 def maybe_reset_eth1_period(state: BeaconState) -> None:
     if state.slot % SLOTS_PER_ETH1_VOTING_PERIOD == 0:
         for eth1_data in state.eth1_data_votes:
-            if state.eth_data_votes.count(eth1_data) * 2 > SLOTS_PER_ETH1_VOTING_PERIOD:
+            if eth1_data != Eth1Data() and state.eth_data_votes.count(eth1_data) * 2 > SLOTS_PER_ETH1_VOTING_PERIOD:
                 state.latest_eth1_data = eth1_data
+        state.eth1_data_votes = Vector([Eth1Data() for _ in range(SLOTS_PER_ETH1_VOTING_PERIOD)])
 ```
 
 #### Rewards and penalties

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -115,7 +115,6 @@
             - [Helper functions](#helper-functions-1)
             - [Justification](#justification)
             - [Crosslinks](#crosslinks)
-            - [Eth1 data](#eth1-data)
             - [Rewards and penalties](#rewards-and-penalties)
                 - [Justification and finalization](#justification-and-finalization)
                 - [Crosslinks](#crosslinks-1)

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -25,7 +25,6 @@
             - [`Fork`](#fork)
             - [`Crosslink`](#crosslink)
             - [`Eth1Data`](#eth1data)
-            - [`Eth1DataVote`](#eth1datavote)
             - [`AttestationData`](#attestationdata)
             - [`AttestationDataAndCustodyBit`](#attestationdataandcustodybit)
             - [`IndexedAttestation`](#indexedattestation)
@@ -229,7 +228,7 @@ These configurations are updated for releases, but may be out of sync during `de
 | `SLOTS_PER_EPOCH` | `2**6` (= 64) | slots | 6.4 minutes |
 | `MIN_SEED_LOOKAHEAD` | `2**0` (= 1) | epochs | 6.4 minutes |
 | `ACTIVATION_EXIT_DELAY` | `2**2` (= 4) | epochs | 25.6 minutes |
-| `EPOCHS_PER_ETH1_VOTING_PERIOD` | `2**4` (= 16) | epochs | ~1.7 hours |
+| `SLOTS_PER_ETH1_VOTING_PERIOD` | `2**10` (= 1,024) | slots | ~1.7 hours |
 | `SLOTS_PER_HISTORICAL_ROOT` | `2**13` (= 8,192) | slots | ~13 hours |
 | `MIN_VALIDATOR_WITHDRAWABILITY_DELAY` | `2**8` (= 256) | epochs | ~27 hours |
 | `PERSISTENT_COMMITTEE_PERIOD` | `2**11` (= 2,048)  | epochs | 9 days  |
@@ -322,17 +321,6 @@ The types are defined topologically to aid in facilitating an executable version
     'deposit_count': 'uint64',
     # Block hash
     'block_hash': 'bytes32',
-}
-```
-
-#### `Eth1DataVote`
-
-```python
-{
-    # Data being voted for
-    'eth1_data': Eth1Data,
-    # Vote count
-    'vote_count': 'uint64',
 }
 ```
 
@@ -615,7 +603,7 @@ The types are defined topologically to aid in facilitating an executable version
 
     # Ethereum 1.0 chain data
     'latest_eth1_data': Eth1Data,
-    'eth1_data_votes': [Eth1DataVote],
+    'eth1_data_votes': ['bytes32', SLOTS_PER_ETH1_VOTING_PERIOD],
     'deposit_index': 'uint64',
 }
 ```
@@ -1485,7 +1473,7 @@ def get_genesis_beacon_state(genesis_validator_deposits: List[Deposit],
 
         # Ethereum 1.0 chain data
         latest_eth1_data=genesis_eth1_data,
-        eth1_data_votes=[],
+        eth1_data_votes=Vector([ZERO_HASH for _ in range(SLOTS_PER_ETH1_VOTING_PERIOD)]),
         deposit_index=0,
     )
 
@@ -1791,13 +1779,10 @@ Run the following function:
 
 ```python
 def maybe_reset_eth1_period(state: BeaconState) -> None:
-    if (get_current_epoch(state) + 1) % EPOCHS_PER_ETH1_VOTING_PERIOD == 0:
-        for eth1_data_vote in state.eth1_data_votes:
-            # If a majority of all votes were for a particular eth1_data value,
-            # then set that as the new canonical value
-            if eth1_data_vote.vote_count * 2 > EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH:
-                state.latest_eth1_data = eth1_data_vote.eth1_data
-        state.eth1_data_votes = []
+    if state.slot % SLOTS_PER_ETH1_VOTING_PERIOD == 0:
+        for eth1_data in state.eth1_data_votes:
+            if state.eth_data_votes.count(eth1_data) * 2 > SLOTS_PER_ETH1_VOTING_PERIOD:
+                state.latest_eth1_data = eth1_data
 ```
 
 #### Rewards and penalties
@@ -2076,13 +2061,7 @@ def process_randao(state: BeaconState, block: BeaconBlock) -> None:
 
 ```python
 def process_eth1_data(state: BeaconState, block: BeaconBlock) -> None:
-    for eth1_data_vote in state.eth1_data_votes:
-        # If someone else has already voted for the same hash, add to its counter
-        if eth1_data_vote.eth1_data == block.body.eth1_data:
-            eth1_data_vote.vote_count += 1
-            return
-    # If we're seeing this hash for the first time, make a new counter
-    state.eth1_data_votes.append(Eth1DataVote(eth1_data=block.body.eth1_data, vote_count=1))
+    state.eth1_data_votes[state.slot % SLOTS_PER_ETH1_VOTING_PERIOD] = block.body.eth1_data
 ```
 
 #### Operations

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -2053,7 +2053,7 @@ def process_randao(state: BeaconState, block: BeaconBlock) -> None:
 def process_eth1_data(state: BeaconState, block: BeaconBlock) -> None:
     state.eth1_data_votes.append(block.body.eth1_data)
     for eth1_data in state.eth1_data_votes:
-        if state.eth_data_votes.count(eth1_data) * 2 > SLOTS_PER_ETH1_VOTING_PERIOD:
+        if state.eth1_data_votes.count(eth1_data) * 2 > SLOTS_PER_ETH1_VOTING_PERIOD:
             state.latest_eth1_data = eth1_data
 ```
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -603,7 +603,7 @@ The types are defined topologically to aid in facilitating an executable version
 
     # Ethereum 1.0 chain data
     'latest_eth1_data': Eth1Data,
-    'eth1_data_votes': [Eth1Data, SLOTS_PER_ETH1_VOTING_PERIOD],
+    'eth1_data_votes': [Eth1Data],
     'deposit_index': 'uint64',
 }
 ```
@@ -1473,7 +1473,7 @@ def get_genesis_beacon_state(genesis_validator_deposits: List[Deposit],
 
         # Ethereum 1.0 chain data
         latest_eth1_data=genesis_eth1_data,
-        eth1_data_votes=Vector([Eth1Data() for _ in range(SLOTS_PER_ETH1_VOTING_PERIOD)]),
+        eth1_data_votes=[],
         deposit_index=0,
     )
 
@@ -1783,7 +1783,7 @@ def maybe_reset_eth1_period(state: BeaconState) -> None:
         for eth1_data in state.eth1_data_votes:
             if eth1_data != Eth1Data() and state.eth_data_votes.count(eth1_data) * 2 > SLOTS_PER_ETH1_VOTING_PERIOD:
                 state.latest_eth1_data = eth1_data
-        state.eth1_data_votes = Vector([Eth1Data() for _ in range(SLOTS_PER_ETH1_VOTING_PERIOD)])
+        state.eth1_data_votes = []
 ```
 
 #### Rewards and penalties

--- a/test_libs/pyspec/eth2spec/phase0/state_transition.py
+++ b/test_libs/pyspec/eth2spec/phase0/state_transition.py
@@ -91,7 +91,6 @@ def process_block(state: BeaconState,
 def process_epoch_transition(state: BeaconState) -> None:
     spec.update_justification_and_finalization(state)
     spec.process_crosslinks(state)
-    spec.maybe_reset_eth1_period(state)
     spec.apply_rewards(state)
     spec.process_balance_driven_status_transitions(state)
     spec.update_registry(state)


### PR DESCRIPTION
* Remove `Eth1DataVote` object and simplify logic throughout. 29 lines removed 🎉
* Reduce voting latency by counting votes per block 🎉 
* Reduce worst-case beacon state overhead