### PR TITLE
[hotfix] bump `py_ecc==1.7.1`

### DIFF
--- a/test_generators/bls/main.py
+++ b/test_generators/bls/main.py
@@ -5,7 +5,9 @@ BLS test vectors generator
 from typing import Tuple
 
 from eth_utils import (
-    to_tuple, int_to_big_endian
+    encode_hex,
+    int_to_big_endian,
+    to_tuple,
 )
 from gen_base import gen_runner, gen_suite, gen_typing
 
@@ -20,7 +22,7 @@ def int_to_hex(n: int, byte_length: int=None) -> str:
     byte_value = int_to_big_endian(n)
     if byte_length:
         byte_value = byte_value.rjust(byte_length, b'\x00')
-    return '0x' + byte_value.hex()
+    return encode_hex(byte_value)
 
 
 def hex_to_int(x: str) -> int:
@@ -28,11 +30,9 @@ def hex_to_int(x: str) -> int:
 
 
 DOMAINS = [
-    0,
-    1,
-    1234,
-    2**32-1,
-    2**64-1
+    b'\x00\x00\x00\x00\x00\x00\x00\x00',
+    b'\x00\x00\x00\x00\x00\x00\x00\x01',
+    b'\xff\xff\xff\xff\xff\xff\xff\xff'
 ]
 
 MESSAGES = [
@@ -51,12 +51,12 @@ PRIVKEYS = [
 
 
 def hash_message(msg: bytes,
-                 domain: int) ->Tuple[Tuple[str, str], Tuple[str, str], Tuple[str, str]]:
+                 domain: bytes) ->Tuple[Tuple[str, str], Tuple[str, str], Tuple[str, str]]:
     """
     Hash message
     Input:
-        - Message as bytes
-        - domain as uint64
+        - Message as bytes32
+        - domain as bytes8
     Output:
         - Message hash as a G2 point
     """
@@ -69,12 +69,12 @@ def hash_message(msg: bytes,
     ]
 
 
-def hash_message_compressed(msg: bytes, domain: int) -> Tuple[str, str]:
+def hash_message_compressed(msg: bytes, domain: bytes) -> Tuple[str, str]:
     """
     Hash message
     Input:
-        - Message as bytes
-        - domain as uint64
+        - Message as bytes32
+        - domain as bytes8
     Output:
         - Message hash as a compressed G2 point
     """
@@ -88,8 +88,8 @@ def case01_message_hash_G2_uncompressed():
         for domain in DOMAINS:
             yield {
                 'input': {
-                    'message': '0x' + msg.hex(),
-                    'domain': int_to_hex(domain, byte_length=8)
+                    'message': encode_hex(msg),
+                    'domain': encode_hex(domain),
                 },
                 'output': hash_message(msg, domain)
             }
@@ -100,8 +100,8 @@ def case02_message_hash_G2_compressed():
         for domain in DOMAINS:
             yield {
                 'input': {
-                    'message': '0x' + msg.hex(),
-                    'domain': int_to_hex(domain, byte_length=8)
+                    'message': encode_hex(msg),
+                    'domain': encode_hex(domain),
                 },
                 'output': hash_message_compressed(msg, domain)
             }
@@ -125,10 +125,10 @@ def case04_sign_messages():
                 yield {
                     'input': {
                         'privkey': int_to_hex(privkey),
-                        'message': '0x' + message.hex(),
-                        'domain': int_to_hex(domain, byte_length=8)
+                        'message': encode_hex(message),
+                        'domain': encode_hex(domain),
                     },
-                    'output': '0x' + sig.hex()
+                    'output': encode_hex(sig)
                 }
 
 # TODO: case05_verify_messages: Verify messages signed in case04
@@ -141,17 +141,17 @@ def case06_aggregate_sigs():
         for message in MESSAGES:
             sigs = [bls.sign(message, privkey, domain) for privkey in PRIVKEYS]
             yield {
-                'input': ['0x' + sig.hex() for sig in sigs],
-                'output': '0x' + bls.aggregate_signatures(sigs).hex(),
+                'input': [encode_hex(sig) for sig in sigs],
+                'output': encode_hex(bls.aggregate_signatures(sigs)),
             }
 
 @to_tuple
 def case07_aggregate_pubkeys():
     pubkeys = [bls.privtopub(privkey) for privkey in PRIVKEYS]
-    pubkeys_serial = ['0x' + pubkey.hex() for pubkey in pubkeys]
+    pubkeys_serial = [encode_hex(pubkey) for pubkey in pubkeys]
     yield {
         'input': pubkeys_serial,
-        'output': '0x' + bls.aggregate_pubkeys(pubkeys).hex(),
+        'output': encode_hex(bls.aggregate_pubkeys(pubkeys)),
     }
 
 

--- a/test_generators/bls/requirements.txt
+++ b/test_generators/bls/requirements.txt
@@ -1,3 +1,3 @@
-py-ecc==1.7.0
+py_ecc==1.7.1
 eth-utils==1.6.0
 ../../test_libs/gen_helpers

--- a/test_libs/pyspec/eth2spec/utils/bls.py
+++ b/test_libs/pyspec/eth2spec/utils/bls.py
@@ -24,13 +24,13 @@ def only_with_bls(alt_return=None):
 @only_with_bls(alt_return=True)
 def bls_verify(pubkey, message_hash, signature, domain):
     return bls.verify(message_hash=message_hash, pubkey=pubkey,
-                      signature=signature, domain=int.from_bytes(domain, byteorder='little'))
+                      signature=signature, domain=domain)
 
 
 @only_with_bls(alt_return=True)
 def bls_verify_multiple(pubkeys, message_hashes, signature, domain):
     return bls.verify_multiple(pubkeys=pubkeys, message_hashes=message_hashes,
-                               signature=signature, domain=int.from_bytes(domain, byteorder='little'))
+                               signature=signature, domain=domain)
 
 
 @only_with_bls(alt_return=STUB_PUBKEY)
@@ -46,4 +46,4 @@ def bls_aggregate_signatures(signatures):
 @only_with_bls(alt_return=STUB_SIGNATURE)
 def bls_sign(message_hash, privkey, domain):
     return bls.sign(message_hash=message_hash, privkey=privkey,
-                    domain=int.from_bytes(domain, byteorder='little'))
+                    domain=domain)

--- a/test_libs/pyspec/requirements.txt
+++ b/test_libs/pyspec/requirements.txt
@@ -1,6 +1,6 @@
 eth-utils>=1.3.0,<2
 eth-typing>=2.1.0,<3.0.0
 pycryptodome==3.7.3
-py_ecc>=1.6.0
+py_ecc==1.7.1
 dataclasses==0.6
 ssz==0.1.0a10

--- a/test_libs/pyspec/setup.py
+++ b/test_libs/pyspec/setup.py
@@ -8,7 +8,7 @@ setup(
         "eth-utils>=1.3.0,<2",
         "eth-typing>=2.1.0,<3.0.0",
         "pycryptodome==3.7.3",
-        "py_ecc>=1.6.0",
+        "py_ecc==1.7.1",
         "ssz==0.1.0a10",
         "dataclasses==0.6",
     ]


### PR DESCRIPTION
### Issue
The new release of `py_ecc` includes #1246 changes and its not backward compatible, that's why pyspec is broken with the current dependency `py_ecc>=1.6.0`.

### Proposing solution
1. Pin `py_ecc==1.7.1`
2. Update both pyspec and BLS test generator's `domain` type.
3. Minor refactoring of BLS test generator

@djrtwo it needs to backport to `dev` branch soon. 
