### PR TITLE
Fix start shard for compact committees root

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1504,8 +1504,6 @@ def process_final_updates(state: BeaconState) -> None:
         HALF_INCREMENT = EFFECTIVE_BALANCE_INCREMENT // 2
         if balance < validator.effective_balance or validator.effective_balance + 3 * HALF_INCREMENT < balance:
             validator.effective_balance = min(balance - balance % EFFECTIVE_BALANCE_INCREMENT, MAX_EFFECTIVE_BALANCE)
-    # Update start shard
-    state.start_shard = Shard((state.start_shard + get_shard_delta(state, current_epoch)) % SHARD_COUNT)
     # Set active index root
     index_epoch = Epoch(next_epoch + ACTIVATION_EXIT_DELAY)
     index_root_position = index_epoch % EPOCHS_PER_HISTORICAL_VECTOR
@@ -1522,6 +1520,8 @@ def process_final_updates(state: BeaconState) -> None:
     if next_epoch % (SLOTS_PER_HISTORICAL_ROOT // SLOTS_PER_EPOCH) == 0:
         historical_batch = HistoricalBatch(block_roots=state.block_roots, state_roots=state.state_roots)
         state.historical_roots.append(hash_tree_root(historical_batch))
+    # Update start shard
+    state.start_shard = Shard((state.start_shard + get_shard_delta(state, current_epoch)) % SHARD_COUNT)
     # Rotate current/previous epoch attestations
     state.previous_epoch_attestations = state.current_epoch_attestations
     state.current_epoch_attestations = []

--- a/test_libs/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_final_updates.py
+++ b/test_libs/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_final_updates.py
@@ -89,3 +89,20 @@ def test_historical_root_accumulator(spec, state):
     yield from run_process_final_updates(spec, state)
 
     assert len(state.historical_roots) == history_len + 1
+
+
+@with_all_phases
+@spec_state_test
+def test_compact_committees_root(spec, state):
+    assert spec.SLOTS_PER_ETH1_VOTING_PERIOD > spec.SLOTS_PER_EPOCH
+    # skip ahead to the end of the epoch
+    state.slot = spec.SLOTS_PER_EPOCH - 1
+
+    next_epoch = spec.get_current_epoch(state) + 1
+
+    # ensure that order in which items are processed in final_updates
+    # does not alter the expected_root
+    expected_root = spec.get_compact_committees_root(state, next_epoch)
+    yield from run_process_final_updates(spec, state)
+
+    assert state.compact_committees_roots[next_epoch % spec.EPOCHS_PER_HISTORICAL_VECTOR] == expected_root


### PR DESCRIPTION
address #1315 

The test is a little silly but does ensure that nothing in `process_final_updates` alters the expected root that ends up in state. This catches any sort of ordering or unintentional side effects 