### PR TITLE
Generators workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ venv
 build/
 output/
 
-yaml_tests/
+eth2.0-spec-tests/
 .pytest_cache
 
 # Dynamically built from Markdown spec

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SPEC_DIR = ./specs
 SCRIPT_DIR = ./scripts
 TEST_LIBS_DIR = ./test_libs
 PY_SPEC_DIR = $(TEST_LIBS_DIR)/pyspec
-YAML_TEST_DIR = ./yaml_tests
+YAML_TEST_DIR = ./eth2.0-spec-tests/tests
 GENERATOR_DIR = ./test_generators
 CONFIGS_DIR = ./configs
 

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ clean:
 	rm -rf $(PY_SPEC_ALL_TARGETS)
 
 # "make gen_yaml_tests" to run generators
-gen_yaml_tests: $(YAML_TEST_DIR) $(YAML_TEST_TARGETS)
+gen_yaml_tests: $(YAML_TEST_TARGETS)
 
 # runs a limited set of tests against a minimal config
 test: $(PY_SPEC_ALL_TARGETS)
@@ -48,24 +48,30 @@ CURRENT_DIR = ${CURDIR}
 
 # The function that builds a set of suite files, by calling a generator for the given type (param 1)
 define build_yaml_tests
-	$(info running generator $(1))
-	# Create the output
-	mkdir -p $(YAML_TEST_DIR)$(1)
-
-	# 1) Create a virtual environment
-	# 2) Activate the venv, this is where dependencies are installed for the generator
-	# 3) Install all the necessary requirements
-	# 4) Run the generator. The generator is assumed to have an "main.py" file.
-	# 5) We output to the tests dir (generator program should accept a "-o <filepath>" argument.
-	cd $(GENERATOR_DIR)$(1); python3 -m venv venv; . venv/bin/activate; pip3 install -r requirements.txt; python3 main.py -o $(CURRENT_DIR)/$(YAML_TEST_DIR)$(1) -c $(CURRENT_DIR)/$(CONFIGS_DIR)
-
-	$(info generator $(1) finished)
+	# Started!
+	# Create output directory
+	# Navigate to the generator
+	# Create a virtual environment, if it does not exist already
+	# Activate the venv, this is where dependencies are installed for the generator
+	# Install all the necessary requirements
+	# Run the generator. The generator is assumed to have an "main.py" file.
+	# We output to the tests dir (generator program should accept a "-o <filepath>" argument.
+	echo "generator $(1) started"; \
+	mkdir -p $(YAML_TEST_DIR)$(1); \
+	cd $(GENERATOR_DIR)$(1); \
+	if test -d venv; then python3 -m venv venv; fi; \
+	. venv/bin/activate; \
+	pip3 install -r requirements.txt; \
+	python3 main.py -o $(CURRENT_DIR)/$(YAML_TEST_DIR)$(1) -c $(CURRENT_DIR)/$(CONFIGS_DIR); \
+	echo "generator $(1) finished"
 endef
 
 # The tests dir itself is simply build by creating the directory (recursively creating deeper directories if necessary)
 $(YAML_TEST_DIR):
 	$(info creating directory, to output yaml targets to: ${YAML_TEST_TARGETS})
 	mkdir -p $@
+$(YAML_TEST_DIR)/:
+	$(info ignoring duplicate yaml tests dir)
 
 # For any target within the tests dir, build it using the build_yaml_tests function.
 # (creation of output dir is a dependency)

--- a/test_generators/README.md
+++ b/test_generators/README.md
@@ -28,8 +28,11 @@ make clean
 This runs all the generators.
 
 ```bash
-make gen_yaml_tests
+make -j 4 gen_yaml_tests
 ```
+
+The `-j N` flag makes the generators run in parallel, with `N` being the amount of cores.
+
 
 ### Running a single generator
 

--- a/test_generators/operations/deposits.py
+++ b/test_generators/operations/deposits.py
@@ -29,7 +29,7 @@ def build_deposit_data(state,
         message_hash=signing_root(deposit_data),
         privkey=privkey,
         domain=spec.get_domain(
-            state.fork,
+            state,
             spec.get_current_epoch(state),
             spec.DOMAIN_DEPOSIT,
         )


### PR DESCRIPTION
After experimenting heavily with CI and generators, I decided it's better to keep generator triggering outside of CI for now.
What I experimented with:
- Mirror of eth2.0-specs, configured with circle CI
- Output repository with Git LFS
- Configured SSH key secret with Circle CI, and pubkey known with output repo to allow for write access.
- Cached generator `venv`s
- Shallow clone output repo
- trigger builds based on branch name prefixes, output to outputs repo on that same branch name, for parallel/async/fixing scenarios

Reasons to not approach this further as of now:
- Unreasonable complexity for something relatively formal and low-frequency
- Circle CI job configuration is poor. No way to configure paralllel jobs succinctly: repeats image, working dir, workflow dependency, and branch presets for every generator. I would rather keep it like the make-file, just automatic detection.
  - Note: we could put them all in one job, and allocate more CPU resources.
- Poor Git LFS support with circle CI. Not sure if I'm missing a command, but having the LFS attributes there, the new commits made by the bot did not add the files as LFS files properly. Likely have to install LFS, and activate it before making the commit.
- Not happy with the branch workflow:
  - Triggers based on a merge into a specific branch seem nice, but I dislike the noise it creates.
  - Anyone can create such a branch and make the CI run. The SSH key is not passed to runs triggered by outside contributors, but still feel like the build itself shouldn't trigger so easily.

Proposal to move forward:
- Run generators locally. No explicit caching necessary, the venvs are all right there (unless you `make clean`)
- Make generators run in parallel, `make -j 4 gen_yaml_tests` to run with 4 cores. Fixes to make this work + documentation included in this PR.
- Output tests to `<repo root>/eth2.0-spec-tests/tests`, with `<repo root>/eth2.0-spec-tests/` being a git-ignored folder. It's easy to manage the output repo, re-build the tests in there.
  - After rebuilding, it's just a matter of `git  add . && git commit -S -m "release foo bar" && git push`. You activate Git LFS once, and it just works.
- I'll create an issue to track how this goes, and we can introduce CI based generator triggering later, when we learn how to avoid the pitfalls of maintaining a large-size dynamicly generated repository through user-triggered CI...

What we need after this:
- Create a `eth2.0-spec-tests` repository, deprecating the old `eth2.0-tests`. We start fresh, with YAML files included using LFS, and a good amount of generators. The old `eth2.0-tests` is deprecated. The naming choice for `eth2.0-spec-tests` comes from the nature of these tests: they all test spec-behavior. Later on, we may have a ` `eth2.0-network-tests` or others.
  - `git lfs install`, `git lfs track "*.yaml"`, and commit `.gitattributes`
  - Add a `README.md`, `LICENSE`
- Update references to old tests, expand testing :)
