### PR TITLE
K coverage tests

### DIFF
--- a/test_libs/pyspec/eth2spec/test/context.py
+++ b/test_libs/pyspec/eth2spec/test/context.py
@@ -10,7 +10,19 @@ from .utils import vector_test, with_meta_tags
 def with_state(fn):
     def entry(*args, **kw):
         try:
-            kw['state'] = create_genesis_state(spec=kw['spec'], num_validators=spec_phase0.SLOTS_PER_EPOCH * 10)
+            kw['state'] = create_genesis_state(spec=kw['spec'], num_validators=spec_phase0.SLOTS_PER_EPOCH * 10,
+                                               validator_balance=spec_phase0.MAX_EFFECTIVE_BALANCE)
+        except KeyError:
+            raise TypeError('Spec decorator must come within state decorator to inject spec into state.')
+        return fn(*args, **kw)
+    return entry
+
+
+def with_state_low_balance(fn):
+    def entry(*args, **kw):
+        try:
+            kw['state'] = create_genesis_state(spec=kw['spec'], num_validators=spec_phase0.SLOTS_PER_EPOCH * 10,
+                                               validator_balance=18 * 10**9)
         except KeyError:
             raise TypeError('Spec decorator must come within state decorator to inject spec into state.')
         return fn(*args, **kw)
@@ -39,6 +51,10 @@ def spec_test(fn):
 # shorthand for decorating @spectest() @with_state
 def spec_state_test(fn):
     return spec_test(with_state(fn))
+
+
+def spec_state_low_balance_test(fn):
+    return spec_test(with_state_low_balance(fn))
 
 
 def expect_assertion_error(fn):

--- a/test_libs/pyspec/eth2spec/test/helpers/genesis.py
+++ b/test_libs/pyspec/eth2spec/test/helpers/genesis.py
@@ -16,7 +16,7 @@ def build_mock_validator(spec, i: int, balance: int):
     )
 
 
-def create_genesis_state(spec, num_validators):
+def create_genesis_state(spec, num_validators, validator_balance):
     deposit_root = b'\x42' * 32
 
     state = spec.BeaconState(
@@ -32,12 +32,12 @@ def create_genesis_state(spec, num_validators):
 
     # We "hack" in the initial validators,
     #  as it is much faster than creating and processing genesis deposits for every single test case.
-    state.balances = [spec.MAX_EFFECTIVE_BALANCE] * num_validators
+    state.balances = [validator_balance] * num_validators
     state.validators = [build_mock_validator(spec, i, state.balances[i]) for i in range(num_validators)]
 
     # Process genesis activations
     for validator in state.validators:
-        if validator.effective_balance >= spec.MAX_EFFECTIVE_BALANCE:
+        if validator.effective_balance >= validator_balance:
             validator.activation_eligibility_epoch = spec.GENESIS_EPOCH
             validator.activation_epoch = spec.GENESIS_EPOCH
 

--- a/test_libs/pyspec/eth2spec/test/phase_0/block_processing/test_process_attestation.py
+++ b/test_libs/pyspec/eth2spec/test/phase_0/block_processing/test_process_attestation.py
@@ -1,4 +1,5 @@
-from eth2spec.test.context import spec_state_test, expect_assertion_error, always_bls, with_all_phases, with_phases
+from eth2spec.test.context import spec_state_test, spec_state_low_balance_test, expect_assertion_error, always_bls, \
+    with_all_phases, with_phases
 from eth2spec.test.helpers.attestations import (
     get_valid_attestation,
     sign_aggregate_attestation,
@@ -50,6 +51,16 @@ def run_attestation_processing(spec, state, attestation, valid=True):
 @with_all_phases
 @spec_state_test
 def test_success(spec, state):
+    attestation = get_valid_attestation(spec, state, signed=True)
+    state.slot += spec.MIN_ATTESTATION_INCLUSION_DELAY
+
+    yield from run_attestation_processing(spec, state, attestation)
+
+
+@with_all_phases
+@spec_state_low_balance_test
+def test_success_multi_proposer_index_iterations(spec, state):
+    state.slot += spec.SLOTS_PER_EPOCH * 2
     attestation = get_valid_attestation(spec, state, signed=True)
     state.slot += spec.MIN_ATTESTATION_INCLUSION_DELAY
 

--- a/test_libs/pyspec/eth2spec/test/phase_0/block_processing/test_process_attestation.py
+++ b/test_libs/pyspec/eth2spec/test/phase_0/block_processing/test_process_attestation.py
@@ -60,7 +60,7 @@ def test_success(spec, state):
 @with_all_phases
 @spec_state_low_balance_test
 def test_success_multi_proposer_index_iterations(spec, state):
-    state.slot += spec.SLOTS_PER_EPOCH * 9 # min value for 3 iterations
+    state.slot += spec.SLOTS_PER_EPOCH * 9  # Min value for 3 iterations of compute_proposer_index()
     attestation = get_valid_attestation(spec, state, signed=True)
     state.slot += spec.MIN_ATTESTATION_INCLUSION_DELAY
 

--- a/test_libs/pyspec/eth2spec/test/phase_0/block_processing/test_process_attestation.py
+++ b/test_libs/pyspec/eth2spec/test/phase_0/block_processing/test_process_attestation.py
@@ -60,7 +60,7 @@ def test_success(spec, state):
 @with_all_phases
 @spec_state_low_balance_test
 def test_success_multi_proposer_index_iterations(spec, state):
-    state.slot += spec.SLOTS_PER_EPOCH * 2
+    state.slot += spec.SLOTS_PER_EPOCH * 9 # min value for 3 iterations
     attestation = get_valid_attestation(spec, state, signed=True)
     state.slot += spec.MIN_ATTESTATION_INCLUSION_DELAY
 

--- a/test_libs/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_justification_and_finalization.py
+++ b/test_libs/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_justification_and_finalization.py
@@ -275,10 +275,12 @@ def test_123_poor_support(spec, state):
 def test_12_ok_support(spec, state):
     yield from finalize_on_12(spec, state, 3, True, False)
 
+
 @with_all_phases
 @spec_state_test
 def test_12_ok_support_messed_target(spec, state):
     yield from finalize_on_12(spec, state, 3, True, True)
+
 
 @with_all_phases
 @spec_state_test

--- a/test_libs/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_justification_and_finalization.py
+++ b/test_libs/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_justification_and_finalization.py
@@ -16,7 +16,7 @@ def get_shards_for_slot(spec, state, slot):
     return [shard + i for i in range(committees_per_slot)]
 
 
-def add_mock_attestations(spec, state, epoch, source, target, sufficient_support=False):
+def add_mock_attestations(spec, state, epoch, source, target, sufficient_support=False, messed_up_target=False):
     # we must be at the end of the epoch
     assert (state.slot + 1) % spec.SLOTS_PER_EPOCH == 0
 
@@ -67,6 +67,8 @@ def add_mock_attestations(spec, state, epoch, source, target, sufficient_support
                 ),
                 inclusion_delay=1,
             ))
