### PR TITLE
attestations: check shard, and check epoch earlier. Open question about another attestation check.

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1722,6 +1722,10 @@ def process_attestation(state: BeaconState, attestation: Attestation) -> None:
     Process ``Attestation`` operation.
     """
     data = attestation.data
+
+    assert data.crosslink.shard < SHARD_COUNT
+    assert data.target_epoch in (get_previous_epoch(state), get_current_epoch(state))
+
     attestation_slot = get_attestation_data_slot(state, data)
     assert attestation_slot + MIN_ATTESTATION_INCLUSION_DELAY <= state.slot <= attestation_slot + SLOTS_PER_EPOCH
 
@@ -1732,7 +1736,6 @@ def process_attestation(state: BeaconState, attestation: Attestation) -> None:
         proposer_index=get_beacon_proposer_index(state),
     )
 
-    assert data.target_epoch in (get_previous_epoch(state), get_current_epoch(state))
     if data.target_epoch == get_current_epoch(state):
         ffg_data = (state.current_justified_epoch, state.current_justified_root, get_current_epoch(state))
         parent_crosslink = state.current_crosslinks[data.crosslink.shard]


### PR DESCRIPTION
Few minor bugfixes in attestation processing:
- out of bounds shards results in invalid lookups/calculations, catch it. (avoid panic in Go)
- target epoch should be checked when we can, not after using it.

Remaining question, for @JustinDrake

~~When there are two bitfields (Aggregation, and custody1), and we derive the indices for custody0 (in `convert_to_indexed`), should we check len(participants) < len(custody1)? E.g. the bitfields could be verified to be committee size, yet the custody bits could be more full than the actual participants, resulting in extra custody-1 indices. Or is this prevented elsewhere?~~ Moved to #1173 
