### PR TITLE
Fix #1146 block state root issue

### DIFF
--- a/test_libs/pyspec/eth2spec/test/helpers/state.py
+++ b/test_libs/pyspec/eth2spec/test/helpers/state.py
@@ -1,3 +1,6 @@
+from eth2spec.test.helpers.block import sign_block
+
+
 def get_balance(state, index):
     return state.balances[index]
 
@@ -23,3 +26,13 @@ def get_state_root(spec, state, slot) -> bytes:
     """
     assert slot < state.slot <= slot + spec.SLOTS_PER_HISTORICAL_ROOT
     return state.latest_state_roots[slot % spec.SLOTS_PER_HISTORICAL_ROOT]
+
+
+def state_transition_and_sign_block(spec, state, block):
+    """
+    State transition via the provided ``block``
+    then package the block with the state root and signature.
+    """
+    spec.state_transition(state, block)
+    block.state_root = state.hash_tree_root()
+    sign_block(spec, state, block)

--- a/test_libs/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_crosslinks.py
+++ b/test_libs/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_crosslinks.py
@@ -3,7 +3,8 @@ from copy import deepcopy
 from eth2spec.test.context import spec_state_test, with_all_phases
 from eth2spec.test.helpers.state import (
     next_epoch,
-    next_slot
+    next_slot,
+    state_transition_and_sign_block,
 )
 from eth2spec.test.helpers.block import apply_empty_block, sign_block
 from eth2spec.test.helpers.attestations import (
@@ -27,10 +28,13 @@ def run_process_crosslinks(spec, state, valid=True):
     block = build_empty_block_for_next_slot(spec, state)
     block.slot = slot
     sign_block(spec, state, block)
-    spec.state_transition(state, block)
+    state_transition_and_sign_block(spec, state, block)
 
     # cache state before epoch transition
     spec.process_slot(state)
+
+    # process components of epoch transition before processing crosslinks
+    spec.process_justification_and_finalization(state)
 
     yield 'pre', state
     spec.process_crosslinks(state)

--- a/test_libs/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_registry_updates.py
+++ b/test_libs/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_registry_updates.py
@@ -1,6 +1,5 @@
-from eth2spec.phase0.spec import state_transition
 from eth2spec.test.helpers.block import build_empty_block_for_next_slot, sign_block
-from eth2spec.test.helpers.state import next_epoch
+from eth2spec.test.helpers.state import next_epoch, state_transition_and_sign_block
 from eth2spec.test.context import spec_state_test, with_all_phases
 
 
@@ -16,7 +15,7 @@ def run_process_registry_updates(spec, state, valid=True):
     block = build_empty_block_for_next_slot(spec, state)
     block.slot = slot
     sign_block(spec, state, block)
-    state_transition(state, block)
+    state_transition_and_sign_block(spec, state, block)
 
     # cache state before epoch transition
     spec.process_slot(state)

--- a/test_libs/pyspec/eth2spec/test/sanity/test_blocks.py
+++ b/test_libs/pyspec/eth2spec/test/sanity/test_blocks.py
@@ -4,7 +4,7 @@ from typing import List
 from eth2spec.utils.ssz.ssz_impl import signing_root
 from eth2spec.utils.bls import bls_sign
 
-from eth2spec.test.helpers.state import get_balance
+from eth2spec.test.helpers.state import get_balance, state_transition_and_sign_block
 # from eth2spec.test.helpers.transfers import get_valid_transfer
 from eth2spec.test.helpers.block import build_empty_block_for_next_slot, sign_block
 from eth2spec.test.helpers.keys import privkeys, pubkeys
@@ -16,6 +16,7 @@ from eth2spec.test.helpers.deposits import prepare_state_and_deposit
 from eth2spec.test.context import spec_state_test, with_all_phases
 
 
+
 @with_all_phases
 @spec_state_test
 def test_empty_block_transition(spec, state):
@@ -25,9 +26,10 @@ def test_empty_block_transition(spec, state):
     yield 'pre', state
 
     block = build_empty_block_for_next_slot(spec, state, signed=True)
-    yield 'blocks', [block], List[spec.BeaconBlock]
 
-    spec.state_transition(state, block)
+    state_transition_and_sign_block(spec, state, block)
+
+    yield 'blocks', [block], List[spec.BeaconBlock]
     yield 'post', state
 
     assert len(state.eth1_data_votes) == pre_eth1_votes + 1
@@ -44,9 +46,10 @@ def test_skipped_slots(spec, state):
     block = build_empty_block_for_next_slot(spec, state)
     block.slot += 3
     sign_block(spec, state, block)
-    yield 'blocks', [block], List[spec.BeaconBlock]
 
-    spec.state_transition(state, block)
+    state_transition_and_sign_block(spec, state, block)
+
+    yield 'blocks', [block], List[spec.BeaconBlock]
     yield 'post', state
 
     assert state.slot == block.slot
@@ -64,9 +67,10 @@ def test_empty_epoch_transition(spec, state):
     block = build_empty_block_for_next_slot(spec, state)
     block.slot += spec.SLOTS_PER_EPOCH
     sign_block(spec, state, block)
-    yield 'blocks', [block], List[spec.BeaconBlock]
 
-    spec.state_transition(state, block)
+    state_transition_and_sign_block(spec, state, block)
+
+    yield 'blocks', [block], List[spec.BeaconBlock]
     yield 'post', state
 
     assert state.slot == block.slot
@@ -84,9 +88,10 @@ def test_empty_epoch_transition(spec, state):
 #     block = build_empty_block_for_next_slot(spec, state)
 #     block.slot += spec.SLOTS_PER_EPOCH * 5
 #     sign_block(spec, state, block, proposer_index=0)
-#     yield 'blocks', [block], List[spec.BeaconBlock]
 
-#     spec.state_transition(state, block)
+#     state_transition_and_sign_block(spec, state, block)
+
+#     yield 'blocks', [block], List[spec.BeaconBlock]
 #     yield 'post', state
 
 #     assert state.slot == block.slot
@@ -113,9 +118,10 @@ def test_proposer_slashing(spec, state):
     block = build_empty_block_for_next_slot(spec, state)
     block.body.proposer_slashings.append(proposer_slashing)
     sign_block(spec, state, block)
-    yield 'blocks', [block], List[spec.BeaconBlock]
 
-    spec.state_transition(state, block)
+    state_transition_and_sign_block(spec, state, block)
+
+    yield 'blocks', [block], List[spec.BeaconBlock]
     yield 'post', state
 
     # check if slashed
@@ -147,9 +153,10 @@ def test_attester_slashing(spec, state):
     block = build_empty_block_for_next_slot(spec, state)
     block.body.attester_slashings.append(attester_slashing)
     sign_block(spec, state, block)
-    yield 'blocks', [block], List[spec.BeaconBlock]
 
-    spec.state_transition(state, block)
+    state_transition_and_sign_block(spec, state, block)
+
+    yield 'blocks', [block], List[spec.BeaconBlock]
     yield 'post', state
 
     slashed_validator = state.validator_registry[validator_index]
@@ -185,9 +192,9 @@ def test_deposit_in_block(spec, state):
     block.body.deposits.append(deposit)
     sign_block(spec, state, block)
 
-    yield 'blocks', [block], List[spec.BeaconBlock]
+    state_transition_and_sign_block(spec, state, block)
 
-    spec.state_transition(state, block)
+    yield 'blocks', [block], List[spec.BeaconBlock]
     yield 'post', state
 
     assert len(state.validator_registry) == initial_registry_len + 1
@@ -213,9 +220,9 @@ def test_deposit_top_up(spec, state):
     block.body.deposits.append(deposit)
     sign_block(spec, state, block)
 
-    yield 'blocks', [block], List[spec.BeaconBlock]
+    state_transition_and_sign_block(spec, state, block)
 
-    spec.state_transition(state, block)
+    yield 'blocks', [block], List[spec.BeaconBlock]
     yield 'post', state
 
     assert len(state.validator_registry) == initial_registry_len
@@ -238,7 +245,7 @@ def test_attestation(spec, state):
     attestation_block.slot += spec.MIN_ATTESTATION_INCLUSION_DELAY
     attestation_block.body.attestations.append(attestation)
     sign_block(spec, state, attestation_block)
-    spec.state_transition(state, attestation_block)
+    state_transition_and_sign_block(spec, state, attestation_block)
 
     assert len(state.current_epoch_attestations) == pre_current_attestations_len + 1
 
@@ -248,7 +255,8 @@ def test_attestation(spec, state):
     epoch_block = build_empty_block_for_next_slot(spec, state)
     epoch_block.slot += spec.SLOTS_PER_EPOCH
     sign_block(spec, state, epoch_block)
-    spec.state_transition(state, epoch_block)
+    state_transition_and_sign_block(spec, state, epoch_block)
+
 
     yield 'blocks', [attestation_block, epoch_block], List[spec.BeaconBlock]
     yield 'post', state
@@ -287,7 +295,7 @@ def test_voluntary_exit(spec, state):
     initiate_exit_block = build_empty_block_for_next_slot(spec, state)
     initiate_exit_block.body.voluntary_exits.append(voluntary_exit)
     sign_block(spec, state, initiate_exit_block)
-    spec.state_transition(state, initiate_exit_block)
+    state_transition_and_sign_block(spec, state, initiate_exit_block)
 
     assert state.validator_registry[validator_index].exit_epoch < spec.FAR_FUTURE_EPOCH
 
@@ -295,7 +303,7 @@ def test_voluntary_exit(spec, state):
     exit_block = build_empty_block_for_next_slot(spec, state)
     exit_block.slot += spec.SLOTS_PER_EPOCH
     sign_block(spec, state, exit_block)
-    spec.state_transition(state, exit_block)
+    state_transition_and_sign_block(spec, state, exit_block)
 
     yield 'blocks', [initiate_exit_block, exit_block], List[spec.BeaconBlock]
     yield 'post', state
@@ -326,9 +334,9 @@ def test_voluntary_exit(spec, state):
     # block.body.transfers.append(transfer)
     # sign_block(spec, state, block)
 
-    # yield 'blocks', [block], List[spec.BeaconBlock]
+    # state_transition_and_sign_block(spec, state, block)
 
-    # spec.state_transition(state, block)
+    # yield 'blocks', [block], List[spec.BeaconBlock]
     # yield 'post', state
 
     # sender_balance = get_balance(state, sender_index)
@@ -354,7 +362,7 @@ def test_balance_driven_status_transitions(spec, state):
     block = build_empty_block_for_next_slot(spec, state)
     block.slot += spec.SLOTS_PER_EPOCH
     sign_block(spec, state, block)
-    spec.state_transition(state, block)
+    state_transition_and_sign_block(spec, state, block)
 
     yield 'blocks', [block], List[spec.BeaconBlock]
     yield 'post', state
@@ -371,7 +379,7 @@ def test_historical_batch(spec, state):
     yield 'pre', state
 
     block = build_empty_block_for_next_slot(spec, state, signed=True)
-    spec.state_transition(state, block)
+    state_transition_and_sign_block(spec, state, block)
 
     yield 'blocks', [block], List[spec.BeaconBlock]
     yield 'post', state
@@ -392,7 +400,7 @@ def test_historical_batch(spec, state):
 #     blocks = []
 #     for _ in range(spec.SLOTS_PER_ETH1_VOTING_PERIOD - 1):
 #         block = build_empty_block_for_next_slot(spec, state)
-#         spec.state_transition(state, block)
+#         state_transition_and_sign_block(spec, state, block)
 #         expected_votes += 1
 #         assert len(state.eth1_data_votes) == expected_votes
 #         blocks.append(block)
@@ -400,7 +408,7 @@ def test_historical_batch(spec, state):
 #     block = build_empty_block_for_next_slot(spec, state)
 #     blocks.append(block)
 
-#     spec.state_transition(state, block)
+#     state_transition_and_sign_block(spec, state, block)
 
 #     yield 'blocks', [block], List[spec.BeaconBlock]
 #     yield 'post', state

--- a/test_libs/pyspec/eth2spec/test/sanity/test_blocks.py
+++ b/test_libs/pyspec/eth2spec/test/sanity/test_blocks.py
@@ -16,7 +16,6 @@ from eth2spec.test.helpers.deposits import prepare_state_and_deposit
 from eth2spec.test.context import spec_state_test, with_all_phases
 
 
-
 @with_all_phases
 @spec_state_test
 def test_empty_block_transition(spec, state):
@@ -256,7 +255,6 @@ def test_attestation(spec, state):
     epoch_block.slot += spec.SLOTS_PER_EPOCH
     sign_block(spec, state, epoch_block)
     state_transition_and_sign_block(spec, state, epoch_block)
-
 
     yield 'blocks', [attestation_block, epoch_block], List[spec.BeaconBlock]
     yield 'post', state

--- a/test_libs/pyspec/eth2spec/test/test_finality.py
+++ b/test_libs/pyspec/eth2spec/test/test_finality.py
@@ -2,7 +2,7 @@ from copy import deepcopy
 from typing import List
 
 from eth2spec.test.context import spec_state_test, never_bls, with_all_phases
-from eth2spec.test.helpers.state import next_epoch
+from eth2spec.test.helpers.state import next_epoch, state_transition_and_sign_block
 from eth2spec.test.helpers.block import build_empty_block_for_next_slot, apply_empty_block
 from eth2spec.test.helpers.attestations import get_valid_attestation
 
@@ -54,7 +54,7 @@ def next_epoch_with_attestations(spec,
             prev_attestation = get_valid_attestation(spec, post_state, slot_to_attest)
             block.body.attestations.append(prev_attestation)
 
-        spec.state_transition(post_state, block)
+        state_transition_and_sign_block(spec, post_state, block)
         blocks.append(block)
 
     return state, blocks, post_state


### PR DESCRIPTION
Addresses #1146 
Add function `state_transition_and_sign_block` to tests that both performs a state transition and properly formats the block by inserting the post state root and signing.

Considering renaming `state_transition_and_sign_block` to `state_transition_and_package_block`