### PR TITLE
Active registry roots

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -402,12 +402,10 @@ The types are defined topologically to aid in facilitating an executable version
 #### `ActiveRegistry`
 
 ```python
-{
-    'committees': [
+    [{
         'pubkeys': ['bytes48'],
         'compact_validators': ['uint64'],
-    ],
-}
+    }, SHARD_COUNT]
 ```
 
 #### `PendingAttestation`


### PR DESCRIPTION
Possible replacement of `latest_active_index_roots` with `latest_active_registry_roots` to allow for significantly more efficient light clients (see item 17 in #1054). Key changes:

* Validator information (including indices) is pre-shuffled and grouped by committee.
* Validator information relevant to light clients (`validator.effective_balance` and `validator.slashed`) is kept "close" to the validator index to avoid accessing `validator_registry`.
* Validator information (`index`, `effective_balance`, `slashed`) is compactified into a `uint64` which is friendly to SSZ packing.
* Shuffled pubkeys are available but kept separate from compact validator information. Light clients with pubkeys cached do not need to re-download and re-authenticate them.