### PR TITLE
update version used in test generators to get SHA-256 hash

### DIFF
--- a/test_generators/bls/requirements.txt
+++ b/test_generators/bls/requirements.txt
@@ -1,3 +1,3 @@
-py-ecc==1.6.0
+py-ecc==1.7.0
 eth-utils==1.4.1
 ../../test_libs/gen_helpers


### PR DESCRIPTION
this is blocked on the new release of `py_ecc` but should fix the issue w/ BLS tests having the wrong hash function