### PR TITLE
Improve beacon proposer selection logic

### DIFF
--- a/specs/validator/0_beacon-chain-validator.md
+++ b/specs/validator/0_beacon-chain-validator.md
@@ -170,7 +170,7 @@ def is_proposer(state: BeaconState,
 
 *Note*: To see if a validator is assigned to propose during the slot, the beacon state must be in the epoch in question. At the epoch boundaries, the validator must run an epoch transition into the epoch to successfully check the proposal assignment of the first slot.
 
-*Note*: `BeaconBlock` proposal is distinct from crosslink committee assignment, and in a given epoch each responsbility might occur at different a different slot.
+*Note*: `BeaconBlock` proposal is distinct from crosslink committee assignment, and in a given epoch each responsability might occur at different a different slot.
 
 ### Lookahead
 

--- a/specs/validator/0_beacon-chain-validator.md
+++ b/specs/validator/0_beacon-chain-validator.md
@@ -170,7 +170,7 @@ def is_proposer(state: BeaconState,
 
 *Note*: To see if a validator is assigned to propose during the slot, the beacon state must be in the epoch in question. At the epoch boundaries, the validator must run an epoch transition into the epoch to successfully check the proposal assignment of the first slot.
 
-*Note*: `BeaconBlock` proposal is distinct from crosslink committee assignment, and in a given epoch each responsability might occur at different a different slot.
+*Note*: `BeaconBlock` proposal is distinct from crosslink committee assignment, and in a given epoch each responsibility might occur at different a different slot.
 
 ### Lookahead
 

--- a/specs/validator/0_beacon-chain-validator.md
+++ b/specs/validator/0_beacon-chain-validator.md
@@ -160,7 +160,7 @@ def get_committee_assignment(state: BeaconState,
     return None
 ```
 
-A validator can use the following function to see if they are supposed to propose during their assigned committee slot. This function can only be run with a `state` of the slot in question. Proposer selection is only stable within the context of the current epoch.
+A validator can use the following function to see if they are supposed to propose during a slot. This function can only be run with a `state` of the slot in question. Proposer selection is only stable within the context of the current epoch.
 
 ```python
 def is_proposer(state: BeaconState,
@@ -169,6 +169,8 @@ def is_proposer(state: BeaconState,
 ```
 
 *Note*: To see if a validator is assigned to propose during the slot, the beacon state must be in the epoch in question. At the epoch boundaries, the validator must run an epoch transition into the epoch to successfully check the proposal assignment of the first slot.
+
+*Note*: `BeaconBlock` proposal is distinct from crosslink committee assignment, and in a given epoch each responsbility might occur at different a different slot.
 
 ### Lookahead
 

--- a/test_libs/pyspec/eth2spec/test/helpers/proposer_slashings.py
+++ b/test_libs/pyspec/eth2spec/test/helpers/proposer_slashings.py
@@ -18,7 +18,6 @@ def get_valid_proposer_slashing(spec, state, signed_1=False, signed_2=False):
     )
     header_2 = deepcopy(header_1)
     header_2.parent_root = b'\x99' * 32
-    header_2.slot = slot + 1
 
     if signed_1:
         sign_block_header(spec, state, header_1, privkey)


### PR DESCRIPTION
Substantive changes:

1) sample proposer from the full set of active validators (as opposed to just the first committee)
2) make proposer slashing per-slot (as opposed to per-epoch)

Advantages of the new proposer logic:

* **improved liveness**: The beacon chain can progress with just one validator (as opposed to `SLOTS_PER_EPOCHS`, an unintended design flaw). Improved liveness with low validator count may be useful for testing, fuzzing, and private consortium beacon chains.
* **reduced complexity**: Avoid calling `get_committee_count`, `get_start_shard` and `get_crosslink_committee`. Reduce `get_beacon_proposer_index` line count by 20% (from 15 lines to 12 lines).
* **improved fairness**: Ensure that the probability of being selected as a proposer is proportional to the effective balance. The current design gradually breaks fairness as the number of validators decreases.
* **more natural design**: Block proposing is natively per-slot, not per-epoch. Block proposing is orthogonal from the notion of committees, and per-slot slashing is more natural than per-epoch slashing.
* **phase 1 reuse**: The `compute_proposer_index` can be reused in phase 1 (see #1383).