### PR TITLE
Bump `py-ssz` to `0.1.3` and update the fuzzing tests

### DIFF
--- a/test_generators/ssz_generic/requirements.txt
+++ b/test_generators/ssz_generic/requirements.txt
@@ -1,4 +1,4 @@
 eth-utils==1.6.0
 ../../test_libs/gen_helpers
 ../../test_libs/config_helpers
-ssz==0.1.0a2
+ssz==0.1.3

--- a/test_libs/pyspec/eth2spec/fuzzing/decoder.py
+++ b/test_libs/pyspec/eth2spec/fuzzing/decoder.py
@@ -18,13 +18,10 @@ def translate_typ(typ) -> ssz.BaseSedes:
     elif issubclass(typ, spec_ssz.Vector):
         return ssz.Vector(translate_typ(typ.elem_type), typ.length)
     elif issubclass(typ, spec_ssz.List):
-        # TODO: Make py-ssz List support the new fixed length list
         return ssz.List(translate_typ(typ.elem_type), typ.length)
     elif issubclass(typ, spec_ssz.Bitlist):
-        # TODO: Once Bitlist implemented in py-ssz, use appropriate type
         return ssz.Bitlist(typ.length)
     elif issubclass(typ, spec_ssz.Bitvector):
-        # TODO: Once Bitvector implemented in py-ssz, use appropriate type
         return ssz.Bitvector(typ.length)
     elif issubclass(typ, spec_ssz.boolean):
         return ssz.boolean

--- a/test_libs/pyspec/eth2spec/fuzzing/decoder.py
+++ b/test_libs/pyspec/eth2spec/fuzzing/decoder.py
@@ -19,13 +19,13 @@ def translate_typ(typ) -> ssz.BaseSedes:
         return ssz.Vector(translate_typ(typ.elem_type), typ.length)
     elif issubclass(typ, spec_ssz.List):
         # TODO: Make py-ssz List support the new fixed length list
-        return ssz.List(translate_typ(typ.elem_type))
+        return ssz.List(translate_typ(typ.elem_type), typ.length)
     elif issubclass(typ, spec_ssz.Bitlist):
         # TODO: Once Bitlist implemented in py-ssz, use appropriate type
-        return ssz.List(translate_typ(typ.elem_type))
+        return ssz.Bitlist(typ.length)
     elif issubclass(typ, spec_ssz.Bitvector):
         # TODO: Once Bitvector implemented in py-ssz, use appropriate type
-        return ssz.Vector(translate_typ(typ.elem_type), typ.length)
+        return ssz.Bitvector(typ.length)
     elif issubclass(typ, spec_ssz.boolean):
         return ssz.boolean
     elif issubclass(typ, spec_ssz.uint):

--- a/test_libs/pyspec/eth2spec/fuzzing/test_decoder.py
+++ b/test_libs/pyspec/eth2spec/fuzzing/test_decoder.py
@@ -9,9 +9,7 @@ def test_decoder():
     rng = Random(123)
 
     # check these types only, Block covers a lot of operation types already.
-    # TODO: Once has Bitlists and Bitvectors, add back
-    #       spec.BeaconState and spec.BeaconBlock
-    for typ in [spec.IndexedAttestation, spec.AttestationDataAndCustodyBit]:
+    for typ in [spec.BeaconState, spec.BeaconBlock]:
         # create a random pyspec value
         original = random_value.get_random_ssz_object(rng, typ, 100, 10,
                                                       mode=random_value.RandomizationMode.mode_random,

--- a/test_libs/pyspec/eth2spec/fuzzing/test_decoder.py
+++ b/test_libs/pyspec/eth2spec/fuzzing/test_decoder.py
@@ -9,7 +9,7 @@ def test_decoder():
     rng = Random(123)
 
     # check these types only, Block covers a lot of operation types already.
-    for typ in [spec.BeaconState, spec.BeaconBlock]:
+    for typ in [spec.AttestationDataAndCustodyBit, spec.BeaconState, spec.BeaconBlock]:
         # create a random pyspec value
         original = random_value.get_random_ssz_object(rng, typ, 100, 10,
                                                       mode=random_value.RandomizationMode.mode_random,

--- a/test_libs/pyspec/eth2spec/fuzzing/test_decoder.py
+++ b/test_libs/pyspec/eth2spec/fuzzing/test_decoder.py
@@ -31,3 +31,4 @@ def test_decoder():
 
         # and see if the hash-tree-root of the original matches the hash-tree-root of the decoded & translated value.
         assert spec_ssz_impl.hash_tree_root(original) == spec_ssz_impl.hash_tree_root(block)
+        assert spec_ssz_impl.hash_tree_root(original) == block_sedes.get_hash_tree_root(raw_value)

--- a/test_libs/pyspec/eth2spec/fuzzing/test_decoder.py
+++ b/test_libs/pyspec/eth2spec/fuzzing/test_decoder.py
@@ -30,5 +30,6 @@ def test_decoder():
         block = translate_value(raw_value, typ)
 
         # and see if the hash-tree-root of the original matches the hash-tree-root of the decoded & translated value.
-        assert spec_ssz_impl.hash_tree_root(original) == spec_ssz_impl.hash_tree_root(block)
-        assert spec_ssz_impl.hash_tree_root(original) == block_sedes.get_hash_tree_root(raw_value)
+        original_hash_tree_root = spec_ssz_impl.hash_tree_root(original)
+        assert original_hash_tree_root == spec_ssz_impl.hash_tree_root(block)
+        assert original_hash_tree_root == block_sedes.get_hash_tree_root(raw_value)

--- a/test_libs/pyspec/requirements.txt
+++ b/test_libs/pyspec/requirements.txt
@@ -3,4 +3,4 @@ eth-typing>=2.1.0,<3.0.0
 pycryptodome==3.7.3
 py_ecc==1.7.1
 dataclasses==0.6
-ssz==0.1.0a10
+ssz==0.1.0a11

--- a/test_libs/pyspec/requirements.txt
+++ b/test_libs/pyspec/requirements.txt
@@ -3,4 +3,4 @@ eth-typing>=2.1.0,<3.0.0
 pycryptodome==3.7.3
 py_ecc==1.7.1
 dataclasses==0.6
-ssz==0.1.0a11
+ssz==0.1.3

--- a/test_libs/pyspec/setup.py
+++ b/test_libs/pyspec/setup.py
@@ -9,7 +9,7 @@ setup(
         "eth-typing>=2.1.0,<3.0.0",
         "pycryptodome==3.7.3",
         "py_ecc==1.7.1",
-        "ssz==0.1.0a11",
+        "ssz==0.1.3",
         "dataclasses==0.6",
     ]
 )

--- a/test_libs/pyspec/setup.py
+++ b/test_libs/pyspec/setup.py
@@ -9,7 +9,7 @@ setup(
         "eth-typing>=2.1.0,<3.0.0",
         "pycryptodome==3.7.3",
         "py_ecc==1.7.1",
-        "ssz==0.1.0a10",
+        "ssz==0.1.0a11",
         "dataclasses==0.6",
     ]
 )


### PR DESCRIPTION
* Bump `py-ssz` to `0.1.3`
* Enable the `spec.BeaconState` & `spec.BeaconBlock` in fuzzing test case.
* Enable py-ssz hash_tree_root assertions