### PR TITLE
fix lint CI race condition

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,12 +102,12 @@ workflows:
   test_spec:
     jobs:
       - checkout_specs
+      - lint:
+          requires:
+            - checkout_specs
       - install_test:
           requires:
             - checkout_specs
       - test:
-          requires:
-            - install_test
-      - lint:
           requires:
             - install_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ jobs:
           reqs_checksum: '{{ checksum "test_libs/pyspec/requirements.txt" }}-{{ checksum "test_libs/pyspec/requirements-testing.txt" }}'
       - run:
           name: Run linter
-          command: make install_lint && make pyspec && make lint
+          command: make install_lint && make lint
 workflows:
   version: 2.1
   test_spec:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,10 +102,12 @@ workflows:
   test_spec:
     jobs:
       - checkout_specs
-      - lint
       - install_test:
           requires:
             - checkout_specs
       - test:
+          requires:
+            - install_test
+      - lint:
           requires:
             - install_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,13 +60,13 @@ jobs:
       - restore_cache:
           key: v1-specs-repo-{{ .Branch }}-{{ .Revision }}
       - restore_cached_venv:
-          venv_name: v1-pyspec-02
+          venv_name: v1-pyspec-03
           reqs_checksum: '{{ checksum "test_libs/pyspec/requirements.txt" }}-{{ checksum "test_libs/pyspec/requirements-testing.txt" }}'
       - run:
           name: Install pyspec requirements
           command: make install_test && make install_lint
       - save_cached_venv:
-          venv_name: v1-pyspec-02
+          venv_name: v1-pyspec-03
           reqs_checksum: '{{ checksum "test_libs/pyspec/requirements.txt" }}-{{ checksum "test_libs/pyspec/requirements-testing.txt" }}'
           venv_path: ./test_libs/pyspec/venv
   build_pyspec:
@@ -77,7 +77,7 @@ jobs:
       - restore_cache:
           key: v1-specs-repo-{{ .Branch }}-{{ .Revision }}
       - restore_cached_venv:
-          venv_name: v1-pyspec-02
+          venv_name: v1-pyspec-03
           reqs_checksum: '{{ checksum "test_libs/pyspec/requirements.txt" }}-{{ checksum "test_libs/pyspec/requirements-testing.txt" }}'
       - run:
           name: Build pyspec
@@ -90,7 +90,7 @@ jobs:
       - restore_cache:
           key: v1-specs-repo-{{ .Branch }}-{{ .Revision }}
       - restore_cached_venv:
-          venv_name: v1-pyspec-02
+          venv_name: v1-pyspec-03
           reqs_checksum: '{{ checksum "test_libs/pyspec/requirements.txt" }}-{{ checksum "test_libs/pyspec/requirements-testing.txt" }}'
       - run:
           name: Run py-tests
@@ -105,7 +105,7 @@ jobs:
       - restore_cache:
           key: v1-specs-repo-{{ .Branch }}-{{ .Revision }}
       - restore_cached_venv:
-          venv_name: v1-pyspec-02
+          venv_name: v1-pyspec-03
           reqs_checksum: '{{ checksum "test_libs/pyspec/requirements.txt" }}-{{ checksum "test_libs/pyspec/requirements-testing.txt" }}'
       - run:
           name: Run linter

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,19 +69,6 @@ jobs:
           venv_name: v1-pyspec-03
           reqs_checksum: '{{ checksum "test_libs/pyspec/requirements.txt" }}-{{ checksum "test_libs/pyspec/requirements-testing.txt" }}'
           venv_path: ./test_libs/pyspec/venv
-  build_pyspec:
-    docker:
-      - image: circleci/python:3.6
-    working_directory: ~/specs-repo
-    steps:
-      - restore_cache:
-          key: v1-specs-repo-{{ .Branch }}-{{ .Revision }}
-      - restore_cached_venv:
-          venv_name: v1-pyspec-03
-          reqs_checksum: '{{ checksum "test_libs/pyspec/requirements.txt" }}-{{ checksum "test_libs/pyspec/requirements-testing.txt" }}'
-      - run:
-          name: Build pyspec
-          command: make pyspec
   test:
     docker:
       - image: circleci/python:3.6
@@ -118,13 +105,9 @@ workflows:
       - install_env:
           requires:
             - checkout_specs
-      - build_pyspec:
-          requires:
-            - checkout_specs
       - test:
           requires:
             - install_env
-            - build_pyspec
       - lint:
           requires:
-            - build_pyspec
+            - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,19 @@ jobs:
           venv_name: v1-pyspec-02
           reqs_checksum: '{{ checksum "test_libs/pyspec/requirements.txt" }}-{{ checksum "test_libs/pyspec/requirements-testing.txt" }}'
           venv_path: ./test_libs/pyspec/venv
