### PR TITLE
Test deposit top-up with inconsistent withdrawal credentials

### DIFF
--- a/scripts/phase0/build_spec.py
+++ b/scripts/phase0/build_spec.py
@@ -13,9 +13,17 @@ from typing import (
     NewType,
     Tuple,
 )
-from eth2spec.utils.minimal_ssz import *
+from eth2spec.utils.minimal_ssz import (
+    SSZType,
+    hash_tree_root,
+    signing_root,
+)
 from eth2spec.utils.hash_function import hash
-from eth2spec.utils.bls import *
+from eth2spec.utils.bls import (
+    bls_aggregate_pubkeys,
+    bls_verify,
+    bls_verify_multiple,
+)
 
 
 # stub, will get overwritten by real var

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1776,7 +1776,8 @@ def process_deposit(state: BeaconState, deposit: Deposit) -> None:
     validator_pubkeys = [v.pubkey for v in state.validator_registry]
     if pubkey not in validator_pubkeys:
         # Verify the deposit signature (proof of possession).
-        # Invalid signatures are allowed by the deposit contract, and hence included on-chain, but must not be processed.
+        # Invalid signatures are allowed by the deposit contract,
+        # and hence included on-chain, but must not be processed.
         # Note: deposits are valid across forks, hence the deposit domain is retrieved directly from `bls_domain`
         if not bls_verify(
             pubkey, signing_root(deposit.data), deposit.data.signature, bls_domain(DOMAIN_DEPOSIT)

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -471,8 +471,6 @@ The types are defined topologically to aid in facilitating an executable version
 {
     # Branch in the deposit tree
     'proof': ['bytes32', DEPOSIT_CONTRACT_TREE_DEPTH],
-    # Index in the deposit tree
-    'index': 'uint64',
     # Data
     'data': DepositData,
 }
@@ -1761,12 +1759,11 @@ def process_deposit(state: BeaconState, deposit: Deposit) -> None:
         leaf=hash_tree_root(deposit.data),
         proof=deposit.proof,
         depth=DEPOSIT_CONTRACT_TREE_DEPTH,
-        index=deposit.index,
+        index=state.deposit_index,
         root=state.latest_eth1_data.deposit_root,
     )
 
     # Deposits must be processed in order
-    assert deposit.index == state.deposit_index
     state.deposit_index += 1
 
     pubkey = deposit.data.pubkey

--- a/specs/test_formats/README.md
+++ b/specs/test_formats/README.md
@@ -35,7 +35,8 @@ Test formats:
 - [`bls`](./bls/README.md)
 - [`operations`](./operations/README.md)
 - [`shuffling`](./shuffling/README.md)
-- [`ssz`](./ssz/README.md)
+- [`ssz_generic`](./ssz_generic/README.md)
+- [`ssz_static`](./ssz_static/README.md)
 - More formats are planned, see tracking issues for CI/testing
 
 ## Glossary

--- a/test_libs/pyspec/eth2spec/test/block_processing/test_process_deposit.py
+++ b/test_libs/pyspec/eth2spec/test/block_processing/test_process_deposit.py
@@ -93,6 +93,21 @@ def test_invalid_sig_top_up(state):
     # invalid signatures, in top-ups, are allowed!
     yield from run_deposit_processing(state, deposit, validator_index, valid=True, effective=True)
 
+@spec_state_test
+def test_invalid_withdrawal_credentials_top_up(state):
+    validator_index = 0
+    amount = spec.MAX_EFFECTIVE_BALANCE // 4
+    withdrawal_credentials = spec.BLS_WITHDRAWAL_PREFIX_BYTE + spec.hash(b"junk")[1:]
+    deposit = prepare_state_and_deposit(
+        state,
+        validator_index,
+        amount,
+        withdrawal_credentials=withdrawal_credentials
+    )
+
+    # inconsistent withdrawal credentials, in top-ups, are allowed!
+    yield from run_deposit_processing(state, deposit, validator_index, valid=True, effective=True)
+
 
 @spec_state_test
 def test_wrong_index(state):

