### PR TITLE
Lookahead fix

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -865,7 +865,7 @@ def get_seed(state: BeaconState, epoch: Epoch) -> Hash:
     """
     Return the seed at ``epoch``.
     """
-    mix = get_randao_mix(state, Epoch(epoch + EPOCHS_PER_HISTORICAL_VECTOR - MIN_SEED_LOOKAHEAD))  # Avoid underflow
+    mix = get_randao_mix(state, Epoch(epoch + EPOCHS_PER_HISTORICAL_VECTOR - MIN_SEED_LOOKAHEAD - 1))  # Avoid underflow
     active_index_root = state.active_index_roots[epoch % EPOCHS_PER_HISTORICAL_VECTOR]
     return hash(mix + active_index_root + int_to_bytes(epoch, length=32))
 ```


### PR DESCRIPTION
address #1269

`current_epoch - 1` for randomness source doesn’t give us lookahead. It is just in time and it’s the bare minimum stable source of randao for any epoch. `MIN_SEED_LOOKAHEAD` of `0` should equate to the `current_epoch - 1` case. `MIN_SEED_LOOKAHEAD > 0` should have a base of the `-1`