### PR TITLE
Test generationm: make nil-count randomization work for lists

### DIFF
--- a/test_libs/pyspec/eth2spec/debug/random_value.py
+++ b/test_libs/pyspec/eth2spec/debug/random_value.py
@@ -94,6 +94,8 @@ def get_random_ssz_object(rng: Random,
             length = 1
         elif mode == RandomizationMode.mode_max_count:
             length = max_list_length
+        elif mode == RandomizationMode.mode_nil_count:
+            length = 0
 
         if typ.length < length:  # SSZ imposes a hard limit on lists, we can't put in more than that
             length = typ.length


### PR DESCRIPTION
The "nil" randomization mode only targeted byte lists, this PR changes that to also make lists 0 in count. The previous tests generated are valid, but not nil. Problem found by @schroedingerscode.

Also see https://github.com/ethereum/eth2.0-spec-tests/pull/11 which updates the tests to reflect this change, along with putting back the BLS tests (they somehow where not included in v0.8.2)



