### PR TITLE
update shuffling func name

### DIFF
--- a/test_generators/shuffling/main.py
+++ b/test_generators/shuffling/main.py
@@ -10,7 +10,7 @@ from preset_loader import loader
 def shuffling_case(seed: spec.Bytes32, count: int):
     yield 'seed', '0x' + seed.hex()
     yield 'count', count
-    yield 'shuffled', [spec.get_permuted_index(i, count, seed) for i in range(count)]
+    yield 'shuffled', [spec.get_shuffled_index(i, count, seed) for i in range(count)]
 
 
 @to_tuple


### PR DESCRIPTION
Note 1: merging into `v06x` branch. The intention here is not to pollute the master branch for fixes to the latest release. And then merge `v06x` into master for a new `v0.6.x` release, and merge into dev to port over fixes + testing improvements.

Note 2: a near-term goal of mine is to generalize the setup of some of the pytests and generators, and hopefully catch these types of problems earlier, and have more tests generated based on the pytests effort (it's understandable people prioritize testing the spec over providing tests for implementers, but I do want to see more consistency between the two).

The generator broke because of #1009 renaming `get_permuted_index` to `get_shuffled_index`. Fixed that.