### PR TITLE
fix #1169 bytes type error

### DIFF
--- a/test_libs/pyspec/eth2spec/test/sanity/test_blocks.py
+++ b/test_libs/pyspec/eth2spec/test/sanity/test_blocks.py
@@ -33,6 +33,7 @@ def test_empty_block_transition(spec, state):
 
     assert len(state.eth1_data_votes) == pre_eth1_votes + 1
     assert spec.get_block_root_at_slot(state, pre_slot) == block.parent_root
+    assert spec.get_randao_mix(state, spec.get_current_epoch(state)) != spec.ZERO_HASH
 
 
 @with_all_phases
@@ -51,6 +52,7 @@ def test_skipped_slots(spec, state):
     yield 'post', state
 
     assert state.slot == block.slot
+    assert spec.get_randao_mix(state, spec.get_current_epoch(state)) != spec.ZERO_HASH
     for slot in range(pre_slot, state.slot):
         assert spec.get_block_root_at_slot(state, slot) == block.parent_root
 

--- a/test_libs/pyspec/eth2spec/utils/ssz/ssz_typing.py
+++ b/test_libs/pyspec/eth2spec/utils/ssz/ssz_typing.py
@@ -1,3 +1,4 @@
+from types import GeneratorType
 from typing import List, Iterable, TypeVar, Type, NewType
 from typing import Union
 from typing_inspect import get_origin
@@ -356,6 +357,8 @@ def parse_bytes(val):
         return val
     elif isinstance(val, int):
         return bytes([val])
+    elif isinstance(val, (list, GeneratorType)):
+        return bytes(val)
     else:
         return None
 


### PR DESCRIPTION
#1169 pointed out that our randao_mix was always staying `0x00`. This was because the call to `Bytes32` in `xor` was not formatting the passed in generator correctly. Added an explicit check for `list` and `Generator` as a potential value type and handle properly.

Also added a sanity check on randao in sanity block tests. Could add a `test_process_randao.py` but wasn't sure if that was overkill...

--------------

also removed `never_bls` from the two sanity tests. We need the crypto to be used properly in test gen