### PR TITLE
Shard chain CI cleanup

### DIFF
--- a/specs/core/1_beacon-chain-misc.md
+++ b/specs/core/1_beacon-chain-misc.md
@@ -226,16 +226,18 @@ def update_period_committee(state: BeaconState) -> None:
     """
     Updates period committee roots at boundary blocks.
     """
-    if (get_current_epoch(state) + 1) % EPOCHS_PER_SHARD_PERIOD == 0:
-        period = (get_current_epoch(state) + 1) // EPOCHS_PER_SHARD_PERIOD
-        committees = Vector[CompactCommittee, SHARD_COUNT]([
-            committee_to_compact_committee(
-                state,
-                get_period_committee(state, Epoch(get_current_epoch(state) + 1), Shard(shard)),
-            )
-            for shard in range(SHARD_COUNT)
-        ])
-        state.period_committee_roots[period % PERIOD_COMMITTEE_ROOT_LENGTH] = hash_tree_root(committees)
+    if (get_current_epoch(state) + 1) % EPOCHS_PER_SHARD_PERIOD != 0:
+        return
+
+    period = (get_current_epoch(state) + 1) // EPOCHS_PER_SHARD_PERIOD
+    committees = Vector[CompactCommittee, SHARD_COUNT]([
+        committee_to_compact_committee(
+            state,
+            get_period_committee(state, Shard(shard), Epoch(get_current_epoch(state) + 1)),
+        )
+        for shard in range(SHARD_COUNT)
+    ])
+    state.period_committee_roots[period % PERIOD_COMMITTEE_ROOT_LENGTH] = hash_tree_root(committees)
 ```
 
 ### Shard receipt processing

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -224,7 +224,7 @@ def process_delta(beacon_state: BeaconState,
                   index: ValidatorIndex,
                   delta: Gwei,
                   positive: bool=True) -> None:
-    epoch = compute_epoch_of_shard_slot(beacon_state.slot)
+    epoch = compute_epoch_of_shard_slot(shard_state.slot)
     older_committee = get_period_committee(beacon_state, shard_state.shard, compute_shard_period_start_epoch(epoch, 2))
     newer_committee = get_period_committee(beacon_state, shard_state.shard, compute_shard_period_start_epoch(epoch, 1))
     if index in older_committee:


### PR DESCRIPTION
Making CI happy for #1383

* Cleaned up some constants in `1_beacon-chain-misc`
* fix minor bug in `process_delta` -- `beacon_state.slot` --> `shard_state.slot`
* fix minor bug in `update_period_committee` -- order of arguments was incorrect
* assert `proposer_index is not None` when getting proposer index to make MyPy happy (because of the `Optional` return type
* add some missing `Gwei` type castings

Note:

* This does _not_ cleanup `shard_receipt_proof`s wrt to the updates in #1383. My plan of attack is to use this PR for minor fixes and use a separate PR for the substantive change to shard rewards processing into the beacon chain
* This does _not_ contain additional tests, it just gets the current ones passing so that #1383 can move forward