### PR TITLE
Add attestation test with extra aggregation bits

### DIFF
--- a/test_libs/pyspec/eth2spec/test/phase_0/block_processing/test_process_attestation.py
+++ b/test_libs/pyspec/eth2spec/test/phase_0/block_processing/test_process_attestation.py
@@ -373,6 +373,20 @@ def test_inconsistent_bits(spec, state):
     yield from run_attestation_processing(spec, state, attestation, False)
 
 
+@with_all_phases
+@spec_state_test
+def test_extra_aggregation_bits(spec, state):
+    attestation = get_valid_attestation(spec, state)
+    state.slot += spec.MIN_ATTESTATION_INCLUSION_DELAY
+
+    for i in range(len(attestation.aggregation_bits), spec.MAX_VALIDATORS_PER_COMMITTEE):
+        attestation.aggregation_bits.append(True)
+
+    sign_attestation(spec, state, attestation)
+
+    yield from run_attestation_processing(spec, state, attestation)
+
+
 @with_phases(['phase0'])
 @spec_state_test
 def test_non_empty_custody_bits(spec, state):


### PR DESCRIPTION
The spec allows the aggregation bits of an attestation to contain true bits beyond the size of the committee, as this test confirms.

We previously had code in Lighthouse to forbid this case, so I wrote this test to confirm the spec's behaviour and figured it was an edge case worth testing.