### PR TITLE
Some fixes to finality tests

### DIFF
--- a/test_libs/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_justification_and_finalization.py
+++ b/test_libs/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_justification_and_finalization.py
@@ -16,14 +16,6 @@ def get_shards_for_slot(spec, state, slot):
     return [shard + i for i in range(committees_per_slot)]
 
 
-def get_committee_size(spec, epoch_start_shard, shard, committee_count, indices):
-    committee_index = (shard + spec.SHARD_COUNT - epoch_start_shard) % spec.SHARD_COUNT
-    start = (len(indices) * committee_index) // committee_count
-    end = (len(indices) * (committee_index + 1)) // committee_count
-    size = end - start
-    return size
-
-
 def add_mock_attestations(spec, state, epoch, source, target, sufficient_support=False):
     # we must be at the end of the epoch
     assert (state.slot + 1) % spec.SLOTS_PER_EPOCH == 0

--- a/test_libs/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_justification_and_finalization.py
+++ b/test_libs/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_justification_and_finalization.py
@@ -36,6 +36,11 @@ def add_mock_attestations(spec, state, epoch, source, target, sufficient_support
     epoch_start_slot = spec.get_epoch_start_slot(epoch)
     for slot in range(epoch_start_slot, epoch_start_slot + spec.SLOTS_PER_EPOCH):
         for shard in get_shards_for_slot(spec, state, slot):
+            # Check if we already have had sufficient balance. (and undone if we don't want it).
+            # If so, do not create more attestations. (we do not have empty pending attestations normally anyway)
+            if remaining_balance < 0:
+                return
+
             committee = spec.get_crosslink_committee(state, spec.slot_to_epoch(slot), shard)
             # Create a bitfield filled with the given count per attestation,
             #  exactly on the right-most part of the committee field.
@@ -45,22 +50,23 @@ def add_mock_attestations(spec, state, epoch, source, target, sufficient_support
                 if remaining_balance > 0:
                     remaining_balance -= state.validators[v].effective_balance
                     aggregation_bits[v] = 1
-                elif not sufficient_support:
-                    aggregation_bits[v - 1] = 0
-                    break
                 else:
                     break
 
-        attestations.append(spec.PendingAttestation(
-            aggregation_bits=aggregation_bits,
-            data=spec.AttestationData(
-                beacon_block_root=b'\xaa' * 32,
-                source=source,
-                target=target,
-                crosslink=spec.Crosslink(shard=shard)
-            ),
-            inclusion_delay=1,
-        ))
+            # remove just one attester to make the marginal support insufficient
+            if not sufficient_support:
+                aggregation_bits[aggregation_bits.index(1)] = 0
+
+            attestations.append(spec.PendingAttestation(
+                aggregation_bits=aggregation_bits,
+                data=spec.AttestationData(
+                    beacon_block_root=b'\xaa' * 32,
+                    source=source,
+                    target=target,
+                    crosslink=spec.Crosslink(shard=shard)
+                ),
+                inclusion_delay=1,
+            ))
 
 
 def finalize_on_234(spec, state, epoch, sufficient_support):
@@ -82,7 +88,7 @@ def finalize_on_234(spec, state, epoch, sufficient_support):
     state.previous_justified_checkpoint = c4
     state.current_justified_checkpoint = c3
     state.justification_bits = spec.Bitvector[spec.JUSTIFICATION_BITS_LENGTH]()
-    state.justification_bits[1:3] = [1, 1]  # mock 2nd and 3rd latest epochs as justified
+    state.justification_bits[1:3] = [1, 1]  # mock 3rd and 4th latest epochs as justified (indices are pre-shift)
     # mock the 2nd latest epoch as justifiable, with 4th as source
     add_mock_attestations(spec, state,
                           epoch=epoch - 2,
@@ -93,12 +99,11 @@ def finalize_on_234(spec, state, epoch, sufficient_support):
     # process!
     yield from run_process_just_and_fin(spec, state)
 
+    assert state.previous_justified_checkpoint == c3  # changed to old current
     if sufficient_support:
-        assert state.previous_justified_checkpoint == c3  # changed to old current
         assert state.current_justified_checkpoint == c2  # changed to 2nd latest
         assert state.finalized_checkpoint == c4  # finalized old previous justified epoch
     else:
-        assert state.previous_justified_checkpoint == c3  # changed to old current
         assert state.current_justified_checkpoint == c3  # still old current
         assert state.finalized_checkpoint == old_finalized  # no new finalized
 
@@ -108,7 +113,8 @@ def finalize_on_23(spec, state, epoch, sufficient_support):
     state.slot = (spec.SLOTS_PER_EPOCH * epoch) - 1  # skip ahead to just before epoch
 
     # 43210 -- epochs ago
-    # 3210x -- justification bitfield indices
+    # 210xx  -- justification bitfield indices (pre shift)
+    # 3210x -- justification bitfield indices (post shift)
     # 01*0. -- justification bitfield contents, . = this epoch, * is being justified now
     # checkpoints for the epochs ago:
     c3 = spec.Checkpoint(epoch=epoch - 3, root=b'\xaa' * 32)
@@ -120,7 +126,7 @@ def finalize_on_23(spec, state, epoch, sufficient_support):
     state.previous_justified_checkpoint = c3
     state.current_justified_checkpoint = c3
     state.justification_bits = spec.Bitvector[spec.JUSTIFICATION_BITS_LENGTH]()
-    state.justification_bits[1] = 1  # mock 2nd latest epoch as justified
+    state.justification_bits[1] = 1  # mock 3rd latest epoch as justified (indices are pre-shift)
     # mock the 2nd latest epoch as justifiable, with 3rd as source
     add_mock_attestations(spec, state,
                           epoch=epoch - 2,
@@ -131,12 +137,11 @@ def finalize_on_23(spec, state, epoch, sufficient_support):
     # process!
     yield from run_process_just_and_fin(spec, state)
 
+    assert state.previous_justified_checkpoint == c3  # changed to old current
     if sufficient_support:
-        assert state.previous_justified_checkpoint == c3  # changed to old current
         assert state.current_justified_checkpoint == c2  # changed to 2nd latest
         assert state.finalized_checkpoint == c3  # finalized old previous justified epoch
     else:
-        assert state.previous_justified_checkpoint == c3  # changed to old current
         assert state.current_justified_checkpoint == c3  # still old current
         assert state.finalized_checkpoint == old_finalized  # no new finalized
 
@@ -146,7 +151,8 @@ def finalize_on_123(spec, state, epoch, sufficient_support):
     state.slot = (spec.SLOTS_PER_EPOCH * epoch) - 1  # skip ahead to just before epoch
 
     # 43210 -- epochs ago
-    # 3210x -- justification bitfield indices
+    # 210xx  -- justification bitfield indices (pre shift)
+    # 3210x -- justification bitfield indices (post shift)
     # 011*. -- justification bitfield contents, . = this epoch, * is being justified now
     # checkpoints for the epochs ago:
     c4 = spec.Checkpoint(epoch=epoch - 4, root=b'\xaa' * 32)
@@ -158,10 +164,10 @@ def finalize_on_123(spec, state, epoch, sufficient_support):
     state.block_roots[spec.get_epoch_start_slot(c1.epoch) % spec.SLOTS_PER_HISTORICAL_ROOT] = c1.root
 
     old_finalized = state.finalized_checkpoint
-    state.previous_justified_checkpoint = c4
+    state.previous_justified_checkpoint = c4  # not c3, otherwise finalize 23 would trigger.
     state.current_justified_checkpoint = c2
     state.justification_bits = spec.Bitvector[spec.JUSTIFICATION_BITS_LENGTH]()
-    state.justification_bits[0:2] = [1, 1]  # mock 1st and 2nd latest epochs as justified
+    state.justification_bits[0:2] = [1, 1]  # mock 2nd and 3rd latest epochs as justified (indices are pre-shift)
     # mock the 1st latest epoch as justifiable, with 3rd as source
     add_mock_attestations(spec, state,
                           epoch=epoch - 1,
@@ -172,12 +178,11 @@ def finalize_on_123(spec, state, epoch, sufficient_support):
     # process!
     yield from run_process_just_and_fin(spec, state)
 
+    assert state.previous_justified_checkpoint == c2  # changed to old current
     if sufficient_support:
-        assert state.previous_justified_checkpoint == c2  # changed to old current
         assert state.current_justified_checkpoint == c1  # changed to 1st latest
         assert state.finalized_checkpoint == c2  # finalized old current
     else:
-        assert state.previous_justified_checkpoint == c2  # changed to old current
         assert state.current_justified_checkpoint == c2  # still old current
         assert state.finalized_checkpoint == old_finalized  # no new finalized
 
@@ -187,7 +192,8 @@ def finalize_on_12(spec, state, epoch, sufficient_support):
     state.slot = (spec.SLOTS_PER_EPOCH * epoch) - 1  # skip ahead to just before epoch
 
     # 43210 -- epochs ago
-    # 3210  -- justification bitfield indices
+    # 210xx  -- justification bitfield indices (pre shift)
+    # 3210x -- justification bitfield indices (post shift)
     # 001*. -- justification bitfield contents, . = this epoch, * is being justified now
     # checkpoints for the epochs ago:
     c2 = spec.Checkpoint(epoch=epoch - 2, root=b'\xbb' * 32)
@@ -199,7 +205,7 @@ def finalize_on_12(spec, state, epoch, sufficient_support):
     state.previous_justified_checkpoint = c2
     state.current_justified_checkpoint = c2
     state.justification_bits = spec.Bitvector[spec.JUSTIFICATION_BITS_LENGTH]()
-    state.justification_bits[0] = 1  # mock latest epoch as justified
+    state.justification_bits[0] = 1  # mock 2nd latest epoch as justified (this is pre-shift)
     # mock the 1st latest epoch as justifiable, with 2nd as source
     add_mock_attestations(spec, state,
                           epoch=epoch - 1,
@@ -210,12 +216,11 @@ def finalize_on_12(spec, state, epoch, sufficient_support):
     # process!
     yield from run_process_just_and_fin(spec, state)
 
+    assert state.previous_justified_checkpoint == c2  # changed to old current
     if sufficient_support:
-        assert state.previous_justified_checkpoint == c2  # changed to old current
         assert state.current_justified_checkpoint == c1  # changed to 1st latest
         assert state.finalized_checkpoint == c2  # finalized previous justified epoch
     else:
-        assert state.previous_justified_checkpoint == c2  # changed to old current
         assert state.current_justified_checkpoint == c2  # still old current
         assert state.finalized_checkpoint == old_finalized  # no new finalized
 

--- a/test_libs/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_justification_and_finalization.py
+++ b/test_libs/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_justification_and_finalization.py
@@ -74,13 +74,15 @@ def finalize_on_234(spec, state, epoch, support):
     c4 = spec.Checkpoint(epoch=epoch - 4, root=b'\xaa' * 32)
     c3 = spec.Checkpoint(epoch=epoch - 3, root=b'\xaa' * 32)
     c2 = spec.Checkpoint(epoch=epoch - 2, root=b'\xbb' * 32)
-    # c1 = spec.Checkpoint(epoch=epoch - 1, root=b'\xcc' * 32)
+    state.block_roots[spec.get_epoch_start_slot(c4.epoch) % spec.SLOTS_PER_HISTORICAL_ROOT] = c4.root
+    state.block_roots[spec.get_epoch_start_slot(c3.epoch) % spec.SLOTS_PER_HISTORICAL_ROOT] = c3.root
+    state.block_roots[spec.get_epoch_start_slot(c2.epoch) % spec.SLOTS_PER_HISTORICAL_ROOT] = c2.root
 
     old_finalized = state.finalized_checkpoint
     state.previous_justified_checkpoint = c4
     state.current_justified_checkpoint = c3
-    bits = state.justification_bits = spec.Bitvector[spec.JUSTIFICATION_BITS_LENGTH]()
-    bits[3:4] = [1, 1]  # mock 3rd and 4th latest epochs as justified
+    state.justification_bits = spec.Bitvector[spec.JUSTIFICATION_BITS_LENGTH]()
+    state.justification_bits[1:3] = [1, 1]  # mock 3rd and 4th latest epochs as justified
     # mock the 2nd latest epoch as justifiable, with 4th as source
     add_mock_attestations(spec, state,
                           epoch=epoch - 2,
@@ -109,16 +111,16 @@ def finalize_on_23(spec, state, epoch, support):
     # 3210x -- justification bitfield indices
     # 01*0. -- justification bitfield contents, . = this epoch, * is being justified now
     # checkpoints for the epochs ago:
-    # c4 = spec.Checkpoint(epoch=epoch - 4, root=b'\xaa' * 32)
     c3 = spec.Checkpoint(epoch=epoch - 3, root=b'\xaa' * 32)
     c2 = spec.Checkpoint(epoch=epoch - 2, root=b'\xbb' * 32)
-    # c1 = spec.Checkpoint(epoch=epoch - 1, root=b'\xcc' * 32)
+    state.block_roots[spec.get_epoch_start_slot(c3.epoch) % spec.SLOTS_PER_HISTORICAL_ROOT] = c3.root
+    state.block_roots[spec.get_epoch_start_slot(c2.epoch) % spec.SLOTS_PER_HISTORICAL_ROOT] = c2.root
 
     old_finalized = state.finalized_checkpoint
     state.previous_justified_checkpoint = c3
     state.current_justified_checkpoint = c3
-    bits = state.justification_bits = spec.Bitvector[spec.JUSTIFICATION_BITS_LENGTH]()
-    bits[2] = 1  # mock 3rd latest epoch as justified
+    state.justification_bits = spec.Bitvector[spec.JUSTIFICATION_BITS_LENGTH]()
+    state.justification_bits[1] = 1  # mock 2nd latest epoch as justified
     # mock the 2nd latest epoch as justifiable, with 3rd as source
     add_mock_attestations(spec, state,
                           epoch=epoch - 2,
@@ -147,16 +149,18 @@ def finalize_on_123(spec, state, epoch, support):
     # 3210x -- justification bitfield indices
     # 011*. -- justification bitfield contents, . = this epoch, * is being justified now
     # checkpoints for the epochs ago:
-    # c4 = spec.Checkpoint(epoch=epoch - 4, root=b'\xaa' * 32)
     c3 = spec.Checkpoint(epoch=epoch - 3, root=b'\xaa' * 32)
     c2 = spec.Checkpoint(epoch=epoch - 2, root=b'\xbb' * 32)
     c1 = spec.Checkpoint(epoch=epoch - 1, root=b'\xcc' * 32)
+    state.block_roots[spec.get_epoch_start_slot(c3.epoch) % spec.SLOTS_PER_HISTORICAL_ROOT] = c3.root
+    state.block_roots[spec.get_epoch_start_slot(c2.epoch) % spec.SLOTS_PER_HISTORICAL_ROOT] = c2.root
+    state.block_roots[spec.get_epoch_start_slot(c1.epoch) % spec.SLOTS_PER_HISTORICAL_ROOT] = c1.root
 
     old_finalized = state.finalized_checkpoint
     state.previous_justified_checkpoint = c3
     state.current_justified_checkpoint = c2
-    bits = state.justification_bits = spec.Bitvector[spec.JUSTIFICATION_BITS_LENGTH]()
-    bits[1:2] = [1, 1]  # mock 2rd and 3th latest epochs as justified
+    state.justification_bits = spec.Bitvector[spec.JUSTIFICATION_BITS_LENGTH]()
+    state.justification_bits[0:2] = [1, 1]  # mock 1st and 2nd latest epochs as justified
     # mock the 1st latest epoch as justifiable, with 3rd as source
     add_mock_attestations(spec, state,
                           epoch=epoch - 1,
@@ -185,8 +189,6 @@ def finalize_on_12(spec, state, epoch, support):
     # 3210  -- justification bitfield indices
     # 001*. -- justification bitfield contents, . = this epoch, * is being justified now
     # checkpoints for the epochs ago:
-    # c4 = spec.Checkpoint(epoch=epoch - 4, root=b'\xaa' * 32)
-    # c3 = spec.Checkpoint(epoch=epoch - 3, root=b'\xaa' * 32)
     c2 = spec.Checkpoint(epoch=epoch - 2, root=b'\xbb' * 32)
     c1 = spec.Checkpoint(epoch=epoch - 1, root=b'\xcc' * 32)
     state.block_roots[spec.get_epoch_start_slot(c2.epoch) % spec.SLOTS_PER_HISTORICAL_ROOT] = c2.root

--- a/test_libs/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_justification_and_finalization.py
+++ b/test_libs/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_justification_and_finalization.py
@@ -187,8 +187,8 @@ def finalize_on_12(spec, state, epoch, support):
     # checkpoints for the epochs ago:
     # c4 = spec.Checkpoint(epoch=epoch - 4, root=b'\xaa' * 32)
     # c3 = spec.Checkpoint(epoch=epoch - 3, root=b'\xaa' * 32)
-    c2 = spec.Checkpoint(epoch=epoch - 2, root=b'\xbb' * 32)
-    c1 = spec.Checkpoint(epoch=epoch - 1, root=b'\xcc' * 32)
+    c2 = spec.Checkpoint(epoch=epoch - 1, root=b'\xbb' * 32)
+    c1 = spec.Checkpoint(epoch=epoch, root=b'\xcc' * 32)
     state.block_roots[spec.get_epoch_start_slot(c2.epoch) % spec.SLOTS_PER_HISTORICAL_ROOT] = c2.root
     state.block_roots[spec.get_epoch_start_slot(c1.epoch) % spec.SLOTS_PER_HISTORICAL_ROOT] = c1.root
 

--- a/test_libs/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_justification_and_finalization.py
+++ b/test_libs/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_justification_and_finalization.py
@@ -82,7 +82,7 @@ def finalize_on_234(spec, state, epoch, support):
     state.previous_justified_checkpoint = c4
     state.current_justified_checkpoint = c3
     state.justification_bits = spec.Bitvector[spec.JUSTIFICATION_BITS_LENGTH]()
-    state.justification_bits[1:3] = [1, 1]  # mock 3rd and 4th latest epochs as justified
+    state.justification_bits[1:3] = [1, 1]  # mock 2nd and 3rd latest epochs as justified
     # mock the 2nd latest epoch as justifiable, with 4th as source
     add_mock_attestations(spec, state,
                           epoch=epoch - 2,

--- a/test_libs/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_justification_and_finalization.py
+++ b/test_libs/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_justification_and_finalization.py
@@ -57,7 +57,7 @@ def add_mock_attestations(spec, state, epoch, att_ratio, source, target):
                     beacon_block_root=b'\xaa' * 32,
                     source=source,
                     target=target,
-                    crosslink=spec.Crosslink()
+                    crosslink=spec.Crosslink(shard=shard)
                 ),
                 inclusion_delay=1,
             ))

--- a/test_libs/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_justification_and_finalization.py
+++ b/test_libs/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_justification_and_finalization.py
@@ -189,12 +189,14 @@ def finalize_on_12(spec, state, epoch, support):
     # c3 = spec.Checkpoint(epoch=epoch - 3, root=b'\xaa' * 32)
     c2 = spec.Checkpoint(epoch=epoch - 2, root=b'\xbb' * 32)
     c1 = spec.Checkpoint(epoch=epoch - 1, root=b'\xcc' * 32)
+    state.block_roots[spec.get_epoch_start_slot(c2.epoch) % spec.SLOTS_PER_HISTORICAL_ROOT] = c2.root
+    state.block_roots[spec.get_epoch_start_slot(c1.epoch) % spec.SLOTS_PER_HISTORICAL_ROOT] = c1.root
 
     old_finalized = state.finalized_checkpoint
     state.previous_justified_checkpoint = c2
     state.current_justified_checkpoint = c2
-    bits = state.justification_bits = spec.Bitvector[spec.JUSTIFICATION_BITS_LENGTH]()
-    bits[3] = 1  # mock 3rd latest epoch as justified
+    state.justification_bits = spec.Bitvector[spec.JUSTIFICATION_BITS_LENGTH]()
+    state.justification_bits[0] = 1  # mock latest epoch as justified
     # mock the 1st latest epoch as justifiable, with 2nd as source
     add_mock_attestations(spec, state,
                           epoch=epoch - 1,

--- a/test_libs/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_justification_and_finalization.py
+++ b/test_libs/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_justification_and_finalization.py
@@ -149,6 +149,7 @@ def finalize_on_123(spec, state, epoch, support):
     # 3210x -- justification bitfield indices
     # 011*. -- justification bitfield contents, . = this epoch, * is being justified now
     # checkpoints for the epochs ago:
+    c4 = spec.Checkpoint(epoch=epoch - 4, root=b'\xaa' * 32)
     c3 = spec.Checkpoint(epoch=epoch - 3, root=b'\xaa' * 32)
     c2 = spec.Checkpoint(epoch=epoch - 2, root=b'\xbb' * 32)
     c1 = spec.Checkpoint(epoch=epoch - 1, root=b'\xcc' * 32)
@@ -157,7 +158,7 @@ def finalize_on_123(spec, state, epoch, support):
     state.block_roots[spec.get_epoch_start_slot(c1.epoch) % spec.SLOTS_PER_HISTORICAL_ROOT] = c1.root
 
     old_finalized = state.finalized_checkpoint
-    state.previous_justified_checkpoint = c3
+    state.previous_justified_checkpoint = c4
     state.current_justified_checkpoint = c2
     state.justification_bits = spec.Bitvector[spec.JUSTIFICATION_BITS_LENGTH]()
     state.justification_bits[0:2] = [1, 1]  # mock 1st and 2nd latest epochs as justified

--- a/test_libs/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_justification_and_finalization.py
+++ b/test_libs/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_justification_and_finalization.py
@@ -56,7 +56,7 @@ def add_mock_attestations(spec, state, epoch, att_ratio, source, target):
                 data=spec.AttestationData(
                     beacon_block_root=b'\xaa' * 32,
                     source=source,
-                    target=source,
+                    target=target,
                     crosslink=spec.Crosslink()
                 ),
                 inclusion_delay=1,
@@ -187,8 +187,8 @@ def finalize_on_12(spec, state, epoch, support):
     # checkpoints for the epochs ago:
     # c4 = spec.Checkpoint(epoch=epoch - 4, root=b'\xaa' * 32)
     # c3 = spec.Checkpoint(epoch=epoch - 3, root=b'\xaa' * 32)
-    c2 = spec.Checkpoint(epoch=epoch - 1, root=b'\xbb' * 32)
-    c1 = spec.Checkpoint(epoch=epoch, root=b'\xcc' * 32)
+    c2 = spec.Checkpoint(epoch=epoch - 2, root=b'\xbb' * 32)
+    c1 = spec.Checkpoint(epoch=epoch - 1, root=b'\xcc' * 32)
     state.block_roots[spec.get_epoch_start_slot(c2.epoch) % spec.SLOTS_PER_HISTORICAL_ROOT] = c2.root
     state.block_roots[spec.get_epoch_start_slot(c1.epoch) % spec.SLOTS_PER_HISTORICAL_ROOT] = c1.root
 

--- a/test_libs/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_justification_and_finalization.py
+++ b/test_libs/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_justification_and_finalization.py
@@ -49,10 +49,10 @@ def add_mock_attestations(spec, state, epoch, att_ratio, source, target):
             # Create a bitfield filled with the given count per attestation,
             #  exactly on the right-most part of the committee field.
             attesting_count = math.ceil(size * att_ratio)
-            aggregation_bitfield = ((1 << attesting_count) - 1).to_bytes(length=((size + 7) // 8), byteorder='big')
+            aggregation_bits = [i < attesting_count for i in range(size)]
 
             attestations.append(spec.PendingAttestation(
-                aggregation_bitfield=aggregation_bitfield,
+                aggregation_bits=aggregation_bits,
                 data=spec.AttestationData(
                     beacon_block_root=b'\xaa' * 32,
                     source=source,


### PR DESCRIPTION
Fix finality_12. This should be a good base to fix the others.

* need to set the associated epoch boundary block roots to ensure that `get_matching_target_` works
* justification bit 0 should be set at first so it gets shift to position 1. Then 0 gets justified and you have 0 and 1 for finality.
* `aggregation_bitfield` -> `aggregation_bits` in `add_mock_attestations` (use bool array for init)
* `add_mock_attestations` had bug, setting `target=source`. fixed
* `add_mock_attestations` sets `shard` in `attestation.data.crosslink`. This piece of data is required to figure out what committee is attesting. Previous, all were defaulting to zero so each committee added looked the same.
