### PR TITLE
Use get_total_balance for get_attestation_deltas

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1433,7 +1433,7 @@ def get_attestation_deltas(state: BeaconState) -> Tuple[List[Gwei], List[Gwei]]:
     matching_head_attestations = get_matching_head_attestations(state, previous_epoch)
     for attestations in (matching_source_attestations, matching_target_attestations, matching_head_attestations):
         unslashed_attesting_indices = get_unslashed_attesting_indices(state, attestations)
-        attesting_balance = get_attesting_balance(state, attestations)
+        attesting_balance = get_total_balance(state, unslashed_attesting_indices)
         for index in eligible_validator_indices:
             if index in unslashed_attesting_indices:
                 rewards[index] += get_base_reward(state, index) * attesting_balance // total_balance


### PR DESCRIPTION
I profiled `process_epoch` and I was able to reduce the processing time by 20% using 62536 validators with this simple change. I'm wondering if we should just fix it in the spec. Also feel free to close this if I violated readability >>> optimization rule 😅  