### PR TITLE
Replace RPC request union with bytes

### DIFF
--- a/specs/networking/rpc-interface.md
+++ b/specs/networking/rpc-interface.md
@@ -41,7 +41,7 @@ Remote method calls are wrapped in a "request" structure:
 (
     id: uint64
     method_id: uint16
-    body: (message_body...)
+    body: bytes
 )
 ```
 
@@ -55,7 +55,7 @@ and their corresponding responses are wrapped in a "response" structure:
 )
 ```
 
-A union type is used to determine the contents of the `body` field in the request structure. Each "body" entry in the RPC calls below corresponds to one subtype in the `body` type union.
+The `method_id` is used to determine the deserialized contents of the `body` field in the request structure. Each "body" entry in the RPC calls below corresponds to the proper ssz deserialization for that method.
 
 The details of the RPC-Over-`libp2p` protocol are similar to [JSON-RPC 2.0](https://www.jsonrpc.org/specification). Specifically:
 


### PR DESCRIPTION
Using a union creates an unnecessary duplication with the method id (with
the union index of the serialized union as a stand-in for the request
method_id) and ultimately must be rechecked against the method_id to
ensure that the proper type has been/will be deserialized.

Instead, the union has been changed to a byte list. This allows for
simple programmatic switching on method_id to determine the deserialized
type as the sole determination, rather than having multiple coupled
switches, eg the method_id AND the union prefix. This also aligns the
Request type with the Response type, as both now have a "body" that is
a byte list and can be decoded with the method_id (and response_code).