### PR TITLE
Network specification update

### DIFF
--- a/specs/networking/p2p-interface.md
+++ b/specs/networking/p2p-interface.md
@@ -115,8 +115,6 @@ This section outlines constants that are used in this spec.
 |---|---|---|
 | `GOSSIP_MAX_SIZE` | `2**20` (= 1048576, 1 MiB) | The maximum allowed size of uncompressed gossip messages. |
 | `REQ_RESP_MAX_SIZE` | `2**20` (1048576, 1 MiB) | The maximum allowed size of uncompressed req/resp chunked responses. |
-| `MAX_REQUESTED_BLOCKS` | `20` | The maximum allowed number of blocks that can
-be requested. |
 | `SHARD_SUBNET_COUNT` | `TODO` | The number of shard subnets used in the gossipsub protocol. |
 | `TTFB_TIMEOUT` | `5s` | The maximum time to wait for first byte of request response (time-to-first-byte). |
 | `RESP_TIMEOUT` | `10s` | The maximum time for complete response transfer. |
@@ -249,7 +247,7 @@ Once a new stream with the protocol ID for the request type has been negotiated,
 
 The requester MUST close the write side of the stream once it finishes writing the request message. At this point, the stream will be half-closed.
 
-The requester MUST wait a maximum of `TTFB_TIMEOUT` for the first response byte to arrive (time to first byte—or TTFB—timeout). On that happening, the requester allows a further `RESP_TIMEOUT` to receive the full response. For responses consisting of potentially many `response_chunk`s (an SSZ-list) the requester SHOULD read from the stream until either; a) An error result is received in one of the chunks, b) The responder closes the stream,  c) More than `REQ_RESP_MAX_SIZE` bytes have been read for a single `response_chunk` payload or d) More than the maximum number of requested chunks are read. For requests consisting of a single `response_chunk` and a length-prefix, the requester should read the exact number of bytes defined by the length-prefix before closing the stream.
+The requester MUST wait a maximum of `TTFB_TIMEOUT` for the first response byte to arrive (time to first byte—or TTFB—timeout). On that happening, the requester allows a further `RESP_TIMEOUT` for each subsequent `response_chunk` received. For responses consisting of potentially many `response_chunk`s (an SSZ-list) the requester SHOULD read from the stream until either; a) An error result is received in one of the chunks, b) The responder closes the stream,  c) More than `REQ_RESP_MAX_SIZE` bytes have been read for a single `response_chunk` payload or d) More than the maximum number of requested chunks are read. For requests consisting of a single `response_chunk` and a length-prefix, the requester should read the exact number of bytes defined by the length-prefix before closing the stream.
 
 If any of these timeouts fire, the requester SHOULD reset the stream and deem the req/resp operation to have failed.
 
@@ -404,8 +402,6 @@ Requests count beacon blocks from the peer starting from `start_slot` on the cha
 
 The request MUST be encoded as an SSZ-container.
 
-The `count` MUST not exceed MAX_REQUESTED_BLOCKS.
-
 The response MUST consist of at least one `response_chunk` and MAY consist of many. Each _successful_ `response_chunk` MUST contain a single `BeaconBlock` payload.
 
 `BeaconBlocksByRange` is primarily used to sync historical blocks.
@@ -441,8 +437,6 @@ Response Content:
 Requests blocks by their block roots. The response is a list of `BeaconBlock` whose length is less than or equal to the number of requested blocks. It may be less in the case that the responding peer is missing blocks.
 
 `BeaconBlocksByRoot` is primarily used to recover recent blocks (e.g. when receiving a block or attestation whose parent is unknown).
-
-The length of `block_roots` MUST not exceed MAX_REQUESTED_BLOCKS.
 
 The request MUST be encoded as an SSZ-field.
 

--- a/specs/networking/p2p-interface.md
+++ b/specs/networking/p2p-interface.md
@@ -113,7 +113,7 @@ This section outlines constants that are used in this spec.
 
 | Name | Value | Description |
 |---|---|---|
-| `REQ_RESP_MAX_SIZE` | `2**22` (4194304, 4 MiB) | The maximum size of uncompressed req/resp messages that clients will allow. |
+| `REQ_RESP_MAX_SIZE` | `2**20` (1048576, 1 MiB) | The maximum size of uncompressed req/resp messages that clients will allow. |
 | `SSZ_MAX_LIST_SIZE` | `TODO` | The maximum size of SSZ-encoded variable lists. |
 | `GOSSIP_MAX_SIZE` | `2**20` (= 1048576, 1 MiB) | The maximum size of uncompressed gossip messages. |
 | `SHARD_SUBNET_COUNT` | `TODO` | The number of shard subnets used in the gossipsub protocol. |
