### PR TITLE
Bigint and bitfield-as-integer

### DIFF
--- a/specs/simple-serialize.md
+++ b/specs/simple-serialize.md
@@ -96,6 +96,19 @@ return b"\x01" if value is True else b"\x00"
 return b""
 ```
 
+### `"bigint"`
+
+```python
+return value.to_bytes(log2(value)//8, "little")
+```
+
+### `"Bitfield"`
+
+```python
+as_integer = (1 << len(value)) + sum([value[i] << i for i in range(len(value))])
+return as_integer.to_bytes(log2(as_integer)//8, "little")
+```
+
 ### Vectors, containers, lists, unions
 
 ```python

--- a/specs/simple-serialize.md
+++ b/specs/simple-serialize.md
@@ -48,10 +48,12 @@
     * angle bracket notation `[type]`, e.g. `["uint64"]`
 * **union**: union type containing one of the given subtypes
     * round bracket notation `(type_1, type_2, ...)`, e.g. `("null", "uint64")`
+* **Bigint**: integer type that can contain a non-negative integer of any magnitude, represented by `"bytes"` of length `log2(value)//8`
+* **Bitfield**: an variable-length list of `"bool"` values
 
 ### Variable-size and fixed-size
 
-We recursively define "variable-size" types to be lists and unions and all types that contain a variable-size type. All other types are said to be "fixed-size".
+We recursively define "variable-size" types to be lists, unions, `Bigint`, `Bitfield` and all types that contain a variable-size type. All other types are said to be "fixed-size".
 
 ### Aliases
 
@@ -64,7 +66,7 @@ For convenience we alias:
 
 ### Default values
 
-The default value of a type upon initialization is recursively defined using `0` for `"uintN"`, `False` for `"bool"`, and `[]` for lists. Unions default to the first type in the union (with type index zero), which is `"null"` if present in the union.
+The default value of a type upon initialization is recursively defined using `0` for `"uintN"` and `Bigint`, `False` for `"bool"`, and `[]` for lists and `Bitfield`. Unions default to the first type in the union (with type index zero), which is `"null"` if present in the union.
 
 ### Illegal types
 
@@ -96,7 +98,7 @@ return b"\x01" if value is True else b"\x00"
 return b""
 ```
 
-### `"bigint"`
+### `"Bigint"`
 
 ```python
 return value.to_bytes(log2(value)//8, "little")

--- a/specs/simple-serialize.md
+++ b/specs/simple-serialize.md
@@ -49,11 +49,15 @@
 * **union**: union type containing one of the given subtypes
     * round bracket notation `(type_1, type_2, ...)`, e.g. `("null", "uint64")`
 * **Bigint**: integer type that can contain a non-negative integer of any magnitude, represented by `"bytes"` of length `log2(value)//8`
-* **Bitfield**: an variable-length list of `"bool"` values
+    * notation `Bigint`
+* **FixedBitfield**: a fixed-length list of `"bool"` values
+    * notation `FixedBitfield[N]`
+* **VariableBitfield**: a variable-length list of `"bool"` values
+    * notation `VariableBitfield`
 
 ### Variable-size and fixed-size
 
-We recursively define "variable-size" types to be lists, unions, `Bigint`, `Bitfield` and all types that contain a variable-size type. All other types are said to be "fixed-size".
+We recursively define "variable-size" types to be lists, unions, `Bigint`, `VariableBitfield` and all types that contain a variable-size type. All other types are said to be "fixed-size".
 
 ### Aliases
 
@@ -66,7 +70,7 @@ For convenience we alias:
 
 ### Default values
 
-The default value of a type upon initialization is recursively defined using `0` for `"uintN"` and `Bigint`, `False` for `"bool"`, and `[]` for lists and `Bitfield`. Unions default to the first type in the union (with type index zero), which is `"null"` if present in the union.
+The default value of a type upon initialization is recursively defined using `0` for `"uintN"` and `Bigint`, `False` for `"bool"`, and `[]` for lists and `VariableBitfield`. Unions default to the first type in the union (with type index zero), which is `"null"` if present in the union.
 
 ### Illegal types
 
@@ -104,7 +108,14 @@ return b""
 return value.to_bytes(log2(value)//8, "little")
 ```
 
-### `"Bitfield"`
+### `"FixedBitfield"`
+
+```python
+as_integer = sum([value[i] << i for i in range(len(value))])
+return as_integer.to_bytes(log2(as_integer)//8, "little")
+```
+
+### `"VariableBitfield"`
 
 ```python
 as_integer = (1 << len(value)) + sum([value[i] << i for i in range(len(value))])


### PR DESCRIPTION
Adds bigint and bitfield support to SSZ.

Possible alternative definition for `Bitfield`:

```
o = [0] * (len(value)//8 + 1)
for i in range(len(value)):
    o[i//8] ^= value[i] << (i%8)
o[len(value)//8] ^= 1 << (len(value) % 8)
return bytes(o)
```