### PR TITLE
Xdist tests for parallelism

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,11 +48,11 @@ install_test:
 
 test: $(PY_SPEC_ALL_TARGETS)
 	cd $(PY_SPEC_DIR); . venv/bin/activate;	export PYTHONPATH="./"; \
-	python -m pytest --cov=eth2spec.phase0.spec --cov=eth2spec.phase1.spec --cov-report="html:$(COV_HTML_OUT)" --cov-branch eth2spec
+	python -m pytest -n auto --cov=eth2spec.phase0.spec --cov=eth2spec.phase1.spec --cov-report="html:$(COV_HTML_OUT)" --cov-branch eth2spec
 
 citest: $(PY_SPEC_ALL_TARGETS)
 	cd $(PY_SPEC_DIR); mkdir -p test-reports/eth2spec; . venv/bin/activate; \
-	python -m pytest --junitxml=test-reports/eth2spec/test_results.xml eth2spec
+	python -m pytest -n auto --junitxml=test-reports/eth2spec/test_results.xml eth2spec
 
 open_cov:
 	((open "$(COV_INDEX_FILE)" || xdg-open "$(COV_INDEX_FILE)") &> /dev/null) &

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ test: $(PY_SPEC_ALL_TARGETS)
 
 citest: $(PY_SPEC_ALL_TARGETS)
 	cd $(PY_SPEC_DIR); mkdir -p test-reports/eth2spec; . venv/bin/activate; \
-	python -m pytest -n auto --junitxml=test-reports/eth2spec/test_results.xml eth2spec
+	python -m pytest -n 8 --junitxml=test-reports/eth2spec/test_results.xml eth2spec
 
 open_cov:
 	((open "$(COV_INDEX_FILE)" || xdg-open "$(COV_INDEX_FILE)") &> /dev/null) &

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ test: $(PY_SPEC_ALL_TARGETS)
 
 citest: $(PY_SPEC_ALL_TARGETS)
 	cd $(PY_SPEC_DIR); mkdir -p test-reports/eth2spec; . venv/bin/activate; \
-	python -m pytest -n 4 --junitxml=test-reports/eth2spec/test_results.xml eth2spec
+	python -m pytest -n 2 --junitxml=test-reports/eth2spec/test_results.xml eth2spec
 
 open_cov:
 	((open "$(COV_INDEX_FILE)" || xdg-open "$(COV_INDEX_FILE)") &> /dev/null) &

--- a/Makefile
+++ b/Makefile
@@ -48,11 +48,11 @@ install_test:
 
 test: $(PY_SPEC_ALL_TARGETS)
 	cd $(PY_SPEC_DIR); . venv/bin/activate;	export PYTHONPATH="./"; \
-	python -m pytest -n auto --cov=eth2spec.phase0.spec --cov=eth2spec.phase1.spec --cov-report="html:$(COV_HTML_OUT)" --cov-branch eth2spec
+	python -m pytest -n 4 --cov=eth2spec.phase0.spec --cov=eth2spec.phase1.spec --cov-report="html:$(COV_HTML_OUT)" --cov-branch eth2spec
 
 citest: $(PY_SPEC_ALL_TARGETS)
 	cd $(PY_SPEC_DIR); mkdir -p test-reports/eth2spec; . venv/bin/activate; \
-	python -m pytest -n 8 --junitxml=test-reports/eth2spec/test_results.xml eth2spec
+	python -m pytest -n 4 --junitxml=test-reports/eth2spec/test_results.xml eth2spec
 
 open_cov:
 	((open "$(COV_INDEX_FILE)" || xdg-open "$(COV_INDEX_FILE)") &> /dev/null) &

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ test: $(PY_SPEC_ALL_TARGETS)
 
 citest: $(PY_SPEC_ALL_TARGETS)
 	cd $(PY_SPEC_DIR); mkdir -p test-reports/eth2spec; . venv/bin/activate; \
-	python -m pytest -n 2 --junitxml=test-reports/eth2spec/test_results.xml eth2spec
+	python -m pytest -n 4 --junitxml=test-reports/eth2spec/test_results.xml eth2spec
 
 open_cov:
 	((open "$(COV_INDEX_FILE)" || xdg-open "$(COV_INDEX_FILE)") &> /dev/null) &

--- a/test_libs/pyspec/requirements-testing.txt
+++ b/test_libs/pyspec/requirements-testing.txt
@@ -1,6 +1,7 @@
 -r requirements.txt
-pytest>=3.6,<3.7
+pytest>=4.4
 ../config_helpers
 flake8==3.7.7
 mypy==0.701
 pytest-cov
+pytest-xdist


### PR DESCRIPTION
Added `xdist` to python tests to utilize 4 cpus 

Locally, this reduced run time from ~350s to ~200s. In circleCI this reduced run time from ~200s to ~90s.