### PR TITLE
Remove bug bitlist length checks in process_attestation

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1615,11 +1615,6 @@ def process_attestation(state: BeaconState, attestation: Attestation) -> None:
         proposer_index=get_beacon_proposer_index(state),
     )
 
-    # Check bitlist lengths
-    committee_size = get_committee_count(state, attestation.data.target.epoch)
-    assert len(attestation.aggregation_bits) == committee_size
-    assert len(attestation.custody_bits) == committee_size
-
     if data.target.epoch == get_current_epoch(state):
         assert data.source == state.current_justified_checkpoint
         parent_crosslink = state.current_crosslinks[data.crosslink.shard]

--- a/test_libs/pyspec/eth2spec/test/context.py
+++ b/test_libs/pyspec/eth2spec/test/context.py
@@ -10,7 +10,7 @@ from .utils import vector_test, with_meta_tags
 def with_state(fn):
     def entry(*args, **kw):
         try:
-            kw['state'] = create_genesis_state(spec=kw['spec'], num_validators=spec_phase0.SLOTS_PER_EPOCH * 8)
+            kw['state'] = create_genesis_state(spec=kw['spec'], num_validators=spec_phase0.SLOTS_PER_EPOCH * 9)
         except KeyError:
             raise TypeError('Spec decorator must come within state decorator to inject spec into state.')
         return fn(*args, **kw)

--- a/test_libs/pyspec/eth2spec/test/context.py
+++ b/test_libs/pyspec/eth2spec/test/context.py
@@ -10,7 +10,7 @@ from .utils import vector_test, with_meta_tags
 def with_state(fn):
     def entry(*args, **kw):
         try:
-            kw['state'] = create_genesis_state(spec=kw['spec'], num_validators=spec_phase0.SLOTS_PER_EPOCH * 9)
+            kw['state'] = create_genesis_state(spec=kw['spec'], num_validators=spec_phase0.SLOTS_PER_EPOCH * 10)
         except KeyError:
             raise TypeError('Spec decorator must come within state decorator to inject spec into state.')
         return fn(*args, **kw)

--- a/test_libs/pyspec/eth2spec/test/phase_1/block_processing/test_process_bit_challenge.py
+++ b/test_libs/pyspec/eth2spec/test/phase_1/block_processing/test_process_bit_challenge.py
@@ -212,13 +212,16 @@ def test_max_reveal_lateness_1(spec, state):
     challenge = get_valid_bit_challenge(spec, state, attestation)
 
     responder_index = challenge.responder_index
+    target_epoch = attestation.data.target.epoch
 
     state.validators[responder_index].max_reveal_lateness = 3
 
-    for i in range(spec.get_randao_epoch_for_custody_period(
-        spec.get_custody_period_for_validator(state, responder_index),
+    latest_reveal_epoch = spec.get_randao_epoch_for_custody_period(
+        spec.get_custody_period_for_validator(state, responder_index, target_epoch),
         responder_index
-    ) + 2 * spec.EPOCHS_PER_CUSTODY_PERIOD + state.validators[responder_index].max_reveal_lateness - 2):
+    ) + 2 * spec.EPOCHS_PER_CUSTODY_PERIOD + state.validators[responder_index].max_reveal_lateness
+
+    while spec.get_current_epoch(state) < latest_reveal_epoch - 2:
         next_epoch(spec, state)
         apply_empty_block(spec, state)
 


### PR DESCRIPTION
Some bug bitlist length checks were accidentally added to `process_attestation` in #1305. They were not just duplicate, but used the wrong length function (`get_committee_count` instead of the actual length of the committee).

Although this was a bug introduced into `dev` it was not caught by our tests because in `minimal` config `get_committee_count() == len(committee)` in most cases. Changed the total number of validators to be `SLOTS_PER_EPOCH * 10` to avoid this coincidence.

When adjusting the number of validators a small bug in custody testing was revealed. It happened to work before due to the random validator index that was selected from the committee, but this validator index changed when adjusting the number of total validators. Made the fix to use the proper `epoch` when calculating latest epoch to respond.

Thank you @0xKiwi for pointing out the strange duplicate code in `process_attestation`!