@@ -244,7 +244,7 @@ Clients MUST ensure the total `response` is less than or equal to `REQ_RESP_MAX_
 
 #### Requesting side
 
-Once a new stream with the protocol ID for the request type has been negotiated, the full request message should be sent immediately. It should be encoded according to the encoding strategy.
+Once a new stream with the protocol ID for the request type has been negotiated, the full request message should be sent immediately. It MUST be encoded according to the encoding strategy.
 
 The requester MUST close the write side of the stream once it finishes writing the request message—at this point, the stream will be half-closed.
 
@@ -344,7 +344,7 @@ The fields are:
 
 The dialing client MUST send a `Hello` request upon connection.
 
-This should be encoded as an SSZ-container. The response consists of a single
+This MUST be encoded as an SSZ-container. The response consists of a single
 `response_chunk`.
 
 Clients SHOULD immediately disconnect from one another following the handshake above under the following conditions:
@@ -374,7 +374,7 @@ Clients MAY use reason codes above `128` to indicate alternative, erroneous requ
 
 The range `[4, 127]` is RESERVED for future usage.
 
-This should not be encoded as an SSZ-container. The response consists of a
+This MUST be encoded as a single SSZ-field. The response consists of a
 single `response_chunk`.
 
 #### BeaconBlocksByRange
@@ -400,7 +400,7 @@ Response Content:
 
 Requests count beacon blocks from the peer starting from `start_slot` on the chain defined by `head_block_root`. The response MUST contain no more than count blocks. `step` defines the slot increment between blocks. For example, requesting blocks starting at `start_slot` 2 with a step value of 2 would return the blocks at [2, 4, 6, …]. In cases where a slot is empty for a given slot number, no block is returned. For example, if slot 4 were empty in the previous example, the returned array would contain [2, 6, …]. A step value of 1 returns all blocks on the range `[start_slot, start_slot + count)`.
 
-The request is encoded as an SSZ-container. The response is sent as many
+The request MUST be encoded as an SSZ-container. The response is sent as many
 `response_chunk` with each chunk consisting of a single `BeaconBlock`.
 
 `BeaconBlocksByRange` is primarily used to sync historical blocks.
@@ -439,7 +439,7 @@ Requests blocks by their block roots. The response is a list of `BeaconBlock` wh
 
 `BeaconBlocksByRoot` is primarily used to recover recent blocks (ex. when receiving a block or attestation whose parent is unknown).
 
-The request is not encoded as an SSZ-container. The response is sent as many `response_chunk` with each chunk consisting of a single `BeaconBlock`.
+The request MUST be encoded as an SSZ-field. The response is sent as many `response_chunk` with each chunk consisting of a single `BeaconBlock`.
 
 Clients MUST support requesting blocks since the latest finalized epoch.
 

--- a/specs/networking/p2p-interface.md
+++ b/specs/networking/p2p-interface.md
@@ -113,9 +113,9 @@ This section outlines constants that are used in this spec.
 
 | Name | Value | Description |
 |---|---|---|
-| `REQ_RESP_MAX_SIZE` | `2**20` (1048576, 1 MiB) | The maximum size of uncompressed req/resp messages that clients will allow. |
+| `GOSSIP_MAX_SIZE` | `2**20` (= 1048576, 1 MiB) | The maximum allowed size of uncompressed gossip messages. |
+| `REQ_RESP_MAX_SIZE` | `2**20` (1048576, 1 MiB) | The maximum allowed size of uncompressed req/resp messages. |
 | `SSZ_MAX_LIST_SIZE` | `TODO` | The maximum size of SSZ-encoded variable lists. |
-| `GOSSIP_MAX_SIZE` | `2**20` (= 1048576, 1 MiB) | The maximum size of uncompressed gossip messages. |
 | `SHARD_SUBNET_COUNT` | `TODO` | The number of shard subnets used in the gossipsub protocol. |
 | `TTFB_TIMEOUT` | `5s` | The maximum time to wait for first byte of request response (time-to-first-byte). |
 | `RESP_TIMEOUT` | `10s` | The maximum time for complete response transfer. |

--- a/specs/networking/p2p-interface.md
+++ b/specs/networking/p2p-interface.md
@@ -422,7 +422,7 @@ Request Content:
 
 ```
 (
-  block_roots: []HashTreeRoot
+  []HashTreeRoot
 )
 ```
 
@@ -430,7 +430,7 @@ Response Content:
 
 ```
 (
-  blocks: []BeaconBlock
+  []BeaconBlock
 )
 ```
 


### PR DESCRIPTION
Provides updates to the networking specification. 

Specifically:
- Fixes the `REQ_RESP_MAX_SIZE`
- Renames the previously similar `BeaconBlocks` and `RecentBeaconBlocks` to `BeaconBlocksByRange` and `BeaconBlocksByRoot` respectively
- Removes the 1:1 mapping in `BeaconBlocksByRoot`, a responder may now return less blocks than requested
- The responder to a `BeaconBlocksByRange` request should also limit their response by the `REQ_RESP_MAX_SIZE` or `SSZ_MAX_LIST_SIZE`
- Adds the notion of a `response_chunk`. Responses that consist of a single SSZ-list (`BeaconBlocksByRange`, `BeaconBlocksByRoot`) are now sent back over the stream in individual `response_chunk`. 
- Adds clarification around the SSZ-encoding of the request/response types
- Adds clarification to the RPC requests

This extends on the improvements in #1390 