### PR TITLE
Increase historical length and cleanups

### DIFF
--- a/configs/constant_presets/mainnet.yaml
+++ b/configs/constant_presets/mainnet.yaml
@@ -74,9 +74,7 @@ MIN_EPOCHS_TO_INACTIVITY_PENALTY: 4
 # State list lengths
 # ---------------------------------------------------------------
 # 2**13 (= 8,192) epochs ~36 days
-RANDAO_MIXES_LENGTH: 8192
-# 2**13 (= 8,192) epochs ~36 days
-ACTIVE_INDEX_ROOTS_LENGTH: 8192
+HISTORICAL_VECTOR_LENGTH: 65536
 # 2**13 (= 8,192) epochs ~36 days
 SLASHED_EXIT_LENGTH: 8192
 

--- a/configs/constant_presets/mainnet.yaml
+++ b/configs/constant_presets/mainnet.yaml
@@ -71,12 +71,12 @@ MAX_EPOCHS_PER_CROSSLINK: 64
 MIN_EPOCHS_TO_INACTIVITY_PENALTY: 4
 
 
-# State list lengths
+# State vector lengths
 # ---------------------------------------------------------------
+# 2**16 (= 65,536) epochs ~0.8 years
+EPOCHS_PER_HISTORICAL_VECTOR: 65536
 # 2**13 (= 8,192) epochs ~36 days
-HISTORICAL_VECTOR_LENGTH: 65536
-# 2**13 (= 8,192) epochs ~36 days
-SLASHED_EXIT_LENGTH: 8192
+EPOCHS_PER_SLASHED_BALANCES_VECTOR: 8192
 
 
 # Reward and penalty quotients

--- a/configs/constant_presets/minimal.yaml
+++ b/configs/constant_presets/minimal.yaml
@@ -75,9 +75,7 @@ EARLY_DERIVED_SECRET_PENALTY_MAX_FUTURE_EPOCHS: 4096
 # State list lengths
 # ---------------------------------------------------------------
 # [customized] smaller state
-RANDAO_MIXES_LENGTH: 64
-# [customized] smaller state
-ACTIVE_INDEX_ROOTS_LENGTH: 64
+HISTORICAL_VECTOR_LENGTH: 64
 # [customized] smaller state
 SLASHED_EXIT_LENGTH: 64
 

--- a/configs/constant_presets/minimal.yaml
+++ b/configs/constant_presets/minimal.yaml
@@ -72,12 +72,12 @@ MIN_EPOCHS_TO_INACTIVITY_PENALTY: 4
 EARLY_DERIVED_SECRET_PENALTY_MAX_FUTURE_EPOCHS: 4096
 
 
-# State list lengths
+# State vector lengths
 # ---------------------------------------------------------------
 # [customized] smaller state
-HISTORICAL_VECTOR_LENGTH: 64
+EPOCHS_PER_HISTORICAL_VECTOR: 64
 # [customized] smaller state
-SLASHED_EXIT_LENGTH: 64
+EPOCHS_PER_SLASHED_BALANCES_VECTOR: 64
 
 
 # Reward and penalty quotients

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1604,7 +1604,7 @@ def process_randao(state: BeaconState, body: BeaconBlockBody) -> None:
     assert bls_verify(proposer.pubkey, hash_tree_root(epoch), body.randao_reveal, get_domain(state, DOMAIN_RANDAO))
     # Mix in RANDAO reveal
     mix = xor(get_randao_mix(state, epoch), hash(body.randao_reveal))
-    state.latest_randao_mixes[epoch % EPOCHS_PER_HISTORICAL_VECTOR] = mix
+    state.randao_mixes[epoch % HISTORICAL_VECTOR_LENGTH] = mix
 ```
 
 #### Eth1 data

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -235,8 +235,8 @@ These configurations are updated for releases, but may be out of sync during `de
 
 | Name | Value | Unit | Duration |
 | - | - | :-: | :-: |
-| `HISTORICAL_VECTOR_LENGTH` | `2**16` (= 65,536) | epochs | ~0.8 years |
-| `SLASHED_EXIT_LENGTH` | `2**13` (= 8,192) | epochs | ~36 days |
+| `EPOCHS_PER_HISTORICAL_VECTOR` | `2**16` (= 65,536) | epochs | ~0.8 years |
+| `EPOCHS_PER_SLASHED_BALANCES_VECTOR` | `2**13` (= 8,192) | epochs | ~36 days |
 
 ### Rewards and penalties
 
@@ -523,10 +523,10 @@ class BeaconState(Container):
     balances: List[Gwei]
     # Shuffling
     start_shard: Shard
