### PR TITLE
[hothotfix] Pin `py_ecc==1.7.0`

### DIFF
--- a/test_libs/pyspec/requirements.txt
+++ b/test_libs/pyspec/requirements.txt
@@ -1,6 +1,6 @@
 eth-utils>=1.3.0,<2
 eth-typing>=2.1.0,<3.0.0
 pycryptodome==3.7.3
-py_ecc>=1.6.0
+py_ecc==1.7.0
 dataclasses==0.6
 ssz==0.1.0a10

--- a/test_libs/pyspec/setup.py
+++ b/test_libs/pyspec/setup.py
@@ -8,7 +8,7 @@ setup(
         "eth-utils>=1.3.0,<2",
         "eth-typing>=2.1.0,<3.0.0",
         "pycryptodome==3.7.3",
-        "py_ecc>=1.6.0",
+        "py_ecc==1.7.0",
         "ssz==0.1.0a10",
         "dataclasses==0.6",
     ]


### PR DESCRIPTION
While #1300 is in reviewing, this PR simply pins to the earlier version of py_ecc.

p.s. CI looks fine due to cache... 😬