### PR TITLE
Fixes verify_merkle_branch indexing error

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1030,9 +1030,9 @@ def verify_merkle_branch(leaf: Bytes32, proof: List[Bytes32], depth: int, index:
     value = leaf
     for i in range(depth):
         if index // (2**i) % 2:
-            value = hash(proof[i] + value)
+            value = hash(proof[index] + value)
         else:
-            value = hash(value + proof[i])
+            value = hash(value + proof[index])
     return value == root
 ```
 


### PR DESCRIPTION
verify_merkle_branch should get proof(index) not proof(i), since the size of proof doesn't index the depth