### PR TITLE
Cosmetic SSZ spec + add `pack()` in `Bitvector` and `Bitlist` Merkleization

### DIFF
--- a/specs/simple-serialize.md
+++ b/specs/simple-serialize.md
@@ -178,7 +178,7 @@ We first define helper functions:
 
 * `pack`: Given ordered objects of the same basic type, serialize them, pack them into `BYTES_PER_CHUNK`-byte chunks, right-pad the last chunk with zero bytes, and return the chunks.
 * `next_pow_of_two(i)`: get the next power of 2 of `i`, if not already a power of 2, with 0 mapping to 1. Examples: `0->1, 1->1, 2->2, 3->4, 4->4, 6->8, 9->16`
-* `merkleize(data, pad_for)`: Given ordered `BYTES_PER_CHUNK`-byte chunks, if necessary append zero chunks so that the number of chunks is a power of two, Merkleize the chunks, and return the root.
+* `merkleize(data, pad_for=1)`: Given ordered `BYTES_PER_CHUNK`-byte chunks, if necessary append zero chunks so that the number of chunks is a power of two, Merkleize the chunks, and return the root.
   The merkleization depends on the effective input, which can be padded: if `pad_for=L`, then pad the `data` with zeroed chunks to `next_pow_of_two(L)` (virtually for memory efficiency).
   Then, merkleize the chunks (empty input is padded to 1 zero chunk):
     - If `1` chunk: A single chunk is simply that chunk, i.e. the identity when the number of chunks is one.

--- a/specs/simple-serialize.md
+++ b/specs/simple-serialize.md
@@ -55,7 +55,6 @@
         foo: uint64
         bar: boolean
     ```
-
 * **vector**: ordered fixed-length homogeneous collection, with `N` values
     * notation `Vector[type, N]`, e.g. `Vector[uint64, N]`
 * **list**: ordered variable-length homogeneous collection, limited to `N` values
@@ -102,7 +101,7 @@ We recursively define the `serialize` function which consumes an object `value` 
 
 ```python
 assert N in [8, 16, 32, 64, 128, 256]
-return value.to_bytes(N // 8, "little")
+return value.to_bytes(N // BITS_PER_BYTE, "little")
 ```
 
 ### `boolean`
@@ -190,11 +189,11 @@ We first define helper functions:
 
 We now define Merkleization `hash_tree_root(value)` of an object `value` recursively:
 
-* `merkleize(pack(value))` if `value` is a basic object or a vector of basic objects
+* `merkleize(pack(value))` if `value` is a basic object or a vector of basic objects.
 * `mix_in_length(merkleize(pack(value), pad_for=(N * elem_size / BYTES_PER_CHUNK)), len(value))` if `value` is a list of basic objects.
-* `merkleize([hash_tree_root(element) for element in value])` if `value` is a vector of composite objects or a container
+* `merkleize([hash_tree_root(element) for element in value])` if `value` is a vector of composite objects or a container.
 * `mix_in_length(merkleize([hash_tree_root(element) for element in value], pad_for=N), len(value))` if `value` is a list of composite objects.
-* `mix_in_type(merkleize(value.value), value.type_index)` if `value` is of union type
+* `mix_in_type(merkleize(value.value), value.type_index)` if `value` is of union type.
 
 ### `Bitvector[N]`
 


### PR DESCRIPTION
1. Clarify optional parameter `pad_for=1`.
2. To confirm with @dankrad @protolambda, it looks like there are some missing `pack()`s in `Bitvector` and `Bitlist` Merkleization? related to #1267
3. Some cosmetic.