### PR TITLE
fix BLS tests name length

### DIFF
--- a/test_generators/bls/main.py
+++ b/test_generators/bls/main.py
@@ -11,6 +11,12 @@ from eth_utils import (
 from gen_base import gen_runner, gen_typing
 
 from py_ecc import bls
+from hashlib import sha256
+
+
+def hash(x):
+    return sha256(x).digest()
+
 
 F2Q_COEFF_LEN = 48
 G2_COMPRESSED_Z_LEN = 48
@@ -122,7 +128,8 @@ def case04_sign_messages():
         for message in MESSAGES:
             for domain in DOMAINS:
                 sig = bls.sign(message, privkey, domain)
-                yield f'sign_msg_{int_to_hex(privkey)}_{encode_hex(message)}_{encode_hex(domain)}', {
+                full_name = f'{int_to_hex(privkey)}_{encode_hex(message)}_{encode_hex(domain)}'
+                yield f'sign_msg_case_{(hash(bytes(full_name, "utf-8"))[:8]).hex()}', {
                     'input': {
                         'privkey': int_to_hex(privkey),
                         'message': encode_hex(message),


### PR DESCRIPTION
Due to limitations on some filesystems (e.g. encryptfs has a 120 file name char limit), some tests could not be loaded due to their name length. This changes the BLS tests with the long names to use small checksums to uniquely identify the test. Other tests stay as-is, as they are < 100 chars, which I will try to maintain as limit in the future.

I'm not sure when we should be releasing a new spec tests version, as we are in the middle of interop-lockin. The tests can at least be ran on normal file-systems, so I do not think it is too urgent anyway.

cc @prestonvanloon