--- a/test_libs/pyspec/eth2spec/test/block_processing/test_process_deposit.py
+++ b/test_libs/pyspec/eth2spec/test/block_processing/test_process_deposit.py
@@ -137,6 +137,7 @@ def test_wrong_deposit_for_deposit_count(state):
         pubkey_1,
         privkey_1,
         spec.MAX_EFFECTIVE_BALANCE,
+        withdrawal_credentials=b'\x00'*32,
         signed=True,
     )
     deposit_count_1 = len(deposit_data_leaves)
@@ -151,6 +152,7 @@ def test_wrong_deposit_for_deposit_count(state):
         pubkey_2,
         privkey_2,
         spec.MAX_EFFECTIVE_BALANCE,
+        withdrawal_credentials=b'\x00'*32,
         signed=True,
     )
 

--- a/test_libs/pyspec/eth2spec/test/block_processing/test_process_deposit.py
+++ b/test_libs/pyspec/eth2spec/test/block_processing/test_process_deposit.py
@@ -93,6 +93,7 @@ def test_invalid_sig_top_up(state):
     # invalid signatures, in top-ups, are allowed!
     yield from run_deposit_processing(state, deposit, validator_index, valid=True, effective=True)
 
+
 @spec_state_test
 def test_invalid_withdrawal_credentials_top_up(state):
     validator_index = 0

--- a/test_libs/pyspec/eth2spec/test/block_processing/test_process_transfer.py
+++ b/test_libs/pyspec/eth2spec/test/block_processing/test_process_transfer.py
@@ -89,7 +89,7 @@ def test_invalid_signature(state):
     transfer = get_valid_transfer(state)
     # un-activate so validator can transfer
     state.validator_registry[transfer.sender].activation_eligibility_epoch = spec.FAR_FUTURE_EPOCH
-    
+
     yield from run_transfer_processing(state, transfer, False)
 
 
@@ -140,7 +140,13 @@ def test_insufficient_balance(state):
 def test_no_dust_sender(state):
     sender_index = get_active_validator_indices(state, get_current_epoch(state))[-1]
     balance = state.balances[sender_index]
-    transfer = get_valid_transfer(state, sender_index=sender_index, amount=balance - spec.MIN_DEPOSIT_AMOUNT + 1, fee=0, signed=True)
+    transfer = get_valid_transfer(
+        state,
+        sender_index=sender_index,
+        amount=balance - spec.MIN_DEPOSIT_AMOUNT + 1,
+        fee=0,
+        signed=True,
+    )
 
     # un-activate so validator can transfer
     state.validator_registry[transfer.sender].activation_epoch = spec.FAR_FUTURE_EPOCH

--- a/test_libs/pyspec/eth2spec/test/conftest.py
+++ b/test_libs/pyspec/eth2spec/test/conftest.py
@@ -3,6 +3,7 @@ from eth2spec.phase0 import spec
 # We import pytest only when it's present, i.e. when we are running tests.
 # The test-cases themselves can be generated without installing pytest.
 
+
 def module_exists(module_name):
     try:
         __import__(module_name)

--- a/test_libs/pyspec/eth2spec/test/helpers/block.py
+++ b/test_libs/pyspec/eth2spec/test/helpers/block.py
@@ -77,4 +77,3 @@ def build_empty_block(state, slot=None, signed=False):
 
 def build_empty_block_for_next_slot(state, signed=False):
     return build_empty_block(state, state.slot + 1, signed=signed)
-

--- a/test_libs/pyspec/eth2spec/test/sanity/test_slots.py
+++ b/test_libs/pyspec/eth2spec/test/sanity/test_slots.py
@@ -55,4 +55,3 @@ def test_over_epoch_boundary(state):
     yield 'slots', slots
     process_slots(state, state.slot + slots)
     yield 'post', state
-


### PR DESCRIPTION
Lighthouse had a check on Deposit withdrawal credentials that was left over from v0.4, which is no longer required (and would break consensus). I wrote this test to confirm the spec's behaviour, and figured it might be useful for other client implementers too.

Not sure exactly which base branch to target, if you'd prefer this merged into `dev`, I'll update the PR

CC @protolambda 