### PR TITLE
Added backward argument to block headers request

### DIFF
--- a/specs/networking/rpc-interface.md
+++ b/specs/networking/rpc-interface.md
@@ -241,7 +241,7 @@ Requests beacon block headers from the peer starting from `(start_root, start_sl
 
 The function of the `skip_slots` parameter helps facilitate light client sync - for example, in [#459](https://github.com/ethereum/eth2.0-specs/issues/459) - and allows clients to balance the peers from whom they request headers. Clients could, for instance, request every 10th block from a set of peers where each peer has a different starting block in order to populate block data.
 
-If `backward` is `1`, request the blocks preceding the requested one in reverse order. E.g. for block `10` return `[10, 9, 8, ...]`.
+If `backward` is `1`, request the blocks preceding the requested one so that the requested one is the last in the response. E.g. for block `10` return `[..., 8, 9, 10]`.
 
 ### Beacon block bodies
 

--- a/specs/networking/rpc-interface.md
+++ b/specs/networking/rpc-interface.md
@@ -225,6 +225,7 @@ Requests a list of block roots and slots from the peer. The `count` parameter MU
     start_slot: uint64
     max_headers: uint64
     skip_slots: uint64
+    backward: uint8 in {0, 1}
 )
 ```
 
@@ -239,6 +240,8 @@ Requests a list of block roots and slots from the peer. The `count` parameter MU
 Requests beacon block headers from the peer starting from `(start_root, start_slot)`. The response MUST contain no more than `max_headers` headers. `skip_slots` defines the maximum number of slots to skip between blocks. For example, requesting blocks starting at slots `2` a `skip_slots` value of `1` would return the blocks at `[2, 4, 6, 8, 10]`. In cases where a slot is empty for a given slot number, the closest previous block MUST be returned. For example, if slot `4` were empty in the previous example, the returned array would contain `[2, 3, 6, 8, 10]`. If slot three were further empty, the array would contain `[2, 6, 8, 10]`—i.e. duplicate blocks MUST be collapsed. A `skip_slots` value of `0` returns all blocks.
 
 The function of the `skip_slots` parameter helps facilitate light client sync - for example, in [#459](https://github.com/ethereum/eth2.0-specs/issues/459) - and allows clients to balance the peers from whom they request headers. Clients could, for instance, request every 10th block from a set of peers where each peer has a different starting block in order to populate block data.
+
+If `backward` is `1`, request the blocks preceding the requested one in reverse order. E.g. for block `10` return `[10, 9, 8, ...]`.
 
 ### Beacon block bodies
 

--- a/specs/networking/rpc-interface.md
+++ b/specs/networking/rpc-interface.md
@@ -225,7 +225,7 @@ Requests a list of block roots and slots from the peer. The `count` parameter MU
     start_slot: uint64
     max_headers: uint64
     skip_slots: uint64
-    backward: uint8 in {0, 1}
+    backward: bool
 )
 ```
 
@@ -241,7 +241,7 @@ Requests beacon block headers from the peer starting from `(start_root, start_sl
 
 The function of the `skip_slots` parameter helps facilitate light client sync - for example, in [#459](https://github.com/ethereum/eth2.0-specs/issues/459) - and allows clients to balance the peers from whom they request headers. Clients could, for instance, request every 10th block from a set of peers where each peer has a different starting block in order to populate block data.
 
-If `backward` is `1`, request the blocks preceding the requested one so that the requested one is the last in the response. E.g. for block `10` return `[..., 8, 9, 10]`.
+If `backward` is `true`, request the blocks preceding the requested one so that the requested one is the last in the response. E.g. for block `10` return `[..., 8, 9, 10]`.
 
 ### Beacon block bodies
 


### PR DESCRIPTION
The `backward` option is useful for obtaining the branches we're missing for some reason, but getting attestations to.