### PR TITLE
Fix delay-based attestation inclusion reward

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1365,9 +1365,7 @@ def get_attestation_deltas(state: BeaconState) -> Tuple[Sequence[Gwei], Sequence
         rewards[attestation.proposer_index] += proposer_reward
         max_attester_reward = get_base_reward(state, index) - proposer_reward
         rewards[index] += Gwei(
-            max_attester_reward
-            * (SLOTS_PER_EPOCH + MIN_ATTESTATION_INCLUSION_DELAY - attestation.inclusion_delay)
-            // SLOTS_PER_EPOCH
+            max_attester_reward // attestation.inclusion_delay
         )
 
     # Inactivity penalty


### PR DESCRIPTION
Modify the delay-based reward function from the current `r = (65-d)/64` to `r = 1/d`.

Rationale is that in the normal case delay is close to 1, so we want a larger incentive to get included more quickly to encourage stability of the fork choice. Particularly, in the status quo if you know that you will be a proposer <4 slots in the future, you can maximize earnings by delaying inclusion of your attestation until you can include it yourself and get the proposer reward; this adjustment fixes this in the normal case.