### PR TITLE
Check attestation bit lengths

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1655,8 +1655,7 @@ def process_attestation(state: BeaconState, attestation: Attestation) -> None:
     assert attestation_slot + MIN_ATTESTATION_INCLUSION_DELAY <= state.slot <= attestation_slot + SLOTS_PER_EPOCH
 
     committee = get_crosslink_committee(state, data.target.epoch, data.crosslink.shard)
-    assert len(attestation.aggregation_bits) == len(committee)
-    assert len(attestation.custody_bits) == len(committee)
+    assert len(attestation.aggregation_bits) == len(attestation.custody_bits) == len(committee)
 
     pending_attestation = PendingAttestation(
         data=data,

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1654,6 +1654,7 @@ def process_attestation(state: BeaconState, attestation: Attestation) -> None:
     attestation_slot = get_attestation_data_slot(state, data)
     assert attestation_slot + MIN_ATTESTATION_INCLUSION_DELAY <= state.slot <= attestation_slot + SLOTS_PER_EPOCH
 
+    committee = get_crosslink_committee(state, data.target.epoch, data.crosslink.shard)
     assert len(attestation.aggregation_bits) == len(committee)
     assert len(attestation.custody_bits) == len(committee)
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1654,6 +1654,9 @@ def process_attestation(state: BeaconState, attestation: Attestation) -> None:
     attestation_slot = get_attestation_data_slot(state, data)
     assert attestation_slot + MIN_ATTESTATION_INCLUSION_DELAY <= state.slot <= attestation_slot + SLOTS_PER_EPOCH
 
+    assert len(attestation.aggregation_bits) == len(committee)
+    assert len(attestation.custody_bits) == len(committee)
+
     pending_attestation = PendingAttestation(
         data=data,
         aggregation_bits=attestation.aggregation_bits,

--- a/test_libs/pyspec/eth2spec/test/phase_0/block_processing/test_process_attestation.py
+++ b/test_libs/pyspec/eth2spec/test/phase_0/block_processing/test_process_attestation.py
@@ -398,3 +398,61 @@ def test_empty_aggregation_bits(spec, state):
     sign_attestation(spec, state, attestation)
 
     yield from run_attestation_processing(spec, state, attestation)
+
+
+@with_all_phases
+@spec_state_test
+def test_too_many_aggregation_bits(spec, state):
+    attestation = get_valid_attestation(spec, state, signed=True)
+    state.slot += spec.MIN_ATTESTATION_INCLUSION_DELAY
+
+    # one too many bits
+    attestation.aggregation_bits.append(0b0)
+
+    yield from run_attestation_processing(spec, state, attestation, False)
+
+
+@with_all_phases
+@spec_state_test
+def test_too_few_aggregation_bits(spec, state):
+    attestation = get_valid_attestation(spec, state)
+    state.slot += spec.MIN_ATTESTATION_INCLUSION_DELAY
+
+    attestation.aggregation_bits = Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](
+        *([0b1] + [0b0] * (len(attestation.aggregation_bits) - 1)))
+
+    sign_attestation(spec, state, attestation)
+
+    # one too few bits
+    attestation.aggregation_bits = attestation.aggregation_bits[:-1]
+
+    yield from run_attestation_processing(spec, state, attestation, False)
+
+
+@with_all_phases
+@spec_state_test
+def test_too_many_custody_bits(spec, state):
+    attestation = get_valid_attestation(spec, state, signed=True)
+    state.slot += spec.MIN_ATTESTATION_INCLUSION_DELAY
+
+    # one too many bits
+    attestation.custody_bits.append(0b0)
+
+    yield from run_attestation_processing(spec, state, attestation, False)
+
+
+@with_all_phases
+@spec_state_test
+def test_too_few_custody_bits(spec, state):
+    attestation = get_valid_attestation(spec, state)
+    state.slot += spec.MIN_ATTESTATION_INCLUSION_DELAY
+
+    attestation.custody_bits = Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](
+        *([0b1] + [0b0] * (len(attestation.custody_bits) - 1)))
+
+    sign_attestation(spec, state, attestation)
+
+    # one too few bits
+    attestation.custody_bits = attestation.custody_bits[:-1]
+
+    yield from run_attestation_processing(spec, state, attestation, False)


### PR DESCRIPTION
resolves #1262 
replaces #1264 

Note that the bitlists with too _few_ bits had to be particular in it's signed and then modified to keep the signing helper from complaining