### PR TITLE
Remove `unpack_compact_validator` from sync spec

### DIFF
--- a/specs/light_client/sync_protocol.md
+++ b/specs/light_client/sync_protocol.md
@@ -13,9 +13,8 @@
     - [Constants](#constants)
     - [Containers](#containers)
         - [`LightClientUpdate`](#lightclientupdate)
-    - [Helpers](#helpers)
         - [`LightClientMemory`](#lightclientmemory)
-        - [`unpack_compact_validator`](#unpack_compact_validator)
+    - [Helpers](#helpers)
         - [`get_persistent_committee_pubkeys_and_balances`](#get_persistent_committee_pubkeys_and_balances)
     - [Light client state updates](#light-client-state-updates)
     - [Data overhead](#data-overhead)
@@ -62,12 +61,9 @@ class LightClientUpdate(container):
     committee_branch: Vector[Hash, PERSISTENT_COMMITTEE_ROOT_IN_BEACON_STATE_DEPTH + log_2(SHARD_COUNT)]
 ```
 
-## Helpers
-
 ### `LightClientMemory`
 
 ```python
-@dataclass
 class LightClientMemory(object):
     shard: Shard  # Randomly initialized and retained forever
     header: BeaconBlockHeader  # Beacon header which is not expected to revert
@@ -77,19 +73,7 @@ class LightClientMemory(object):
     next_committee: CompactCommittee
 ```
 
-### `unpack_compact_validator`
-
-```python
-def unpack_compact_validator(compact_validator: CompactValidator) -> Tuple[ValidatorIndex, bool, uint64]:
-    """
-    Return the index, slashed, effective_balance // EFFECTIVE_BALANCE_INCREMENT of ``compact_validator``.
-    """
-    return (
-        ValidatorIndex(compact_validator >> 16),
-        bool((compact_validator >> 15) % 2),
-        uint64(compact_validator & (2**15 - 1)),
-    )
-```
+## Helpers
 
 ### `get_persistent_committee_pubkeys_and_balances`
 

--- a/specs/light_client/sync_protocol.md
+++ b/specs/light_client/sync_protocol.md
@@ -13,8 +13,8 @@
     - [Constants](#constants)
     - [Containers](#containers)
         - [`LightClientUpdate`](#lightclientupdate)
-        - [`LightClientMemory`](#lightclientmemory)
     - [Helpers](#helpers)
+        - [`LightClientMemory`](#lightclientmemory)
         - [`get_persistent_committee_pubkeys_and_balances`](#get_persistent_committee_pubkeys_and_balances)
     - [Light client state updates](#light-client-state-updates)
     - [Data overhead](#data-overhead)
@@ -66,8 +66,8 @@ class LightClientUpdate(container):
 ### `LightClientMemory`
 
 ```python
+@dataclass
 class LightClientMemory(object):
-    @dataclass
     shard: Shard  # Randomly initialized and retained forever
     header: BeaconBlockHeader  # Beacon header which is not expected to revert
     # Persistent committees corresponding to the beacon header

--- a/specs/light_client/sync_protocol.md
+++ b/specs/light_client/sync_protocol.md
@@ -61,10 +61,13 @@ class LightClientUpdate(container):
     committee_branch: Vector[Hash, PERSISTENT_COMMITTEE_ROOT_IN_BEACON_STATE_DEPTH + log_2(SHARD_COUNT)]
 ```
 
+## Helpers
+
 ### `LightClientMemory`
 
 ```python
 class LightClientMemory(object):
+    @dataclass
     shard: Shard  # Randomly initialized and retained forever
     header: BeaconBlockHeader  # Beacon header which is not expected to revert
     # Persistent committees corresponding to the beacon header
@@ -72,8 +75,6 @@ class LightClientMemory(object):
     current_committee: CompactCommittee
     next_committee: CompactCommittee
 ```
-
-## Helpers
 
 ### `get_persistent_committee_pubkeys_and_balances`
 


### PR DESCRIPTION
Change list:
- Removed `unpack_compact_validator`, it's defined in [1_beacon-chain-misc](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/core/1_beacon-chain-misc.md#unpack_compact_validator)
- ~Moved `LightClientMemory` from `Helpers` section to `Containers` section~