### PR TITLE
Change uint aliases to just be subclasses

### DIFF
--- a/scripts/build_spec.py
+++ b/scripts/build_spec.py
@@ -130,11 +130,7 @@ def objects_to_spec(functions: Dict[str, str],
     new_type_definitions = (
         '\n\n'.join(
             [
-                f"class {key}({value}):\n"
-                f"    def __init__(self, _x: {value}) -> None:\n"
-                f"        ...\n"
-                if value.startswith("uint")
-                else f"class {key}({value}):\n    pass\n"
+                f"class {key}({value}):\n    pass\n"
                 for key, value in custom_types.items()
             ]
         )

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1142,7 +1142,7 @@ def is_genesis_trigger(deposits: Sequence[Deposit], timestamp: uint64) -> bool:
 
     # Count active validators at genesis
     active_validator_count = 0
-    for validator in state.validator_registry:
+    for validator in state.validators:
         if validator.effective_balance == MAX_EFFECTIVE_BALANCE:
             active_validator_count += 1
 

--- a/test_libs/pyspec/eth2spec/utils/ssz/ssz_typing.py
+++ b/test_libs/pyspec/eth2spec/utils/ssz/ssz_typing.py
@@ -34,7 +34,7 @@ class BasicValue(int, SSZValue, metaclass=BasicType):
 class Bool(BasicValue):  # can't subclass bool.
     byte_len = 1
 
-    def __new__(cls, value, *args, **kwargs):
+    def __new__(cls, value: int):  # int value, but can be any subclass of int (bool, Bit, Bool, etc...)
         if value < 0 or value > 1:
             raise ValueError(f"value {value} out of bounds for bit")
         return super().__new__(cls, value)
@@ -54,7 +54,7 @@ class Bit(Bool):
 
 class uint(BasicValue, metaclass=BasicType):
 
-    def __new__(cls, value, *args, **kwargs):
+    def __new__(cls, value: int):
         if value < 0:
             raise ValueError("unsigned types must not be negative")
         if cls.byte_len and value.bit_length() > (cls.byte_len << 3):


### PR DESCRIPTION
Change uint aliases to just be subclasses do not override init with no-op.

old (note that the ellipsis here is not for code showing purposes, it's python code):
```python
class ValidatorIndex(uint64):
    def __init__(self, _x: uint64) -> None:
        ...
```

new:
```python
class ValidatorIndex(uint64):
    pass
```

The subclassing works just fine, and does not have all the edge-cases to think about when overriding the `__init__`. Also enables (read: makes IDE type hint checker happy) us to do `ValidatorIndex(123)` instead of `ValidatorIndex(uint64(123))`.

Also experimented with the use of `__metaclass__` or `Elements.elem_type`, `ElementsType.elem_type` in type hinting. Intellij + Mypy are happy (surprisingly), but Python is not. So we would have to shadow the bahavior of `Generic` to do that kind of type-hinting. That is for another time, construction of types and passing them is the most important now. The getter/setter/iteration is not even picked up as a problem by mypy, while it could be better (if Python allowed us to).

And fixed an old `validator_registry` reference, which was missed (genesis trigger testing is in progress I believe)