### PR TITLE
Avoid negative `state.basefee`

### DIFF
--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -519,16 +519,15 @@ def shard_block_transition(state: ShardState,
     # Process and update block data fees
     add_fee(state, beacon_state, proposer_index, state.basefee * len(block.core.data) // SHARD_BLOCK_SIZE_LIMIT)
     QUOTIENT = SHARD_BLOCK_SIZE_LIMIT * BASEFEE_ADJUSTMENT_FACTOR
-    if len(block.core.data) > SHARD_BLOCK_SIZE_TARGET:
-        state.basefee += Gwei(max(1, state.basefee * (len(block.core.data) - SHARD_BLOCK_SIZE_TARGET) // QUOTIENT))
-    elif len(block.core.data) < SHARD_BLOCK_SIZE_TARGET:
-        state.basefee -= Gwei(max(1, state.basefee * (len(block.core.data) - SHARD_BLOCK_SIZE_TARGET) // QUOTIENT))
+    diff_amount = Gwei(max(1, state.basefee * (len(block.core.data) - SHARD_BLOCK_SIZE_TARGET) // QUOTIENT))
     state.basefee = Gwei(max(
         1,
         min(
             EFFECTIVE_BALANCE_INCREMENT // EPOCHS_PER_SHARD_PERIOD // SHARD_SLOTS_PER_BEACON_SLOT * SLOTS_PER_EPOCH,
-            state.basefee,
-        )
+            state.basefee + diff_amount if len(block.core.data) > SHARD_BLOCK_SIZE_TARGET else (
+                state.basefee - diff_amount if len(block.core.data) < SHARD_BLOCK_SIZE_TARGET else state.basefee
+            ),
+        ),
     ))
 
     # Check total bytes


### PR DESCRIPTION
### Issue

Follow up of https://github.com/ethereum/eth2.0-specs/pull/1326#discussion_r309576400, it's possible that `state.basefee` (`uint64`) becomes a negative integer during the computation.

### Proposed solution

I proposed a cleaner solution with temporary variable [here](https://github.com/ethereum/eth2.0-specs/pull/1326#discussion_r309576400), and @vbuterin pointed out that people will complain about even temporary variables that could be negative... 😂 So here is, a solution with the ternary conditional operators. It's less readable, but, maybe fine enough? Open to other better solutions. 😊
