### PR TITLE
BLS—separate cryptographic-layer from application-layer

### DIFF
--- a/scripts/phase0/build_spec.py
+++ b/scripts/phase0/build_spec.py
@@ -5,7 +5,7 @@ import function_puller
 def build_phase0_spec(sourcefile, outfile):
     code_lines = []
     code_lines.append("""
-    
+
 from typing import (
     Any,
     Callable,
@@ -14,9 +14,8 @@ from typing import (
     NewType,
     Tuple,
 )
-from eth2spec.utils.minimal_ssz import *
-from eth2spec.utils.bls_stub import *
 
+from eth2spec.phase0.data_types import *
 
     """)
     for i in (1, 2, 3, 4, 8, 32, 48, 96):
@@ -29,17 +28,12 @@ SLOTS_PER_EPOCH = 64
 
 def slot_to_epoch(x): return x // SLOTS_PER_EPOCH
 
-
-Slot = NewType('Slot', int)  # uint64
-Epoch = NewType('Epoch', int)  # uint64
-Shard = NewType('Shard', int)  # uint64
-ValidatorIndex = NewType('ValidatorIndex', int)  # uint64
-Gwei = NewType('Gwei', int)  # uint64
-Bytes32 = NewType('Bytes32', bytes)  # bytes32
-BLSPubkey = NewType('BLSPubkey', bytes)  # bytes48
-BLSSignature = NewType('BLSSignature', bytes)  # bytes96
 Any = None
 Store = None
+
+
+from eth2spec.utils.minimal_ssz import *
+from eth2spec.utils.bls_stub import *
     """)
 
     code_lines += function_puller.get_spec(sourcefile)
@@ -88,7 +82,7 @@ def apply_constants_preset(preset: Dict[str, Any]):
 
     # Deal with derived constants
     global_vars['GENESIS_EPOCH'] = slot_to_epoch(GENESIS_SLOT)
-    
+
     # Initialize SSZ types again, to account for changed lengths
     init_SSZ_types()
 """)

