### PR TITLE
Remove get_state_root from state transition doc

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -66,7 +66,6 @@
         - [`get_attestation_slot`](#get_attestation_slot)
         - [`get_block_root_at_slot`](#get_block_root_at_slot)
         - [`get_block_root`](#get_block_root)
-        - [`get_state_root`](#get_state_root)
         - [`get_randao_mix`](#get_randao_mix)
         - [`get_active_index_root`](#get_active_index_root)
         - [`generate_seed`](#generate_seed)
@@ -791,18 +790,6 @@ def get_block_root(state: BeaconState,
     Return the block root at a recent ``epoch``.
     """
     return get_block_root_at_slot(state, get_epoch_start_slot(epoch))
-```
-
-### `get_state_root`
-
-```python
-def get_state_root(state: BeaconState,
-                   slot: Slot) -> Bytes32:
-    """
-    Return the state root at a recent ``slot``.
-    """
-    assert slot < state.slot <= slot + SLOTS_PER_HISTORICAL_ROOT
-    return state.latest_state_roots[slot % SLOTS_PER_HISTORICAL_ROOT]
 ```
 
 ### `get_randao_mix`

--- a/test_libs/pyspec/tests/helpers.py
+++ b/test_libs/pyspec/tests/helpers.py
@@ -412,3 +412,11 @@ def next_epoch(state):
     block.slot += spec.SLOTS_PER_EPOCH - (state.slot % spec.SLOTS_PER_EPOCH)
     state_transition(state, block)
     return block
+
+
+def get_state_root(state, slot) -> bytes:
+    """
+    Return the state root at a recent ``slot``.
+    """
+    assert slot < state.slot <= slot + spec.SLOTS_PER_HISTORICAL_ROOT
+    return state.latest_state_roots[slot % spec.SLOTS_PER_HISTORICAL_ROOT]

--- a/test_libs/pyspec/tests/test_sanity.py
+++ b/test_libs/pyspec/tests/test_sanity.py
@@ -9,6 +9,7 @@ from eth2spec.utils.minimal_ssz import signing_root
 from eth2spec.phase0.spec import (
     # constants
     ZERO_HASH,
+    SLOTS_PER_HISTORICAL_ROOT,
     # SSZ
     Deposit,
     Transfer,
@@ -17,7 +18,6 @@ from eth2spec.phase0.spec import (
     get_active_validator_indices,
     get_beacon_proposer_index,
     get_block_root_at_slot,
-    get_state_root,
     get_current_epoch,
     get_domain,
     advance_slot,
@@ -38,6 +38,7 @@ from .helpers import (
     build_deposit_data,
     build_empty_block_for_next_slot,
     fill_aggregate_attestation,
+    get_state_root,
     get_valid_attestation,
     get_valid_attester_slashing,
     get_valid_proposer_slashing,


### PR DESCRIPTION
Remove `get_state_root` from the state transition function spec because it is not used by the state transition function. (Unused code affects spec testability and conciseness. Also note that `get_state_root` is slot-based which is inconsistent with its `get_block_root` counterpart.)

The `get_state_root` helper *is* used by the test suite and is now defined there. If useful to validators beyond the test suite, it may make sense to define `get_state_root` in the validator doc.