-    randao_mixes: Vector[Hash, HISTORICAL_VECTOR_LENGTH]
-    active_index_roots: Vector[Hash, HISTORICAL_VECTOR_LENGTH]  # Digests of the active registry, for light clients
+    randao_mixes: Vector[Hash, EPOCHS_PER_HISTORICAL_VECTOR]
+    active_index_roots: Vector[Hash, EPOCHS_PER_HISTORICAL_VECTOR]  # Digests of the active registry, for light clients
     # Slashings
-    slashed_balances: Vector[Gwei, SLASHED_EXIT_LENGTH]  # Sums of the effective balances of slashed validators
+    slashed_balances: Vector[Gwei, EPOCHS_PER_SLASHED_BALANCES_VECTOR]  # Sums of the effective balances of slashed validators
     # Attestations
     previous_epoch_attestations: List[PendingAttestation]
     current_epoch_attestations: List[PendingAttestation]
@@ -750,9 +750,9 @@ def get_randao_mix(state: BeaconState,
                    epoch: Epoch) -> Hash:
     """
     Return the randao mix at a recent ``epoch``.
-    ``epoch`` expected to be between (current_epoch - HISTORICAL_VECTOR_LENGTH, current_epoch].
+    ``epoch`` expected to be between (current_epoch - EPOCHS_PER_HISTORICAL_VECTOR, current_epoch].
     """
-    return state.randao_mixes[epoch % HISTORICAL_VECTOR_LENGTH]
+    return state.randao_mixes[epoch % EPOCHS_PER_HISTORICAL_VECTOR]
 ```
 
 ### `get_active_index_root`
@@ -763,9 +763,9 @@ def get_active_index_root(state: BeaconState,
     """
     Return the index root at a recent ``epoch``.
     ``epoch`` expected to be between
-    (current_epoch - HISTORICAL_VECTOR_LENGTH + ACTIVATION_EXIT_DELAY, current_epoch + ACTIVATION_EXIT_DELAY].
+    (current_epoch - EPOCHS_PER_HISTORICAL_VECTOR + ACTIVATION_EXIT_DELAY, current_epoch + ACTIVATION_EXIT_DELAY].
     """
-    return state.active_index_roots[epoch % HISTORICAL_VECTOR_LENGTH]
+    return state.active_index_roots[epoch % EPOCHS_PER_HISTORICAL_VECTOR]
 ```
 
 ### `generate_seed`
