### PR TITLE
update note about when proposer assignment valid

### DIFF
--- a/specs/validator/0_beacon-chain-validator.md
+++ b/specs/validator/0_beacon-chain-validator.md
@@ -157,7 +157,7 @@ def get_committee_assignment(
                 return committee, shard, slot
 ```
 
-A validator can use the following function to see if they are supposed to propose during their assigned committee slot. This function can only be run with a `state` of the slot in question. Proposer selection is only stable within the context of the current epoch.
+A validator can use the following function to see if they are supposed to propose during their assigned committee slot. This function can only be run with a `state` of the slot in question. Proposer selection is only guaranteed to be stable within the current slot.
 
 ```python
 def is_proposer(state: BeaconState,


### PR DESCRIPTION
There was a minor bug in the language here. The validator guide claimed that proposers are stable within the current epoch, but due to the ability for `slash_validator` to modify balances on a per block basis, this is not actually true.

