### PR TITLE
rebased old BLS rework. For discussion purposes.

### DIFF
--- a/specs/bls_signature.md
+++ b/specs/bls_signature.md
@@ -71,10 +71,10 @@ We require:
 G2_cofactor = 305502333931268344200999753193121504214466019254188142667664032982267604182971884026507427359259977847832272839041616661285803823378372096355777062779109
 q = 4002409555221667393417789825735904156556882819939007885332058136124031650490837864442687629129015664037894272559787
 
-def hash_to_G2(message_hash: Bytes32, domain: uint64) -> Tuple[uint384, uint384]:
+def hash_to_G2(message: bytes) -> Tuple[uint384, uint384]:
     # Initial candidate x coordinate
-    x_re = int.from_bytes(hash(message_hash + bytes8(domain) + b'\x01'), 'big')
-    x_im = int.from_bytes(hash(message_hash + bytes8(domain) + b'\x02'), 'big')
+    x_re = int.from_bytes(hash(message + b'\x01'), 'big')
+    x_im = int.from_bytes(hash(message + b'\x02'), 'big')
     x_coordinate = Fq2([x_re, x_im])  # x = x_re + i * x_im
     
     # Test candidate y coordinates until a one is found
@@ -130,17 +130,43 @@ g = Fq2([g_x, g_y])
 
 ### `bls_verify`
 
-Let `bls_verify(pubkey: Bytes48, message_hash: Bytes32, signature: Bytes96, domain: uint64) -> bool`:
+Let `bls_verify(pubkey: Bytes48, message: bytes, signature: Bytes96) -> bool`:
 
 * Verify that `pubkey` is a valid G1 point.
 * Verify that `signature` is a valid G2 point.
-* Verify that `e(pubkey, hash_to_G2(message_hash, domain)) == e(g, signature)`.
+* Verify that `e(pubkey, hash_to_G2(message)) == e(g, signature)`.
 
 ### `bls_verify_multiple`
 
-Let `bls_verify_multiple(pubkeys: List[Bytes48], message_hashes: List[Bytes32], signature: Bytes96, domain: uint64) -> bool`:
+Let `bls_verify_multiple(pubkeys: List[Bytes48], messages: List[bytes], signature: Bytes96) -> bool`:
 
 * Verify that each `pubkey` in `pubkeys` is a valid G1 point.
 * Verify that `signature` is a valid G2 point.
-* Verify that `len(pubkeys)` equals `len(message_hashes)` and denote the length `L`.
-* Verify that `e(pubkeys[0], hash_to_G2(message_hashes[0], domain)) * ... * e(pubkeys[L-1], hash_to_G2(message_hashes[L-1], domain)) == e(g, signature)`.
+* Verify that `len(pubkeys)` equals `len(messages)` and denote the length `L`.
+* Verify that `e(pubkeys[0], hash_to_G2(messages[0])) * ... * e(pubkeys[L-1], hash_to_G2(messages[L-1]) == e(g, signature)`.
+
+
+## Application layer
+
+In the specification documents, the following usage interface is followed:
+
+| `BLSDomain` | `Bytes8` | a BLS12-381 domain |
+| `BLSPubkey` | `Bytes48` | a BLS12-381 public key |
+| `BLSSignature` | `Bytes96` | a BLS12-381 signature |
+
+### `bls_verify`
+
+```python
+
+def bls_verify(pubkey: BLSPubkey, self_signed_object: Container, domain: BLSDomain) -> bool:
+    return bls.bls_verify(pubkey, domain + signed_root(self_signed_object), self_signed_object.signature)
+```
+
+### `bls_verify_multiple`
+
+```python
+def bls_verify_multiple(pubkeys: List[BLSPubkey], roots: List[Bytes32],
+                        signature: BLSSignature, domain: BLSDomain) -> bool:
+    messages = [domain + root for root in roots]
+    return bls.verify_multiple(pubkeys, messages, signature)
+```

