### PR TITLE
Change CI to not trigger gen building

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,12 +15,12 @@ jobs:
           name: Run py-tests
           command: make test
 
-      - run:
-          name: Generate YAML tests
-          command: make gen_yaml_tests
-
-# TODO in future PR (after #851): decide on CI triggering of yaml tests building,
+# TODO see #928: decide on CI triggering of yaml tests building,
 #  and destination of output (new yaml tests LFS-configured repository)
+#
+#      - run:
+#          name: Generate YAML tests
+#          command: make gen_yaml_tests
 #
 #      - store_artifacts:
 #          path: test-reports


### PR DESCRIPTION
Change CI to not trigger generator building, since output is not committed anyway. See issue #928