### PR TITLE
Add the prefix `state` when accessing the latest deposit count

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -2155,7 +2155,7 @@ def process_proposer_attestation_rewards(state: BeaconState) -> None:
 
 ##### Deposits
 
-Verify that `len(block.body.deposits) == min(MAX_DEPOSITS, latest_eth1_data.deposit_count - state.deposit_index)`.
+Verify that `len(block.body.deposits) == min(MAX_DEPOSITS, state.latest_eth1_data.deposit_count - state.deposit_index)`.
 
 For each `deposit` in `block.body.deposits`, run the following function:
 


### PR DESCRIPTION
While it seems clear from context, be consistent with the rest of the document by explicitly accessing the latest `deposit_count` via the `state` object.