### PR TITLE
Update genesis trigger

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1158,15 +1158,14 @@ def slash_validator(state: BeaconState,
 
 ### Genesis trigger
 
-Before genesis has been triggered and whenever the deposit contract emits a `Deposit` log, call the function `is_genesis_trigger(deposits: List[Deposit], timestamp: uint64) -> bool` where:
+Before genesis has been triggered and whenever the deposit contract emits a `Deposit` log, call the function `is_genesis_trigger(deposits: List[Deposit]) -> bool` where:
 
 * `deposits` is the list of all deposits, ordered chronologically, up to and including the deposit triggering the latest `Deposit` log
-* `timestamp` is the Unix timestamp in the Ethereum 1.0 block that emitted the latest `Deposit` log
 
 When `is_genesis_trigger(deposits, timestamp) is True` for the first time let:
 
 * `genesis_deposits = deposits`
-* `genesis_time = timestamp - timestamp % SECONDS_PER_DAY + 2 * SECONDS_PER_DAY` where `SECONDS_PER_DAY = 86400`
+* `genesis_time = timestamp - timestamp % SECONDS_PER_DAY + 2 * SECONDS_PER_DAY` where `SECONDS_PER_DAY = 86400` and `timestamp` is the Unix timestamp in the Ethereum 1.0 block that emitted the latest `Deposit` log
 * `genesis_eth1_data` be the object of type `Eth1Data` where:
     * `genesis_eth1_data.block_hash` is the Ethereum 1.0 block hash that emitted the log for the last deposit in `deposits`
     * `genesis_eth1_data.deposit_root` is the deposit root for the last deposit in `deposits`


### PR DESCRIPTION
`timestamp` was never used in `is_genesis_trigger`, not sure if it was meant to be a placeholder for the later updates