@@ -777,7 +777,7 @@ def generate_seed(state: BeaconState,
     Generate a seed for the given ``epoch``.
     """
     return hash(
-        get_randao_mix(state, Epoch(epoch + HISTORICAL_VECTOR_LENGTH - MIN_SEED_LOOKAHEAD)) +
+        get_randao_mix(state, Epoch(epoch + EPOCHS_PER_HISTORICAL_VECTOR - MIN_SEED_LOOKAHEAD)) +
         get_active_index_root(state, epoch) +
         int_to_bytes(epoch, length=32)
     )
@@ -1111,9 +1111,9 @@ def slash_validator(state: BeaconState,
     current_epoch = get_current_epoch(state)
     initiate_validator_exit(state, slashed_index)
     state.validators[slashed_index].slashed = True
-    state.validators[slashed_index].withdrawable_epoch = Epoch(current_epoch + SLASHED_EXIT_LENGTH)
+    state.validators[slashed_index].withdrawable_epoch = Epoch(current_epoch + EPOCHS_PER_SLASHED_BALANCES_VECTOR)
     slashed_balance = state.validators[slashed_index].effective_balance
-    state.slashed_balances[current_epoch % SLASHED_EXIT_LENGTH] += slashed_balance
+    state.slashed_balances[current_epoch % EPOCHS_PER_SLASHED_BALANCES_VECTOR] += slashed_balance
 
     proposer_index = get_beacon_proposer_index(state)
     if whistleblower_index is None:
@@ -1187,7 +1187,7 @@ def get_genesis_beacon_state(deposits: List[Deposit], genesis_time: int, genesis
 
     # Populate active_index_roots
     genesis_active_index_root = hash_tree_root(get_active_validator_indices(state, GENESIS_EPOCH))
-    for index in range(HISTORICAL_VECTOR_LENGTH):
+    for index in range(EPOCHS_PER_HISTORICAL_VECTOR):
         state.active_index_roots[index] = genesis_active_index_root
 
     return state
@@ -1510,12 +1510,12 @@ def process_slashings(state: BeaconState) -> None:
     total_balance = get_total_active_balance(state)
 
     # Compute slashed balances in the current epoch
-    total_at_start = state.slashed_balances[(current_epoch + 1) % SLASHED_EXIT_LENGTH]
-    total_at_end = state.slashed_balances[current_epoch % SLASHED_EXIT_LENGTH]
+    total_at_start = state.slashed_balances[(current_epoch + 1) % EPOCHS_PER_SLASHED_BALANCES_VECTOR]
+    total_at_end = state.slashed_balances[current_epoch % EPOCHS_PER_SLASHED_BALANCES_VECTOR]
     total_penalties = total_at_end - total_at_start
 
     for index, validator in enumerate(state.validators):
-        if validator.slashed and current_epoch == validator.withdrawable_epoch - SLASHED_EXIT_LENGTH // 2:
+        if validator.slashed and current_epoch == validator.withdrawable_epoch - EPOCHS_PER_SLASHED_BALANCES_VECTOR // 2:
             penalty = max(
                 validator.effective_balance * min(total_penalties * 3, total_balance) // total_balance,
                 validator.effective_balance // MIN_SLASHING_PENALTY_QUOTIENT
@@ -1541,16 +1541,16 @@ def process_final_updates(state: BeaconState) -> None:
     # Update start shard
     state.start_shard = Shard((state.start_shard + get_shard_delta(state, current_epoch)) % SHARD_COUNT)
     # Set active index root
-    index_root_position = (next_epoch + ACTIVATION_EXIT_DELAY) % HISTORICAL_VECTOR_LENGTH
+    index_root_position = (next_epoch + ACTIVATION_EXIT_DELAY) % EPOCHS_PER_HISTORICAL_VECTOR
     state.active_index_roots[index_root_position] = hash_tree_root(
         get_active_validator_indices(state, Epoch(next_epoch + ACTIVATION_EXIT_DELAY))
     )
     # Set total slashed balances
-    state.slashed_balances[next_epoch % SLASHED_EXIT_LENGTH] = (
-        state.slashed_balances[current_epoch % SLASHED_EXIT_LENGTH]
+    state.slashed_balances[next_epoch % EPOCHS_PER_SLASHED_BALANCES_VECTOR] = (
+        state.slashed_balances[current_epoch % EPOCHS_PER_SLASHED_BALANCES_VECTOR]
     )
     # Set randao mix
-    state.randao_mixes[next_epoch % HISTORICAL_VECTOR_LENGTH] = get_randao_mix(state, current_epoch)
+    state.randao_mixes[next_epoch % EPOCHS_PER_HISTORICAL_VECTOR] = get_randao_mix(state, current_epoch)
     # Set historical root accumulator
     if next_epoch % (SLOTS_PER_HISTORICAL_ROOT // SLOTS_PER_EPOCH) == 0:
         historical_batch = HistoricalBatch(
@@ -1604,7 +1604,7 @@ def process_randao(state: BeaconState, body: BeaconBlockBody) -> None:
     assert bls_verify(proposer.pubkey, hash_tree_root(epoch), body.randao_reveal, get_domain(state, DOMAIN_RANDAO))
     # Mix in RANDAO reveal
     mix = xor(get_randao_mix(state, epoch), hash(body.randao_reveal))
-    state.randao_mixes[epoch % HISTORICAL_VECTOR_LENGTH] = mix
+    state.randao_mixes[epoch % EPOCHS_PER_HISTORICAL_VECTOR] = mix
 ```
 
 #### Eth1 data

--- a/test_libs/pyspec/eth2spec/test/helpers/genesis.py
+++ b/test_libs/pyspec/eth2spec/test/helpers/genesis.py
@@ -41,7 +41,7 @@ def create_genesis_state(spec, num_validators):
             validator.activation_epoch = spec.GENESIS_EPOCH
 
     genesis_active_index_root = hash_tree_root(spec.get_active_validator_indices(state, spec.GENESIS_EPOCH))
-    for index in range(spec.ACTIVE_INDEX_ROOTS_LENGTH):
+    for index in range(spec.HISTORICAL_VECTOR_LENGTH):
         state.active_index_roots[index] = genesis_active_index_root
 
     return state

--- a/test_libs/pyspec/eth2spec/test/helpers/genesis.py
+++ b/test_libs/pyspec/eth2spec/test/helpers/genesis.py
@@ -41,7 +41,7 @@ def create_genesis_state(spec, num_validators):
             validator.activation_epoch = spec.GENESIS_EPOCH
 
     genesis_active_index_root = hash_tree_root(spec.get_active_validator_indices(state, spec.GENESIS_EPOCH))
-    for index in range(spec.HISTORICAL_VECTOR_LENGTH):
+    for index in range(spec.EPOCHS_PER_HISTORICAL_VECTOR):
         state.active_index_roots[index] = genesis_active_index_root
 
     return state


### PR DESCRIPTION
_[port of #1109. PR was stale and rewrite was easier than merge]_

* Address item 11 of #1054. This stores 8-month old historical start shards so that historical committees to be recomputed (e.g. for attester slashings).
* collapse `ACTIVE_INDEX_ROOTS_LENGTH` and `RANDAO_MIXES_LENGTH` into single var -- `HISTORICAL_VECTOR_LENGTH`
* some minor cleanups