### PR TITLE
Avoid finalization when zero total stake

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1394,7 +1394,7 @@ def process_crosslinks(state: BeaconState) -> None:
             shard = (get_epoch_start_shard(state, epoch) + offset) % SHARD_COUNT
             crosslink_committee = get_crosslink_committee(state, epoch, shard)
             winning_crosslink, attesting_indices = get_winning_crosslink_and_attesting_indices(state, epoch, shard)
-            if 3 * get_total_balance(state, attesting_indices) >= 2 * get_total_balance(state, crosslink_committee):
+            if 3 * get_total_balance(state, attesting_indices) > 2 * get_total_balance(state, crosslink_committee):
                 state.current_crosslinks[shard] = winning_crosslink
 ```
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1352,14 +1352,14 @@ def process_justification_and_finalization(state: BeaconState) -> None:
     previous_epoch_matching_target_balance = get_attesting_balance(
         state, get_matching_target_attestations(state, previous_epoch)
     )
-    if previous_epoch_matching_target_balance * 3 >= get_total_active_balance(state) * 2:
+    if previous_epoch_matching_target_balance * 3 > get_total_active_balance(state) * 2:
         state.current_justified_epoch = previous_epoch
         state.current_justified_root = get_block_root(state, state.current_justified_epoch)
         state.justification_bitfield |= (1 << 1)
     current_epoch_matching_target_balance = get_attesting_balance(
         state, get_matching_target_attestations(state, current_epoch)
     )
-    if current_epoch_matching_target_balance * 3 >= get_total_active_balance(state) * 2:
+    if current_epoch_matching_target_balance * 3 > get_total_active_balance(state) * 2:
         state.current_justified_epoch = current_epoch
         state.current_justified_root = get_block_root(state, state.current_justified_epoch)
         state.justification_bitfield |= (1 << 0)


### PR DESCRIPTION
### Problem

After applying some number of 'empty slot transitions' to any state all validators are finally exited due to inactivity penalties and the state has zero active validators. From this point the state becomes finalized due to the `>=` condition (see proposed change).
Of course this is not the case for the actual network but may cause client software issues. E.g. when the client is not synced yet but is trying calculate the state of the current slot (based on system clocks) by applying 'empty slot transitions'. When encountering a finalized epoch it may stick to this zero-balance fork and then just fail to sync correctly 

### Solution 
Change `>=` to `>` condition to avoid justifying epoch when the total stake balance is zero