### PR TITLE
Validate state root for fork choice on_block

### DIFF
--- a/specs/core/0_fork-choice.md
+++ b/specs/core/0_fork-choice.md
@@ -154,7 +154,7 @@ def on_block(store: Store, block: BeaconBlock) -> None:
     # Check that block is later than the finalized epoch slot
     assert block.slot > compute_start_slot_of_epoch(store.finalized_checkpoint.epoch)
     # Check the block is valid and compute the post-state
-    state = state_transition(pre_state, block)
+    state = state_transition(pre_state, block, true)
     # Add new state for this block to the store
     store.block_states[signing_root(block)] = state
 

--- a/specs/core/0_fork-choice.md
+++ b/specs/core/0_fork-choice.md
@@ -154,7 +154,7 @@ def on_block(store: Store, block: BeaconBlock) -> None:
     # Check that block is later than the finalized epoch slot
     assert block.slot > compute_start_slot_of_epoch(store.finalized_checkpoint.epoch)
     # Check the block is valid and compute the post-state
-    state = state_transition(pre_state, block, true)
+    state = state_transition(pre_state, block, True)
     # Add new state for this block to the store
     store.block_states[signing_root(block)] = state
 


### PR DESCRIPTION
I think we do want to validate state root for `state_transition` in `on_block`. The default argument for `validate_state_root` is false 