### PR TITLE
Add 32-byte graffiti

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -518,6 +518,7 @@ The types are defined topologically to aid in facilitating an executable version
 {
     'randao_reveal': 'bytes96',
     'eth1_data': Eth1Data,
+    'graffiti': 'bytes32',
     'proposer_slashings': [ProposerSlashing],
     'attester_slashings': [AttesterSlashing],
     'attestations': [Attestation],


### PR DESCRIPTION
Add 32-byte of arbitrary "graffiti" data in beacon blocks, in a similar vein to `extraData` in Eth1 headers. To be used in wonderful and unpredictable ways (permissionless innovation by block proposers).