### PR TITLE
Fix #1173

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -991,6 +991,7 @@ def convert_to_indexed(state: BeaconState, attestation: Attestation) -> IndexedA
     """
     attesting_indices = get_attesting_indices(state, attestation.data, attestation.aggregation_bitfield)
     custody_bit_1_indices = get_attesting_indices(state, attestation.data, attestation.custody_bitfield)
+    assert set(custody_bit_1_indices).issubset(attesting_indices)
     custody_bit_0_indices = [index for index in attesting_indices if index not in custody_bit_1_indices]
 
     return IndexedAttestation(


### PR DESCRIPTION
The bug is that it's possible to include a participating validator which has custody bit one *without* specifying that validator in `attestation.aggregation_bitfield`. In other words, we want to check that every bit in `custody_bitfield` is zero whenever the corresponding bit in `aggregation_bitfield` is zero. Well spotted @protolambda