### PR TITLE
Shard chain CI cleanup

### DIFF
--- a/scripts/build_spec.py
+++ b/scripts/build_spec.py
@@ -37,7 +37,7 @@ from eth2spec.utils.bls import (
 from eth2spec.utils.hash_function import hash
 '''
 PHASE1_IMPORTS = '''from typing import (
-    Any, Dict, Optional, Set, Sequence, MutableSequence, NewType, Tuple, Union,
+    Any, Dict, Set, Sequence, MutableSequence, NewType, Tuple, Union,
 )
 from math import (
     log2,

--- a/specs/core/1_beacon-chain-misc.md
+++ b/specs/core/1_beacon-chain-misc.md
@@ -226,16 +226,18 @@ def update_period_committee(state: BeaconState) -> None:
     """
     Updates period committee roots at boundary blocks.
     """
-    if (get_current_epoch(state) + 1) % EPOCHS_PER_SHARD_PERIOD == 0:
-        period = (get_current_epoch(state) + 1) // EPOCHS_PER_SHARD_PERIOD
-        committees = Vector[CompactCommittee, SHARD_COUNT]([
-            committee_to_compact_committee(
-                state,
-                get_period_committee(state, Epoch(get_current_epoch(state) + 1), Shard(shard)),
-            )
-            for shard in range(SHARD_COUNT)
-        ])
-        state.period_committee_roots[period % PERIOD_COMMITTEE_ROOT_LENGTH] = hash_tree_root(committees)
+    if (get_current_epoch(state) + 1) % EPOCHS_PER_SHARD_PERIOD != 0:
+        return
+
+    period = (get_current_epoch(state) + 1) // EPOCHS_PER_SHARD_PERIOD
+    committees = Vector[CompactCommittee, SHARD_COUNT]([
+        committee_to_compact_committee(
+            state,
+            get_period_committee(state, Shard(shard), Epoch(get_current_epoch(state) + 1)),
+        )
+        for shard in range(SHARD_COUNT)
+    ])
+    state.period_committee_roots[period % PERIOD_COMMITTEE_ROOT_LENGTH] = hash_tree_root(committees)
 ```
 
 ### Shard receipt processing

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -224,7 +224,7 @@ def process_delta(beacon_state: BeaconState,
                   index: ValidatorIndex,
                   delta: Gwei,
                   positive: bool=True) -> None:
-    epoch = compute_epoch_of_shard_slot(beacon_state.slot)
+    epoch = compute_epoch_of_shard_slot(shard_state.slot)
     older_committee = get_period_committee(beacon_state, shard_state.shard, compute_shard_period_start_epoch(epoch, 2))
     newer_committee = get_period_committee(beacon_state, shard_state.shard, compute_shard_period_start_epoch(epoch, 1))
     if index in older_committee:

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -202,12 +202,11 @@ def get_shard_committee(beacon_state: BeaconState, shard: Shard, epoch: Epoch) -
 #### `get_shard_proposer_index`
 
 ```python
-def get_shard_proposer_index(beacon_state: BeaconState, shard: Shard, slot: ShardSlot) -> Optional[ValidatorIndex]:
+def get_shard_proposer_index(beacon_state: BeaconState, shard: Shard, slot: ShardSlot) -> ValidatorIndex:
     epoch = get_current_epoch(beacon_state)
     shard_committee = get_shard_committee(beacon_state, shard, epoch)
     active_indices = [i for i in shard_committee if is_active_validator(beacon_state.validators[i], epoch)]
-    if not any(active_indices):
-        return None
+    assert any(active_indices)
 
     epoch_seed = get_seed(beacon_state, epoch, DOMAIN_SHARD_PROPOSER)
     seed = hash(epoch_seed + int_to_bytes(slot, length=8) + int_to_bytes(shard, length=8))
@@ -356,7 +355,6 @@ def process_shard_block_header(beacon_state: BeaconState, shard_state: ShardStat
     assert block.block_size_sum == shard_state.block_size_sum
     # Verify proposer is not slashed
     proposer_index = get_shard_proposer_index(beacon_state, shard_state.shard, block.slot)
-    assert proposer_index is not None
     proposer = beacon_state.validators[proposer_index]
     assert not proposer.slashed
     # Verify proposer signature
@@ -385,7 +383,6 @@ def process_shard_attestations(beacon_state: BeaconState, shard_state: ShardStat
     assert bls_verify(bls_aggregate_pubkeys(pubkeys), message, block.attestations, domain)
     # Proposer micro-reward
     proposer_index = get_shard_proposer_index(beacon_state, shard_state.shard, block.slot)
-    assert proposer_index is not None
     reward = attestation_count * get_base_reward(beacon_state, proposer_index) // PROPOSER_REWARD_QUOTIENT
     process_delta(beacon_state, shard_state, proposer_index, Gwei(reward))
 ```
@@ -399,7 +396,6 @@ def process_shard_block_body(beacon_state: BeaconState, shard_state: ShardState,
     # Apply proposer block body fee
     block_body_fee = shard_state.block_body_price * len(block.body) // MAX_SHARD_BLOCK_SIZE
     proposer_index = get_shard_proposer_index(beacon_state, shard_state.shard, block.slot)
-    assert proposer_index is not None
     process_delta(beacon_state, shard_state, proposer_index, Gwei(block_body_fee), positive=False)  # Burn
     process_delta(beacon_state, shard_state, proposer_index, Gwei(block_body_fee // PROPOSER_REWARD_QUOTIENT))  # Reward
     # Calculate new block body price


### PR DESCRIPTION
Making CI happy for #1383

* Cleaned up some constants in `1_beacon-chain-misc`
* fix minor bug in `process_delta` -- `beacon_state.slot` --> `shard_state.slot`
* fix minor bug in `update_period_committee` -- order of arguments was incorrect
* assert `proposer_index is not None` when getting proposer index to make MyPy happy (because of the `Optional` return type
* add some missing `Gwei` type castings

Note:

* This does _not_ cleanup `shard_receipt_proof`s wrt to the updates in #1383, and still utilizes the old `receipt_root`. My plan of attack is to use this PR for minor fixes and use a separate PR for the substantive change to shard rewards processing into the beacon chain
* This does _not_ contain additional tests, it just gets the current ones passing so that #1383 can move forward