### PR TITLE
Signal non-final status of base reward and desired issuance goal

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -241,7 +241,7 @@ These configurations are updated for releases, but may be out of sync during `de
 | `INACTIVITY_PENALTY_QUOTIENT` | `2**24` (= 16,777,216) |
 | `MIN_PENALTY_QUOTIENT` | `2**5` (= 32) |
 
-* The `BASE_REWARD_QUOTIENT` parameter dictates the per-epoch reward. It corresponds to ~2.54% annual interest assuming 10 million participating ETH in every epoch.
+* **The `BASE_REWARD_QUOTIENT` is NOT final. Once all other protocol details are finalized it will be adjusted, to target a theoretical maximum total issuance of `2**21` ETH per year if `2**27` ETH is validating (and therefore `2**20` per year if `2**25` ETH is validating, etc etc)**
 * The `INACTIVITY_PENALTY_QUOTIENT` equals `INVERSE_SQRT_E_DROP_TIME**2` where `INVERSE_SQRT_E_DROP_TIME := 2**12 epochs` (~18 days) is the time it takes the inactivity penalty to reduce the balance of non-participating [validators](#dfn-validator) to about `1/sqrt(e) ~= 60.6%`. Indeed, the balance retained by offline [validators](#dfn-validator) after `n` epochs is about `(1 - 1/INACTIVITY_PENALTY_QUOTIENT)**(n**2/2)` so after `INVERSE_SQRT_E_DROP_TIME` epochs it is roughly `(1 - 1/INACTIVITY_PENALTY_QUOTIENT)**(INACTIVITY_PENALTY_QUOTIENT/2) ~= 1/sqrt(e)`.
 
 ### Max operations per block


### PR DESCRIPTION
An issuance increase is proposed based on community feedback, to `2**21` ETH if `2**27` ETH is validating, along with an agreement to set the base reward quotient based on a pre-set max issuance bound once all protocol details are finalized.

Here's a table of new total issuance rates with this proposal:

| ETH validating | Max annual issuance | Max annual return rate |
| - | - | - |
| 1,000,000 | 181,019 | 18.10% |
| 3,000,000 | 313,534 | 10.45% |
| 10,000,000 | 572,433 | 5.72% |
| 30,000,000 | 991,483 | 3.30% |
|100,000,000 | 1,810,193 | 1.81% |
| 134,217,728 | 2,097,152 | 1.56% |