### PR TITLE
avoid overflow in slashing penalty calculation

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1482,12 +1482,9 @@ def process_slashings(state: BeaconState) -> None:
     total_balance = get_total_active_balance(state)
     for index, validator in enumerate(state.validators):
         if validator.slashed and epoch + EPOCHS_PER_SLASHINGS_VECTOR // 2 == validator.withdrawable_epoch:
-            penalty = (
-                (validator.effective_balance // EFFECTIVE_BALANCE_INCREMENT)  # avoid 64-bit overflow
-                * min(sum(state.slashings) * 3, total_balance)
-                // total_balance
-                * EFFECTIVE_BALANCE_INCREMENT
-            )
+            increment = EFFECTIVE_BALANCE_INCREMENT  # Factored out from penalty numerator to avoid uint64 overflow
+            penalty_numerator = validator.effective_balance // increment * min(sum(state.slashings) * 3, total_balance)
+            penalty = penalty_numerator // total_balance * increment
             decrease_balance(state, ValidatorIndex(index), penalty)
 ```
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1487,7 +1487,7 @@ def process_slashings(state: BeaconState) -> None:
                 (validator.effective_balance // GWEI_PER_ETH)
                 * min(sum(state.slashings) * 3 // GWEI_PER_ETH, total_balance_in_eth)
                 // total_balance_in_eth
-            )  #  In eth to avoid 64-bit overflow during computation
+            )  # In eth to avoid 64-bit overflow during computation
             decrease_balance(state, ValidatorIndex(index), penalty_in_eth * GWEI_PER_ETH)
 ```
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -161,7 +161,6 @@ The following values are (non-configurable) constants used throughout the specif
 | Name | Value |
 | - | - |
 | `FAR_FUTURE_EPOCH` | `Epoch(2**64 - 1)` |
-| `GWEI_PER_ETH` | `10**9` (= 1,000,000,000)|
 | `BASE_REWARDS_PER_EPOCH` | `5` |
 | `DEPOSIT_CONTRACT_TREE_DEPTH` | `2**5` (= 32) |
 | `SECONDS_PER_DAY` | `86400` |
@@ -1480,15 +1479,16 @@ def process_registry_updates(state: BeaconState) -> None:
 ```python
 def process_slashings(state: BeaconState) -> None:
     epoch = get_current_epoch(state)
-    total_balance_in_eth = get_total_active_balance(state) // GWEI_PER_ETH
+    total_balance = get_total_active_balance(state)
     for index, validator in enumerate(state.validators):
         if validator.slashed and epoch + EPOCHS_PER_SLASHINGS_VECTOR // 2 == validator.withdrawable_epoch:
-            penalty_in_eth = (
-                (validator.effective_balance // GWEI_PER_ETH)
-                * min(sum(state.slashings) * 3 // GWEI_PER_ETH, total_balance_in_eth)
-                // total_balance_in_eth
-            )  # In eth to avoid 64-bit overflow during computation
-            decrease_balance(state, ValidatorIndex(index), penalty_in_eth * GWEI_PER_ETH)
+            penalty = (
+                (validator.effective_balance // EFFECTIVE_BALANCE_INCREMENT)  # avoid 64-bit overflow
+                * min(sum(state.slashings) * 3, total_balance)
+                // total_balance
+                * EFFECTIVE_BALANCE_INCREMENT
+            )
+            decrease_balance(state, ValidatorIndex(index), penalty)
 ```
 
 #### Final updates

--- a/test_libs/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_slashings.py
+++ b/test_libs/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_slashings.py
@@ -66,8 +66,13 @@ def test_small_penalty(spec, state):
     spec.process_slashings(state)
     yield 'post', state
 
-    assert state.balances[0] == pre_slash_balances[0] - (state.validators[0].effective_balance
-                                                         * 3 * total_penalties // total_balance)
+    expected_penalty = (
+        state.validators[0].effective_balance // spec.GWEI_PER_ETH
+        * (3 * total_penalties // spec.GWEI_PER_ETH)
+        // (total_balance // spec.GWEI_PER_ETH)
+        * spec.GWEI_PER_ETH
+    )
+    assert state.balances[0] == pre_slash_balances[0] - expected_penalty
 
 
 @with_all_phases
@@ -121,5 +126,10 @@ def test_scaled_penalties(spec, state):
 
     for i in slashed_indices:
         v = state.validators[i]
-        penalty = v.effective_balance * total_penalties * 3 // total_balance
+        penalty = (
+            v.effective_balance // spec.GWEI_PER_ETH
+            * (3 * total_penalties // spec.GWEI_PER_ETH)
+            // (total_balance // spec.GWEI_PER_ETH)
+            * spec.GWEI_PER_ETH
+        )
         assert state.balances[i] == pre_slash_balances[i] - penalty

--- a/test_libs/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_slashings.py
+++ b/test_libs/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_slashings.py
@@ -67,10 +67,10 @@ def test_small_penalty(spec, state):
     yield 'post', state
 
     expected_penalty = (
-        state.validators[0].effective_balance // spec.GWEI_PER_ETH
-        * (3 * total_penalties // spec.GWEI_PER_ETH)
-        // (total_balance // spec.GWEI_PER_ETH)
-        * spec.GWEI_PER_ETH
+        state.validators[0].effective_balance // spec.EFFECTIVE_BALANCE_INCREMENT
+        * (3 * total_penalties)
+        // total_balance
+        * spec.EFFECTIVE_BALANCE_INCREMENT
     )
     assert state.balances[0] == pre_slash_balances[0] - expected_penalty
 
@@ -126,10 +126,10 @@ def test_scaled_penalties(spec, state):
 
     for i in slashed_indices:
         v = state.validators[i]
-        penalty = (
-            v.effective_balance // spec.GWEI_PER_ETH
-            * (3 * total_penalties // spec.GWEI_PER_ETH)
-            // (total_balance // spec.GWEI_PER_ETH)
-            * spec.GWEI_PER_ETH
+        expected_penalty = (
+            v.effective_balance // spec.EFFECTIVE_BALANCE_INCREMENT
+            * (3 * total_penalties)
+            // (total_balance)
+            * spec.EFFECTIVE_BALANCE_INCREMENT
         )
-        assert state.balances[i] == pre_slash_balances[i] - penalty
+        assert state.balances[i] == pre_slash_balances[i] - expected_penalty


### PR DESCRIPTION
Addresses #1284 

Perform penalty calculation on the `EFFECTIVE_BALANCE_INCREMENT` fraction of GWEI to avoid 64-bit overflows
