### PR TITLE
Fix underflows from #1017

### DIFF
--- a/scripts/phase0/build_spec.py
+++ b/scripts/phase0/build_spec.py
@@ -48,10 +48,8 @@ def compute_committee(indices: List[ValidatorIndex], seed: Bytes32, index: int, 
     param_hash = (hash_tree_root(indices), seed, index, count)
 
     if param_hash in committee_cache:
-        # print("Cache hit, param_hash: ", param_hash)
         return committee_cache[param_hash]
     else:
-        # print("Cache miss, param_hash: ", param_hash)
         ret = _compute_committee(indices, seed, index, count)
         committee_cache[param_hash] = ret
         return ret

--- a/scripts/phase0/build_spec.py
+++ b/scripts/phase0/build_spec.py
@@ -48,10 +48,10 @@ def compute_committee(indices: List[ValidatorIndex], seed: Bytes32, index: int, 
     param_hash = (hash_tree_root(indices), seed, index, count)
 
     if param_hash in committee_cache:
-        print("Cache hit, param_hash: ", param_hash)
+        # print("Cache hit, param_hash: ", param_hash)
         return committee_cache[param_hash]
     else:
-        print("Cache miss, param_hash: ", param_hash)
+        # print("Cache miss, param_hash: ", param_hash)
         ret = _compute_committee(indices, seed, index, count)
         committee_cache[param_hash] = ret
         return ret

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -800,7 +800,8 @@ def get_randao_mix(state: BeaconState,
     """
     Return the randao mix at a recent ``epoch``.
     """
-    assert get_current_epoch(state) - LATEST_RANDAO_MIXES_LENGTH < epoch <= get_current_epoch(state)
+    min_epoch = epoch - LATEST_RANDAO_MIXES_LENGTH + 1 if epoch > LATEST_RANDAO_MIXES_LENGTH else GENESIS_EPOCH
+    assert min_epoch <= epoch <= get_current_epoch(state)
     return state.latest_randao_mixes[epoch % LATEST_RANDAO_MIXES_LENGTH]
 ```
 
@@ -812,7 +813,8 @@ def get_active_index_root(state: BeaconState,
     """
     Return the index root at a recent ``epoch``.
     """
-    assert get_current_epoch(state) - LATEST_ACTIVE_INDEX_ROOTS_LENGTH + ACTIVATION_EXIT_DELAY < epoch <= get_current_epoch(state) + ACTIVATION_EXIT_DELAY
+    min_epoch = get_current_epoch(state) + ACTIVATION_EXIT_DELAY - LATEST_ACTIVE_INDEX_ROOTS_LENGTH + 1 if epoch > LATEST_ACTIVE_INDEX_ROOTS_LENGTH - ACTIVATION_EXIT_DELAY else GENESIS_EPOCH
+    assert min_epoch <= epoch <= get_current_epoch(state) + ACTIVATION_EXIT_DELAY
     return state.latest_active_index_roots[epoch % LATEST_ACTIVE_INDEX_ROOTS_LENGTH]
 ```
 
@@ -825,7 +827,7 @@ def generate_seed(state: BeaconState,
     Generate a seed for the given ``epoch``.
     """
     return hash(
-        get_randao_mix(state, epoch - MIN_SEED_LOOKAHEAD) +
+        get_randao_mix(state, epoch - MIN_SEED_LOOKAHEAD) if epoch >= MIN_SEED_LOOKAHEAD else ZERO_HASH +
         get_active_index_root(state, epoch) +
         int_to_bytes32(epoch)
     )

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -799,9 +799,8 @@ def get_randao_mix(state: BeaconState,
                    epoch: Epoch) -> Bytes32:
     """
     Return the randao mix at a recent ``epoch``.
+    ``epoch`` expected to be between (current_epoch - LATEST_RANDAO_MIXES_LENGTH, current_epoch].
     """
-    min_epoch = epoch - LATEST_RANDAO_MIXES_LENGTH + 1 if epoch > LATEST_RANDAO_MIXES_LENGTH else GENESIS_EPOCH
-    assert min_epoch <= epoch <= get_current_epoch(state)
     return state.latest_randao_mixes[epoch % LATEST_RANDAO_MIXES_LENGTH]
 ```
 
@@ -812,9 +811,9 @@ def get_active_index_root(state: BeaconState,
                           epoch: Epoch) -> Bytes32:
     """
     Return the index root at a recent ``epoch``.
+    ``epoch`` expected to be between
+    (current_epoch - LATEST_ACTIVE_INDEX_ROOTS_LENGTH + ACTIVATION_EXIT_DELAY, current_epoch + ACTIVATION_EXIT_DELAY].
     """
-    min_epoch = get_current_epoch(state) + ACTIVATION_EXIT_DELAY - LATEST_ACTIVE_INDEX_ROOTS_LENGTH + 1 if epoch > LATEST_ACTIVE_INDEX_ROOTS_LENGTH - ACTIVATION_EXIT_DELAY else GENESIS_EPOCH
-    assert min_epoch <= epoch <= get_current_epoch(state) + ACTIVATION_EXIT_DELAY
     return state.latest_active_index_roots[epoch % LATEST_ACTIVE_INDEX_ROOTS_LENGTH]
 ```
 
@@ -827,7 +826,7 @@ def generate_seed(state: BeaconState,
     Generate a seed for the given ``epoch``.
     """
     return hash(
-        get_randao_mix(state, epoch - MIN_SEED_LOOKAHEAD) if epoch >= MIN_SEED_LOOKAHEAD else ZERO_HASH +
+        get_randao_mix(state, epoch + LATEST_RANDAO_MIXES_LENGTH - MIN_SEED_LOOKAHEAD) +
         get_active_index_root(state, epoch) +
         int_to_bytes32(epoch)
     )


### PR DESCRIPTION
prevent underflows in `generate_seed`, `get_randao_mix`, and `get_active_index_root`.

Note that for epochs less than `MIN_SEED_LOOKAHEAD` we use `ZERO_HASH` rather than just pulling from `get_randao_mix(state, GENESIS_EPOCH)` because the randao_mix at `GENESIS_EPOCH` is not static and would thus break lookahead.