### PR TITLE
Add embedded values to containers

### DIFF
--- a/specs/simple-serialize.md
+++ b/specs/simple-serialize.md
@@ -237,7 +237,7 @@ We now define Merkleization `hash_tree_root(value)` of an object `value` recursi
 
 ## Self-signed containers
 
-Let `value` be a self-signed container object. The convention is that the signature (e.g. a `"bytes96"` BLS12-381 signature) be the last field of `value`. Further, the signed message for `value` is `signing_root(value) = hash_tree_root(truncate_last(value))` where `truncate_last` truncates the last element of `value`.
+Let `value` be a self-signed container object. The convention is that the signature (e.g. a `"bytes96"` BLS12-381 signature) be the last field of `value`. Further, the signed message for `value` is `signing_root(value) = hash_tree_root(truncate_last(value))` where `truncate_last` truncates the last element of `value`. In the case where the last element is `Embedded`, the entire last element is truncated, not just the last element's own last element.
 
 ## Summaries and expansions
 


### PR DESCRIPTION
Alternative to #1392 

See https://github.com/ethereum/eth2.0-specs/pull/1383#discussion_r321320585 for original rationale, though note that this proposal deviates from the original proposal in that it adds padding to ensure that embedded values get an aligned subtree, so one can still meaningfully speak of eg. `get_generalized_index(Container, "baz")` if `baz` is the embedded vector in the example given in this PR.