+  build_pyspec:
+    docker:
+      - image: circleci/python:3.6
+    working_directory: ~/specs-repo
+    steps:
+      - restore_cache:
+          key: v1-specs-repo-{{ .Branch }}-{{ .Revision }}
+      - restore_cached_venv:
+          venv_name: v1-pyspec-02
+          reqs_checksum: '{{ checksum "test_libs/pyspec/requirements.txt" }}-{{ checksum "test_libs/pyspec/requirements-testing.txt" }}'
+      - run:
+          name: Build pyspec
+          command: make pyspec
   test:
     docker:
       - image: circleci/python:3.6
@@ -105,9 +118,13 @@ workflows:
       - install_env:
           requires:
             - checkout_specs
+      - build_pyspec:
+          requires:
+            - checkout_specs
       - test:
           requires:
             - install_env
+            - build_pyspec
       - lint:
           requires:
-            - test
+            - build_pyspec

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
           key: v1-specs-repo-{{ .Branch }}-{{ .Revision }}
           paths:
             - ~/specs-repo
-  install_test:
+  install_env:
     docker:
       - image: circleci/python:3.6
     working_directory: ~/specs-repo
@@ -64,7 +64,7 @@ jobs:
           reqs_checksum: '{{ checksum "test_libs/pyspec/requirements.txt" }}-{{ checksum "test_libs/pyspec/requirements-testing.txt" }}'
       - run:
           name: Install pyspec requirements
-          command: make install_test
+          command: make install_test && make install_lint
       - save_cached_venv:
           venv_name: v1-pyspec
           reqs_checksum: '{{ checksum "test_libs/pyspec/requirements.txt" }}-{{ checksum "test_libs/pyspec/requirements-testing.txt" }}'
@@ -96,18 +96,18 @@ jobs:
           reqs_checksum: '{{ checksum "test_libs/pyspec/requirements.txt" }}-{{ checksum "test_libs/pyspec/requirements-testing.txt" }}'
       - run:
           name: Run linter
-          command: make install_lint && make lint
+          command: make lint
 workflows:
   version: 2.1
   test_spec:
     jobs:
       - checkout_specs
-      - lint:
-          requires:
-            - checkout_specs
-      - install_test:
+      - install_env:
           requires:
             - checkout_specs
       - test:
           requires:
-            - install_test
+            - install_env
+      - lint:
+          requires:
+            - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,13 +60,13 @@ jobs:
       - restore_cache:
           key: v1-specs-repo-{{ .Branch }}-{{ .Revision }}
       - restore_cached_venv:
-          venv_name: v1-pyspec
+          venv_name: v1-pyspec-02
           reqs_checksum: '{{ checksum "test_libs/pyspec/requirements.txt" }}-{{ checksum "test_libs/pyspec/requirements-testing.txt" }}'
       - run:
           name: Install pyspec requirements
           command: make install_test && make install_lint
       - save_cached_venv:
-          venv_name: v1-pyspec
+          venv_name: v1-pyspec-02
           reqs_checksum: '{{ checksum "test_libs/pyspec/requirements.txt" }}-{{ checksum "test_libs/pyspec/requirements-testing.txt" }}'
           venv_path: ./test_libs/pyspec/venv
   test:
@@ -77,7 +77,7 @@ jobs:
       - restore_cache:
           key: v1-specs-repo-{{ .Branch }}-{{ .Revision }}
       - restore_cached_venv:
-          venv_name: v1-pyspec
+          venv_name: v1-pyspec-02
           reqs_checksum: '{{ checksum "test_libs/pyspec/requirements.txt" }}-{{ checksum "test_libs/pyspec/requirements-testing.txt" }}'
       - run:
           name: Run py-tests
@@ -92,7 +92,7 @@ jobs:
       - restore_cache:
           key: v1-specs-repo-{{ .Branch }}-{{ .Revision }}
       - restore_cached_venv:
-          venv_name: v1-pyspec
+          venv_name: v1-pyspec-02
           reqs_checksum: '{{ checksum "test_libs/pyspec/requirements.txt" }}-{{ checksum "test_libs/pyspec/requirements-testing.txt" }}'
       - run:
           name: Run linter

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ citest: $(PY_SPEC_ALL_TARGETS)
 install_lint:
 	cd $(PY_SPEC_DIR); python3 -m venv venv; . venv/bin/activate; pip3 install flake8==3.5.0
 
-lint:
+lint: $(PY_SPEC_ALL_TARGETS)
 	cd $(PY_SPEC_DIR); . venv/bin/activate; \
 	flake8 --max-line-length=120 ./eth2spec;
 


### PR DESCRIPTION
Lint CI requires `install_test` and was sometimes failing due to a race condition.

fixed!