--- a/specs/bls_signature.md
+++ b/specs/bls_signature.md
@@ -18,6 +18,8 @@
         - [`bls_aggregate_pubkeys`](#bls_aggregate_pubkeys)
         - [`bls_aggregate_signatures`](#bls_aggregate_signatures)
     - [Signature verification](#signature-verification)
+        - [`raw_bls_verify`](#raw_bls_verify)
+        - [`raw_bls_verify_multiple`](#raw_bls_verify_multiple)
         - [`bls_verify`](#bls_verify)
         - [`bls_verify_multiple`](#bls_verify_multiple)
 

--- a/specs/bls_signature.md
+++ b/specs/bls_signature.md
@@ -142,7 +142,7 @@ def bls_verify(pubkey: Bytes48, self_signed_object: Any, domain: Bytes8) -> bool
 ### `bls_verify_multiple`
 
 ```python
-def bls_verify(pubkeys: List[Bytes48], roots: List[Bytes32], signature: Bytes96, domain: Bytes8) -> bool:
+def bls_verify_multiple(pubkeys: List[Bytes48], roots: List[Bytes32], signature: Bytes96, domain: Bytes8) -> bool:
     messages = [domain + root for root in roots]
     return bls_verify_multiple(pubkey, messages, signature)
 ```

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1059,13 +1059,13 @@ def get_total_balance(state: BeaconState, validators: List[ValidatorIndex]) -> G
 ```python
 def get_domain(state: BeaconState,
                domain_type: int,
-               message_epoch: int=None) -> int:
+               message_epoch: int=None) -> Bytes8:
     """
     Return the signature domain (fork version concatenated with domain type) of a message.
     """
     epoch = get_current_epoch(state) if message_epoch is None else message_epoch
     fork_version = state.fork.previous_version if epoch < state.fork.epoch else state.fork.current_version
-    return bytes_to_int(fork_version + int_to_bytes4(domain_type))
+    return fork_version + int_to_bytes4(domain_type)
 ```
 
 ### `get_bitfield_bit`
@@ -1219,16 +1219,9 @@ def get_churn_limit(state: BeaconState) -> int:
     )
 ```
 
-### `raw_bls_verify`
-
-`raw_bls_verify` is a function for verifying a BLS signature, defined in the [BLS Signature spec](../bls_signature.md#bls_verify).
-
 ### `bls_verify`
 
-```python
-def bls_verify(pubkey: bytes48, self_signed_object: Any, domain: bytes4) -> bool:
-    return raw_bls_verify(pubkey, domain + signed_root(self_signed_object), self_signed_object.signature)
-```
+`bls_verify` is a function for verifying a BLS signature, defined in the [BLS Signature spec](../bls_signature.md#bls_verify).
 
 ### `bls_verify_multiple`
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -28,6 +28,7 @@
             - [`AttestationData`](#attestationdata)
             - [`AttestationDataAndCustodyBit`](#attestationdataandcustodybit)
             - [`IndexedAttestation`](#indexedattestation)
+            - [`RandaoReveal`](#randaoreveal)
             - [`DepositData`](#depositdata)
             - [`BeaconBlockHeader`](#beaconblockheader)
             - [`Validator`](#validator)
@@ -1145,7 +1146,7 @@ def verify_indexed_attestation(state: BeaconState, indexed_attestation: IndexedA
             bls_aggregate_pubkeys([state.validator_registry[i].pubkey for i in custody_bit_0_indices]),
             bls_aggregate_pubkeys([state.validator_registry[i].pubkey for i in custody_bit_1_indices]),
         ],
-        message_hashes=[
+        roots=[
             hash_tree_root(AttestationDataAndCustodyBit(data=indexed_attestation.data, custody_bit=0b0)),
             hash_tree_root(AttestationDataAndCustodyBit(data=indexed_attestation.data, custody_bit=0b1)),
         ],

--- a/specs/core/1_custody-game.md
+++ b/specs/core/1_custody-game.md
@@ -235,7 +235,7 @@ def epoch_to_custody_period(epoch: Epoch) -> int:
 def verify_custody_key(state: BeaconState, reveal: CustodyKeyReveal) -> bool:
     # Case 1: non-masked non-punitive non-early reveal
     pubkeys = [state.validator_registry[reveal.revealer_index].pubkey]
-    message_hashes = [hash_tree_root(reveal.period)]
+    roots = [hash_tree_root(reveal.period)]
 
     # Case 2: masked punitive early reveal
     # Masking prevents proposer stealing the whistleblower reward
@@ -243,11 +243,11 @@ def verify_custody_key(state: BeaconState, reveal: CustodyKeyReveal) -> bool:
     # See pages 11-12 of https://crypto.stanford.edu/~dabo/pubs/papers/aggreg.pdf
     if reveal.mask != ZERO_HASH:
         pubkeys.append(state.validator_registry[reveal.masker_index].pubkey)
-        message_hashes.append(reveal.mask)
+        roots.append(reveal.mask)
 
     return bls_verify_multiple(
         pubkeys=pubkeys,
-        message_hashes=message_hashes,
+        roots=roots,
         signature=reveal.key,
         domain=get_domain(
             fork=state.fork,

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -165,7 +165,7 @@ def get_persistent_committee(state: BeaconState,
         len(get_active_validator_indices(state.validator_registry, later_start_epoch)) //
         (SHARD_COUNT * TARGET_COMMITTEE_SIZE),
     ) + 1
-    
+
     index = slot % committee_count
     earlier_committee = get_period_committee(state, shard, earlier_start_epoch, index, committee_count)
     later_committee = get_period_committee(state, shard, later_start_epoch, index, committee_count)

--- a/test_libs/pyspec/eth2spec/phase0/data_types.py
+++ b/test_libs/pyspec/eth2spec/phase0/data_types.py
@@ -1,0 +1,13 @@
+from typing import NewType
+
+Slot = NewType('Slot', int)  # uint64
+Epoch = NewType('Epoch', int)  # uint64
+Shard = NewType('Shard', int)  # uint64
+ValidatorIndex = NewType('ValidatorIndex', int)  # uint64
+Gwei = NewType('Gwei', int)  # uint64
+Bytes8 = NewType('Bytes8', bytes)  # bytes8
+Bytes32 = NewType('Bytes32', bytes)  # bytes32
+Bytes48 = NewType('Bytes48', bytes)  # bytes48
+Bytes96 = NewType('Bytes96', bytes)  # bytes96
+BLSPubkey = NewType('BLSPubkey', bytes)  # bytes48
+BLSSignature = NewType('BLSSignature', bytes)  # bytes96

--- a/test_libs/pyspec/eth2spec/utils/bls_stub.py
+++ b/test_libs/pyspec/eth2spec/utils/bls_stub.py
@@ -1,12 +1,14 @@
+from typing import List, Any
+from eth2spec.phase0.data_types import *
 
 
-def bls_verify(pubkey, message_hash, signature, domain):
+def bls_verify(pubkey: Bytes48, self_signed_object: Any, domain: Bytes8) -> bool:
     return True
 
 
-def bls_verify_multiple(pubkeys, message_hashes, signature, domain):
+def bls_verify_multiple(pubkeys: List[Bytes48], roots: List[Bytes32], signature: Bytes96, domain: Bytes8) -> bool:
     return True
 
 
-def bls_aggregate_pubkeys(pubkeys):
+def bls_aggregate_pubkeys(pubkeys: List[Bytes48]):
     return b'\x42' * 96

--- a/test_libs/pyspec/tests/helpers.py
+++ b/test_libs/pyspec/tests/helpers.py
@@ -243,7 +243,7 @@ def get_valid_proposer_slashing(state):
 
     domain = get_domain(
         state=state,
-        domain_type=spec.DOMAIN_BEACON_PROPOSER,
+        domain_type=spec.DOMAIN_PROPOSER,
     )
     header_1.signature = bls.sign(
         message_hash=signing_root(header_1),


### PR DESCRIPTION
Cryptographic layer (under standardisation):
   * Do not deal with application-layer domains (as per initial standardisation rough consensus)
   * Allow for arbitrary long messages to `hash_to_G2` (as per initial standardisation rough consensus)
   * Use `raw_bls_verify` and `raw_bls_verify_multiple` (as opposed to `bls_verify` and `bls_verify_multiple` for application layer)

Application layer:
   * Abstract away self-signed object logic (only 3 inputs to `bls_verify` instead of 4)
   * Clean up domains (use `Bytes4` instead of `int`)
   * Add `RandaoReveal` object