--- a/specs/bls_signature.md
+++ b/specs/bls_signature.md
@@ -20,6 +20,8 @@
         - [`bls_aggregate_pubkeys`](#bls_aggregate_pubkeys)
         - [`bls_aggregate_signatures`](#bls_aggregate_signatures)
     - [Signature verification](#signature-verification)
+        - [`raw_bls_verify`](#raw_bls_verify)
+        - [`raw_bls_verify_multiple`](#raw_bls_verify_multiple)
         - [`bls_verify`](#bls_verify)
         - [`bls_verify_multiple`](#bls_verify_multiple)
 
@@ -66,6 +68,8 @@ We require:
 ## Helpers
 
 ### `hash_to_G2`
+
+Note: The following function is an (insecure!) placeholder that will be replaced according to the recommendations of the ongoing BLS12-381 standardisation effort.
 
 ```python
 G2_cofactor = 305502333931268344200999753193121504214466019254188142667664032982267604182971884026507427359259977847832272839041616661285803823378372096355777062779109

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1042,16 +1042,9 @@ def get_churn_limit(state: BeaconState) -> int:
     )
 ```
 
-### `raw_bls_verify`
-
-`raw_bls_verify` is a function for verifying a BLS signature, defined in the [BLS Signature spec](../bls_signature.md#bls_verify).
-
 ### `bls_verify`
 
-```python
-def bls_verify(pubkey: BLSPubkey, self_signed_object: Container, domain: BLSDomain) -> bool:
-    return raw_bls_verify(pubkey, domain + signed_root(self_signed_object), self_signed_object.signature)
-```
+`bls_verify` is a function for verifying a BLS signature, defined in the [BLS Signature spec](../bls_signature.md#bls_verify).
 
 ### `bls_verify_multiple`
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -31,6 +31,7 @@
             - [`AttestationDataAndCustodyBit`](#attestationdataandcustodybit)
             - [`IndexedAttestation`](#indexedattestation)
             - [`PendingAttestation`](#pendingattestation)
+            - [`RandaoReveal`](#randaoreveal)
             - [`Eth1Data`](#eth1data)
             - [`HistoricalBatch`](#historicalbatch)
             - [`DepositData`](#depositdata)
@@ -367,6 +368,14 @@ class PendingAttestation(Container):
     data: AttestationData
     inclusion_delay: Slot
     proposer_index: ValidatorIndex
+```
+
+#### `RandaoReveal`
+
+```python
+class RandaoReveal(Container):
+    epoch: Epoch
+    signature: BLSSginature
 ```
 
 #### `Eth1Data`
@@ -979,7 +988,7 @@ def validate_indexed_attestation(state: BeaconState, indexed_attestation: Indexe
             bls_aggregate_pubkeys([state.validators[i].pubkey for i in bit_0_indices]),
             bls_aggregate_pubkeys([state.validators[i].pubkey for i in bit_1_indices]),
         ],
-        message_hashes=[
+        roots=[
             hash_tree_root(AttestationDataAndCustodyBit(data=indexed_attestation.data, custody_bit=0b0)),
             hash_tree_root(AttestationDataAndCustodyBit(data=indexed_attestation.data, custody_bit=0b1)),
         ],

--- a/test_libs/pyspec/eth2spec/utils/bls.py
+++ b/test_libs/pyspec/eth2spec/utils/bls.py
@@ -1,4 +1,5 @@
 from py_ecc import bls
+from .ssz.ssz_impl import signing_root
 
 # Flag to make BLS active or not. Used for testing, do not ignore BLS in production unless you know what you are doing.
 bls_active = True
@@ -22,13 +23,14 @@ def only_with_bls(alt_return=None):
 
 
 @only_with_bls(alt_return=True)
-def bls_verify(pubkey, message_hash, signature, domain):
-    return bls.verify(message_hash=message_hash, pubkey=pubkey, signature=signature, domain=domain)
+def bls_verify(pubkey, self_signed_object, signature, domain):
+    return bls.verify(message_hash=signing_root(self_signed_object), pubkey=pubkey,
+                      signature=signature, domain=int.from_bytes(domain, 'little'))
 
 
 @only_with_bls(alt_return=True)
-def bls_verify_multiple(pubkeys, message_hashes, signature, domain):
-    return bls.verify_multiple(pubkeys, message_hashes, signature, domain)
+def bls_verify_multiple(pubkeys, roots, signature, domain):
+    return bls.verify_multiple(pubkeys, roots, signature, int.from_bytes(domain, 'little'))
 
 
 @only_with_bls(alt_return=STUB_PUBKEY)


### PR DESCRIPTION
Honestly, the BLS interface as-is is ok\*. But if we still want to separate out application layer from the inner BLS layer, we may want to consider something alike to this PR; a rebased version of the initial work by @JustinDrake

I propose we discuss if we move forward with it, making it a post spec-freeze non-breaking change, i.e. fully backwards compatible for signatures during testnet. And keep this apart from the BLS spec-update itself, as a presentation thing.

\*: ok, test-vectors will adopt the spec status to alleviate the typing inconsistency highlighted in #964