### PR TITLE
Disallow transfers

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -257,7 +257,7 @@ These configurations are updated for releases, but may be out of sync during `de
 | `MAX_ATTESTATIONS` | `2**7` (= 128) |
 | `MAX_DEPOSITS` | `2**4` (= 16) |
 | `MAX_VOLUNTARY_EXITS` | `2**4` (= 16) |
-| `MAX_TRANSFERS` | `2**4` (= 16) |
+| `MAX_TRANSFERS` | `0` |
 
 ### Signature domains
 

--- a/test_libs/pyspec/tests/test_sanity.py
+++ b/test_libs/pyspec/tests/test_sanity.py
@@ -380,7 +380,10 @@ def test_voluntary_exit(state):
     return pre_state, [initiate_exit_block, exit_block], post_state
 
 
-def test_transfer(state):
+def test_transfer(state, config):
+    # overwrite default 0 to test
+    spec.MAX_TRANSFERS = 1
+
     pre_state = deepcopy(state)
     current_epoch = get_current_epoch(pre_state)
     sender_index = get_active_validator_indices(pre_state, current_epoch)[-1]


### PR DESCRIPTION
As discussed in yesterday's call, temporarily disable transfers until the network is deemed stable enough. We can consider doing a "test-run hard fork" changing this constant prior to the phase 1 hard fork.