### PR TITLE
update version used in test generators to get SHA-256 hash

### DIFF
--- a/test_generators/bls/requirements.txt
+++ b/test_generators/bls/requirements.txt
@@ -1,3 +1,3 @@
-py-ecc==1.6.0
+py-ecc==1.7.0
 eth-utils==1.6.0
 ../../test_libs/gen_helpers


### PR DESCRIPTION
updates this branch w/ the new `py-ecc` version to use the correct hash