### PR TITLE
Refactoring shard committees and attestations

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -142,7 +142,7 @@ We define the following Python custom types for type hinting and readability:
 
 | Name | SSZ equivalent | Description |
 | - | - | - |
-| `Slot` | `uint64` | a slot number |
+| `Slot` | `uint64` | a slot number in beacon chain |
 | `Epoch` | `uint64` | an epoch number |
 | `Shard` | `uint64` | a shard number |
 | `ValidatorIndex` | `uint64` | a validator registry index |

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -222,7 +222,7 @@ def get_shard_block_proposer_index(state: BeaconState,
 ```python
 def get_shard_block_attester_committee(state: BeaconState,
                                        shard: Shard,
-                                       slot: Slot) -> Sequence[Optional[ValidatorIndex]]:
+                                       slot: ShardSlot) -> Sequence[Optional[ValidatorIndex]]:
     committee_size = min(
         len(get_shard_epoch_committee(state, shard, compute_epoch_of_shard_slot(slot))),
         SHARD_SLOT_COMMITTEE_SIZE,

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -30,7 +30,6 @@
         - [`compute_crosslink_data_root`](#compute_crosslink_data_root)
     - [Object validity](#object-validity)
         - [Shard blocks](#shard-blocks)
-        - [Shard attestations](#shard-attestations)
         - [Beacon attestations](#beacon-attestations)
     - [Shard fork choice rule](#shard-fork-choice-rule)
 
@@ -49,7 +48,7 @@ This document describes the shard data layer and the shard fork choice rule in P
 | `BYTES_PER_SHARD_BLOCK_BODY` | `2**14` (= 16,384) |
 | `MAX_SHARD_ATTESTIONS` | `2**4` (= 16) |
 | `SHARD_SLOTS_PER_BEACON_SLOT` | `2**0` (= 1) |
-| `SHARD_SLOT_COMMITTEE_SIZE` | `2**5` (=32) |
+| `SHARD_SLOT_COMMITTEE_SIZE` | `2**5` (= 32) |
 
 ### Initial values
 
@@ -323,33 +322,6 @@ def is_valid_shard_block(beacon_blocks: Sequence[BeaconBlock],
 
     # Check signatures
     assert verify_shard_attestation_signature(beacon_state, candidate)
-
-    return True
-```
-
-### Shard attestations
-
-Let:
-
-- `valid_shard_blocks` be the list of valid `ShardBlock`
-- `beacon_state` be the canonical `BeaconState`
-- `candidate` be a candidate `ShardAttestation` for which validity is to be determined by running `is_valid_shard_attestation`
-
-```python
-def is_valid_shard_attestation(valid_shard_blocks: Sequence[ShardBlock],
-                               beacon_state: BeaconState,
-                               candidate: ShardAttestation) -> bool:
-    # Check shard block
-    shard_block = next(
-        (block for block in valid_shard_blocks if signing_root(block) == candidate.data.shard_block_root),
-        None,
-    )
-    assert shard_block is not None
-    assert shard_block.slot == candidate.data.slot
-    assert shard_block.shard == candidate.data.shard
-
-    # Check signature
-    verify_shard_attestation_signature(beacon_state, candidate)
 
     return True
 ```

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -9,6 +9,7 @@
 - [Ethereum 2.0 Phase 1 -- Shard Data Chains](#ethereum-20-phase-1----shard-data-chains)
     - [Table of contents](#table-of-contents)
     - [Introduction](#introduction)
+    - [Custom types](#custom-types)
     - [Configuration](#configuration)
         - [Misc](#misc)
         - [Initial values](#initial-values)
@@ -20,6 +21,7 @@
         - [`ShardBlock`](#shardblock)
         - [`ShardBlockHeader`](#shardblockheader)
     - [Helper functions](#helper-functions)
+        - [`compute_epoch_of_shard_slot`](#compute_epoch_of_shard_slot)
         - [`get_period_committee`](#get_period_committee)
         - [`get_switchover_epoch`](#get_switchover_epoch)
         - [`get_shard_epoch_committee`](#get_shard_epoch_committee)
@@ -38,6 +40,14 @@
 ## Introduction
 
 This document describes the shard data layer and the shard fork choice rule in Phase 1 of Ethereum 2.0.
+
+## Custom types
+
+We define the following Python custom types for type hinting and readability:
+
+| Name | SSZ equivalent | Description |
+| - | - | - |
+| `ShardSlot` | `uint64` | a slot number in shard chain |
 
 ## Configuration
 
@@ -122,7 +132,7 @@ class ShardBlockHeader(Container):
 
 ```python
 def compute_epoch_of_shard_slot(slot: ShardSlot) -> Epoch:
-    return slot // SHARD_SLOTS_PER_BEACON_SLOT // SLOTS_PER_EPOCH
+    return Epoch(slot // SHARD_SLOTS_PER_BEACON_SLOT // SLOTS_PER_EPOCH)
 ```
 
 ### `get_period_committee`

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -13,18 +13,18 @@
         - [Misc](#misc)
         - [Initial values](#initial-values)
         - [Time parameters](#time-parameters)
-        - [Signature domains](#signature-domains)
+        - [Signature domain types](#signature-domain-types)
         - [TODO PLACEHOLDER](#todo-placeholder)
     - [Data structures](#data-structures)
         - [`ShardBlockBody`](#shardblockbody)
-        - [`ShardAttestation`](#shardattestation)
         - [`ShardBlock`](#shardblock)
         - [`ShardBlockHeader`](#shardblockheader)
     - [Helper functions](#helper-functions)
         - [`get_period_committee`](#get_period_committee)
         - [`get_switchover_epoch`](#get_switchover_epoch)
-        - [`get_persistent_committee`](#get_persistent_committee)
-        - [`get_shard_proposer_index`](#get_shard_proposer_index)
+        - [`get_shard_epoch_committee`](#get_shard_epoch_committee)
+        - [`get_shard_block_proposer_index`](#get_shard_block_proposer_index)
+        - [`get_shard_block_attester_committee`](#get_shard_block_attester_committee)
         - [`get_shard_header`](#get_shard_header)
         - [`verify_shard_attestation_signature`](#verify_shard_attestation_signature)
         - [`compute_crosslink_data_root`](#compute_crosslink_data_root)
@@ -49,7 +49,7 @@ This document describes the shard data layer and the shard fork choice rule in P
 | `BYTES_PER_SHARD_BLOCK_BODY` | `2**14` (= 16,384) |
 | `MAX_SHARD_ATTESTIONS` | `2**4` (= 16) |
 | `SHARD_SLOTS_PER_BEACON_SLOT` | `2**0` (= 1) |
-| `SHARD_SLOT_COMMITTEE_SIZE` | `2**5 (=32) |
+| `SHARD_SLOT_COMMITTEE_SIZE` | `2**5` (=32) |
 
 ### Initial values
 
@@ -99,7 +99,7 @@ class ShardBlock(Container):
     parent_root: Bytes32
     data: ShardBlockBody
     state_root: Bytes32
-    attester_bitfield: BitVector[SHARD_SLOT_COMMITTEE_SIZE]
+    attester_bitfield: Bitvector[SHARD_SLOT_COMMITTEE_SIZE]
     signature: BLSSignature
 ```
 
@@ -113,7 +113,7 @@ class ShardBlockHeader(Container):
     parent_root: Bytes32
     body_root: Bytes32
     state_root: Bytes32
-    attester_bitfield: BitVector[SHARD_SLOT_COMMITTEE_SIZE]
+    attester_bitfield: Bitvector[SHARD_SLOT_COMMITTEE_SIZE]
     signature: BLSSignature
 ```
 
@@ -158,7 +158,7 @@ def get_shard_epoch_committee(state: BeaconState,
     later_start_epoch = Epoch(epoch - (epoch % PERSISTENT_COMMITTEE_PERIOD) - PERSISTENT_COMMITTEE_PERIOD)
 
     index = slot % committee_count
-    earlier_committee = compute_committee(get_active_validator_indices(earlier_start_epoch)
+    earlier_committee = compute_committee(get_active_validator_indices(earlier_start_epoch))
     earlier_committee = get_period_committee(state, earlier_start_epoch, shard)
     later_committee = get_period_committee(state, later_start_epoch, shard)
 


### PR DESCRIPTION
* Removed the attestation list, replaced with one attestation
* Reformed how committees are computed, to a structure where a 64-sized committee (due to be 128 if we increase shard slots to 2 per one beacon slot) is created per epoch, and then a proposer from that committee is chosen per slot, and the attesters of a slot are the last N (here N=32) proposers
* Added shard slot <-> beacon slot decoupling and more precise rules for which beacon slot to use when processing a shard slot

I welcome other concrete proposals; there are some difficult tradeoffs here to make. As I can see, the goals are:

* Efficiency: reduce the number of validators in a persistent committee that have to verify any given block
* Light client friendliness: give light clients the ability to verify any block with at least some security guarantee
* Unpredictability of who proposes blocks
* Probability of being selected proportional to balance
* You get kicked out if slashed

Does NOT include:

* The beacon chain committing to the persistent committees