### PR TITLE
Update config_helper dependencies.

### DIFF
--- a/test_libs/config_helpers/requirements.txt
+++ b/test_libs/config_helpers/requirements.txt
@@ -1,1 +1,1 @@
-ruamel.yaml==0.15.96
+ruamel.yaml==0.16.5

--- a/test_libs/config_helpers/setup.py
+++ b/test_libs/config_helpers/setup.py
@@ -4,6 +4,6 @@ setup(
     name='config_helpers',
     packages=['preset_loader'],
     install_requires=[
-        "ruamel.yaml==0.15.96"
+        "ruamel.yaml==0.16.5"
     ]
 )


### PR DESCRIPTION
Fixes build errors for python 3.8.

I added the latest version (v0.16.5) as there don't appear to be any backwards-incompatible changes, but v0.15.98 would be sufficient to resolve the build errors.

See:
- https://bitbucket.org/ruamel/yaml/issues/292/failure-to-build-python38
- https://bitbucket.org/ruamel/yaml/issues/296/another-python-38-dev-compilation-breakage