+            if messed_up_target:
+                attestations[len(attestations) - 1].data.target.root = b'\x99' * 32
 
 
 def get_checkpoints(spec, epoch):
@@ -196,7 +198,7 @@ def finalize_on_123(spec, state, epoch, sufficient_support):
         assert state.finalized_checkpoint == old_finalized  # no new finalized
 
 
-def finalize_on_12(spec, state, epoch, sufficient_support):
+def finalize_on_12(spec, state, epoch, sufficient_support, messed_up_target):
     assert epoch > 2
     state.slot = (spec.SLOTS_PER_EPOCH * epoch) - 1  # skip ahead to just before epoch
 
@@ -218,13 +220,13 @@ def finalize_on_12(spec, state, epoch, sufficient_support):
                           epoch=epoch - 1,
                           source=c2,
                           target=c1,
-                          sufficient_support=sufficient_support)
+                          sufficient_support=sufficient_support, messed_up_target=messed_up_target)
 
     # process!
     yield from run_process_just_and_fin(spec, state)
 
     assert state.previous_justified_checkpoint == c2  # changed to old current
-    if sufficient_support:
+    if sufficient_support and not messed_up_target:
         assert state.current_justified_checkpoint == c1  # changed to 1st latest
         assert state.finalized_checkpoint == c2  # finalized previous justified epoch
     else:
@@ -271,10 +273,14 @@ def test_123_poor_support(spec, state):
 @with_all_phases
 @spec_state_test
 def test_12_ok_support(spec, state):
-    yield from finalize_on_12(spec, state, 3, True)
+    yield from finalize_on_12(spec, state, 3, True, False)
 
+@with_all_phases
+@spec_state_test
+def test_12_ok_support_messed_target(spec, state):
+    yield from finalize_on_12(spec, state, 3, True, True)
 
 @with_all_phases
 @spec_state_test
 def test_12_poor_support(spec, state):
-    yield from finalize_on_12(spec, state, 3, False)
+    yield from finalize_on_12(spec, state, 3, False, False)


### PR DESCRIPTION
2 tests for code not covered by K coverage analysis.
Test 1: `get_matching_target_attestations`, line 842, case false.
Test 2: `get_beacon_proposer_index`, case when `while` loop has more than one iteration.
