### PR TITLE
Set genesis_state.latest_block_header with the root of empty `BeaconBlockBody`

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1189,7 +1189,11 @@ Let `genesis_state = get_genesis_beacon_state(genesis_deposits, eth2genesis.gene
 
 ```python
 def get_genesis_beacon_state(deposits: List[Deposit], genesis_time: int, genesis_eth1_data: Eth1Data) -> BeaconState:
-    state = BeaconState(genesis_time=genesis_time, latest_eth1_data=genesis_eth1_data)
+    state = BeaconState(
+        genesis_time=genesis_time,
+        latest_eth1_data=genesis_eth1_data,
+        latest_block_header=BeaconBlockHeader(body_root=hash_tree_root(BeaconBlockBody())),
+    )
 
     # Process genesis deposits
     for deposit in deposits:


### PR DESCRIPTION
Fix #1089.

I think it is a bug because before this fix, the test helper [`build_empty_block_for_next_slot`](https://github.com/ethereum/eth2.0-specs/blob/23b1cb225d4aab476bbeba06ab1d17755ccfd104/test_libs/pyspec/tests/helpers.py#L131-L132) *did not* build the correct `slot=GENESIS_SLOT+1` block which the parent block is point to [`genesis_block`](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/core/0_beacon-chain.md#genesis-block).

https://github.com/ethereum/eth2.0-specs/blob/23b1cb225d4aab476bbeba06ab1d17755ccfd104/test_libs/pyspec/tests/helpers.py#L131-L132


/cc @sorpaas
