### PR TITLE
Found by Cem Özer: Ignore older latest messages in attesting balance

### DIFF
--- a/specs/core/0_fork-choice.md
+++ b/specs/core/0_fork-choice.md
@@ -101,8 +101,12 @@ def get_genesis_store(genesis_state: BeaconState) -> Store:
 ```python
 def get_ancestor(store: Store, root: Hash, slot: Slot) -> Hash:
     block = store.blocks[root]
-    assert block.slot >= slot
-    return root if block.slot == slot else get_ancestor(store, block.parent_root, slot)
+    if block.slot > slot:
+        return get_ancestor(store, block.parent_root, slot)
+    elif block.slot == slot:
+        return root
+    else:
+        return Bytes32()  # root is older than queried slot: no results. 
 ```
 
 #### `get_latest_attesting_balance`


### PR DESCRIPTION
Found by Cem Özer (@cemozerr): Ignore older latest messages in attesting balance sum, instead of assertion error.

> I think there might be an error in get_latest_attesting_balance. Lets say that the children root (in the last line of get_head) that gets passed into get_latest_attesting_balance is the root of the actual head block. in the last line of get_latest_attesting_balance, lets say that the root we get by indexing latest_messages by the validator index i corresponds to the parent block of this head block. since head block will have slot number n , and its parent will have slot number n - 1, the assert statement at get_ancestor will throw.

Previously we asserted that the retrieved block was newer than the slot. But it may actually be older, if a latest message is older than the justified block (or later).

It is not breaking anything if there are no latest messages older than the justified epoch (not always the case). And I do not think that any clients are directly affected, as they are expected to not copy the inefficient spec implementation. It should be considered as a bug however.

Another option would be to check the lastest message slot, but we only track the epoch. Hence the decision to just return an empty hash in the query instead, which will always be different to the root being compared.

