### PR TITLE
Fix typo in operations spec test

### DIFF
--- a/specs/test_formats/operations/README.md
+++ b/specs/test_formats/operations/README.md
@@ -24,7 +24,7 @@ Operations:
 |-------------------------|----------------------|----------------------|--------------------------------------------------------|
 | `attestation`           | `Attestation`        | `attestation`        | `process_attestation(state, attestation)`              |
 | `attester_slashing`     | `AttesterSlashing`   | `attester_slashing`  | `process_attester_slashing(state, attester_slashing)`  |
-| `block_header`          | `Block`              | `block`              | `process_block_header(state, block)`                   |
+| `block`                 | `Block`              | `block`              | `process_block_header(state, block)`                   |
 | `deposit`               | `Deposit`            | `deposit`            | `process_deposit(state, deposit)`                      |
 | `proposer_slashing`     | `ProposerSlashing`   | `proposer_slashing`  | `process_proposer_slashing(state, proposer_slashing)`  |
 | `transfer`              | `Transfer`           | `transfer`           | `process_transfer(state, transfer)`                    |


### PR DESCRIPTION
The key in the provided test data is `block` not `block_header`. 