### PR TITLE
Minor python style tweaks

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1438,8 +1438,8 @@ def process_registry_updates(state: BeaconState) -> None:
     # Process activation eligibility and ejections
     for index, validator in enumerate(state.validators):
         if (
-            validator.activation_eligibility_epoch == FAR_FUTURE_EPOCH and
-            validator.effective_balance == MAX_EFFECTIVE_BALANCE
+            validator.activation_eligibility_epoch == FAR_FUTURE_EPOCH
+            and validator.effective_balance == MAX_EFFECTIVE_BALANCE
         ):
             validator.activation_eligibility_epoch = get_current_epoch(state)
 
@@ -1448,9 +1448,9 @@ def process_registry_updates(state: BeaconState) -> None:
 
     # Queue validators eligible for activation and not dequeued for activation prior to finalized epoch
     activation_queue = sorted([
-        index for index, validator in enumerate(state.validators) if
-        validator.activation_eligibility_epoch != FAR_FUTURE_EPOCH and
-        validator.activation_epoch >= compute_activation_exit_epoch(state.finalized_checkpoint.epoch)
+        index for index, validator in enumerate(state.validators)
+        if validator.activation_eligibility_epoch != FAR_FUTURE_EPOCH
+        and validator.activation_epoch >= compute_activation_exit_epoch(state.finalized_checkpoint.epoch)
     ], key=lambda index: state.validators[index].activation_eligibility_epoch)
     # Dequeued validators for activation up to churn limit (without resetting activation epoch)
     for index in activation_queue[:get_validator_churn_limit(state)]:

--- a/specs/core/0_fork-choice.md
+++ b/specs/core/0_fork-choice.md
@@ -113,8 +113,8 @@ def get_latest_attesting_balance(store: Store, root: Hash) -> Gwei:
     active_indices = get_active_validator_indices(state, get_current_epoch(state))
     return Gwei(sum(
         state.validators[i].effective_balance for i in active_indices
-        if (i in store.latest_messages and
-            get_ancestor(store, store.latest_messages[i].root, store.blocks[root].slot) == root)
+        if (i in store.latest_messages 
+            and get_ancestor(store, store.latest_messages[i].root, store.blocks[root].slot) == root)
     ))
 ```
 

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -399,7 +399,7 @@ def is_valid_beacon_attestation(shard: Shard,
     else:
         previous_attestation = next(
             (attestation for attestation in valid_attestations
-            if attestation.data.crosslink.data_root == candidate.data.previous_crosslink.data_root),
+             if attestation.data.crosslink.data_root == candidate.data.previous_crosslink.data_root),
             None,
         )
         assert previous_attestation is not None

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -181,8 +181,8 @@ def get_persistent_committee(state: BeaconState,
     # Take not-yet-cycled-out validators from earlier committee and already-cycled-in validators from
     # later committee; return a sorted list of the union of the two, deduplicated
     return sorted(list(set(
-        [i for i in earlier_committee if epoch % PERSISTENT_COMMITTEE_PERIOD < get_switchover_epoch(state, epoch, i)] +
-        [i for i in later_committee if epoch % PERSISTENT_COMMITTEE_PERIOD >= get_switchover_epoch(state, epoch, i)]
+        [i for i in earlier_committee if epoch % PERSISTENT_COMMITTEE_PERIOD < get_switchover_epoch(state, epoch, i)]
+        + [i for i in later_committee if epoch % PERSISTENT_COMMITTEE_PERIOD >= get_switchover_epoch(state, epoch, i)]
     )))
 ```
 
@@ -398,8 +398,8 @@ def is_valid_beacon_attestation(shard: Shard,
         assert candidate.data.previous_crosslink.data_root == Hash()
     else:
         previous_attestation = next(
-            (attestation for attestation in valid_attestations if
-                attestation.data.crosslink.data_root == candidate.data.previous_crosslink.data_root),
+            (attestation for attestation in valid_attestations
+            if attestation.data.crosslink.data_root == candidate.data.previous_crosslink.data_root),
             None,
         )
         assert previous_attestation is not None

--- a/specs/light_client/sync_protocol.md
+++ b/specs/light_client/sync_protocol.md
@@ -153,8 +153,8 @@ def compute_committee(header: BeaconBlockHeader,
     # Take not-yet-cycled-out validators from earlier committee and already-cycled-in validators from
     # later committee; return a sorted list of the union of the two, deduplicated
     return sorted(list(set(
-        [i for i in actual_earlier_committee if epoch % PERSISTENT_COMMITTEE_PERIOD < get_switchover_epoch(i)] +
-        [i for i in actual_later_committee if epoch % PERSISTENT_COMMITTEE_PERIOD >= get_switchover_epoch(i)]
+        [i for i in actual_earlier_committee if epoch % PERSISTENT_COMMITTEE_PERIOD < get_switchover_epoch(i)]
+        + [i for i in actual_later_committee if epoch % PERSISTENT_COMMITTEE_PERIOD >= get_switchover_epoch(i)]
     )))
 ```
 

--- a/specs/validator/0_beacon-chain-validator.md
+++ b/specs/validator/0_beacon-chain-validator.md
@@ -132,10 +132,9 @@ Once a validator is activated, the validator is assigned [responsibilities](#bea
 A validator can get committee assignments for a given epoch using the following helper via `get_committee_assignment(state, epoch, validator_index)` where `epoch <= next_epoch`.
 
 ```python
-def get_committee_assignment(
-        state: BeaconState,
-        epoch: Epoch,
-        validator_index: ValidatorIndex) -> Tuple[List[ValidatorIndex], Shard, Slot]:
+def get_committee_assignment(state: BeaconState,
+                             epoch: Epoch,
+                             validator_index: ValidatorIndex) -> Tuple[List[ValidatorIndex], Shard, Slot]:
     """
     Return the committee assignment in the ``epoch`` for ``validator_index``.
     ``assignment`` returned is a tuple of the following form:

--- a/test_libs/pyspec/eth2spec/test/sanity/test_blocks.py
+++ b/test_libs/pyspec/eth2spec/test/sanity/test_blocks.py
@@ -188,8 +188,8 @@ def test_attester_slashing(spec, state):
     pre_state = deepcopy(state)
 
     attester_slashing = get_valid_attester_slashing(spec, state, signed_1=True, signed_2=True)
-    validator_index = (attester_slashing.attestation_1.custody_bit_0_indices +
-                       attester_slashing.attestation_1.custody_bit_1_indices)[0]
+    validator_index = (attester_slashing.attestation_1.custody_bit_0_indices
+                       + attester_slashing.attestation_1.custody_bit_1_indices)[0]
 
     assert not state.validators[validator_index].slashed
 


### PR DESCRIPTION
This implements the following minor style tweaks that I'd rather have in before the freeze:

- Binary operators that are across multiple lines lead with the operator on the new line
- Consistency in how long function arguments are broken up