### PR TITLE
Tests based on K cov from #1420, updated to get into v08x before release.

### DIFF
--- a/test_generators/epoch_processing/main.py
+++ b/test_generators/epoch_processing/main.py
@@ -7,6 +7,7 @@ from eth2spec.test.phase_0.epoch_processing import (
     test_process_final_updates,
     test_process_justification_and_finalization,
     test_process_registry_updates,
+    test_process_rewards_and_penalties,
     test_process_slashings
 )
 from gen_base import gen_runner, gen_typing
@@ -43,6 +44,8 @@ if __name__ == "__main__":
         create_provider('justification_and_finalization', test_process_justification_and_finalization, 'mainnet'),
         create_provider('registry_updates', test_process_registry_updates, 'minimal'),
         create_provider('registry_updates', test_process_registry_updates, 'mainnet'),
+        create_provider('rewards_and_penalties', test_process_rewards_and_penalties, 'minimal'),
+        create_provider('rewards_and_penalties', test_process_rewards_and_penalties, 'mainnet'),
         create_provider('slashings', test_process_slashings, 'minimal'),
         create_provider('slashings', test_process_slashings, 'mainnet'),
     ])

--- a/test_libs/pyspec/eth2spec/test/context.py
+++ b/test_libs/pyspec/eth2spec/test/context.py
@@ -2,43 +2,62 @@ from eth2spec.phase0 import spec as spec_phase0
 from eth2spec.phase1 import spec as spec_phase1
 from eth2spec.utils import bls
 
-from .helpers.genesis import create_genesis_state, create_genesis_state_misc_balances
+from .helpers.genesis import create_genesis_state
 
 from .utils import vector_test, with_meta_tags
 
-
-def with_state(fn):
-    def entry(*args, **kw):
-        try:
-            kw['state'] = create_genesis_state(spec=kw['spec'], num_validators=spec_phase0.SLOTS_PER_EPOCH * 8,
-                                               validator_balance=spec_phase0.MAX_EFFECTIVE_BALANCE)
-        except KeyError:
-            raise TypeError('Spec decorator must come within state decorator to inject spec into state.')
-        return fn(*args, **kw)
-    return entry
+from typing import Any, Callable, Sequence
 
 
-def with_state_low_balance(fn):
-    def entry(*args, **kw):
-        try:
-            kw['state'] = create_genesis_state(spec=kw['spec'], num_validators=spec_phase0.SLOTS_PER_EPOCH * 8,
-                                               validator_balance=18 * 10**9)
-        except KeyError:
-            raise TypeError('Spec decorator must come within state decorator to inject spec into state.')
-        return fn(*args, **kw)
-    return entry
+def with_custom_state(balances_fn: Callable[[Any], Sequence[int]],
+                      threshold_fn: Callable[[Any], int]):
+    def deco(fn):
+        def entry(*args, **kw):
+            try:
+                spec = kw['spec']
+
+                balances = balances_fn(spec)
+                activation_threshold = threshold_fn(spec)
+
+                kw['state'] = create_genesis_state(spec=spec, validator_balances=balances,
+                                                   activation_threshold=activation_threshold)
+            except KeyError:
+                raise TypeError('Spec decorator must come within state decorator to inject spec into state.')
+            return fn(*args, **kw)
+        return entry
+    return deco
 
 
-def with_state_misc_balances(fn):
-    def entry(*args, **kw):
-        try:
-            validator_balances = [spec_phase0.MAX_EFFECTIVE_BALANCE] * (spec_phase0.SLOTS_PER_EPOCH * 8) + [
-                spec_phase0.MIN_DEPOSIT_AMOUNT] * spec_phase0.SLOTS_PER_EPOCH
-            kw['state'] = create_genesis_state_misc_balances(spec=kw['spec'], validator_balances=validator_balances)
-        except KeyError:
-            raise TypeError('Spec decorator must come within state decorator to inject spec into state.')
-        return fn(*args, **kw)
-    return entry
+def default_activation_threshold(spec):
+    return spec.MAX_EFFECTIVE_BALANCE
+
+
+def default_balances(spec):
+    num_validators = spec.SLOTS_PER_EPOCH * 8
+    return [spec.MAX_EFFECTIVE_BALANCE] * num_validators
+
+
+with_state = with_custom_state(default_balances, default_activation_threshold)
+
+
+def low_balances(spec):
+    """
+    Helper method to create a series of low balances. Usage: `@with_validator_balances(low_balances)`
+    """
+    num_validators = spec.SLOTS_PER_EPOCH * 8
+    # Technically the balances cannot be this low starting from genesis, but it is useful for testing
+    low_balance = 18 * 10 ** 9
+    return [low_balance] * num_validators
+
+
+def misc_balances(spec):
+    """
+    Helper method to create a series of balances that includes some misc. balances.
+    Usage: `@with_validator_balances(misc_balances)`
+    """
+    num_validators = spec.SLOTS_PER_EPOCH * 8
+    num_misc_validators = spec.SLOTS_PER_EPOCH
+    return [spec.MAX_EFFECTIVE_BALANCE] * num_validators + [spec.MIN_DEPOSIT_AMOUNT] * num_misc_validators
 
 
 # BLS is turned off by default *for performance purposes during TESTING*.
@@ -63,14 +82,6 @@ def spec_test(fn):
 # shorthand for decorating @spectest() @with_state
 def spec_state_test(fn):
     return spec_test(with_state(fn))
-
-
-def spec_state_low_balance_test(fn):
-    return spec_test(with_state_low_balance(fn))
-
-
-def spec_state_misc_balances_test(fn):
-    return spec_test(with_state_misc_balances(fn))
 
 
 def expect_assertion_error(fn):

--- a/test_libs/pyspec/eth2spec/test/context.py
+++ b/test_libs/pyspec/eth2spec/test/context.py
@@ -10,7 +10,19 @@ from .utils import vector_test, with_meta_tags
 def with_state(fn):
     def entry(*args, **kw):
         try:
-            kw['state'] = create_genesis_state(spec=kw['spec'], num_validators=spec_phase0.SLOTS_PER_EPOCH * 8)
+            kw['state'] = create_genesis_state(spec=kw['spec'], num_validators=spec_phase0.SLOTS_PER_EPOCH * 8,
+                                               validator_balance=spec_phase0.MAX_EFFECTIVE_BALANCE)
+        except KeyError:
+            raise TypeError('Spec decorator must come within state decorator to inject spec into state.')
+        return fn(*args, **kw)
+    return entry
+
+
+def with_state_low_balance(fn):
+    def entry(*args, **kw):
+        try:
+            kw['state'] = create_genesis_state(spec=kw['spec'], num_validators=spec_phase0.SLOTS_PER_EPOCH * 8,
+                                               validator_balance=18 * 10**9)
         except KeyError:
             raise TypeError('Spec decorator must come within state decorator to inject spec into state.')
         return fn(*args, **kw)
@@ -39,6 +51,10 @@ def spec_test(fn):
 # shorthand for decorating @spectest() @with_state
 def spec_state_test(fn):
     return spec_test(with_state(fn))
+
+
+def spec_state_low_balance_test(fn):
+    return spec_test(with_state_low_balance(fn))
 
 
 def expect_assertion_error(fn):

--- a/test_libs/pyspec/eth2spec/test/genesis/test_initialization.py
+++ b/test_libs/pyspec/eth2spec/test/genesis/test_initialization.py
@@ -8,7 +8,7 @@ from eth2spec.test.helpers.deposits import (
 @spec_test
 def test_initialize_beacon_state_from_eth1(spec):
     deposit_count = spec.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT
-    deposits, deposit_root = prepare_genesis_deposits(spec, deposit_count, spec.MAX_EFFECTIVE_BALANCE, signed=True)
+    deposits, deposit_root, _ = prepare_genesis_deposits(spec, deposit_count, spec.MAX_EFFECTIVE_BALANCE, signed=True)
 
     eth1_block_hash = b'\x12' * 32
     eth1_timestamp = spec.MIN_GENESIS_TIME
@@ -25,6 +25,43 @@ def test_initialize_beacon_state_from_eth1(spec):
     assert state.eth1_data.deposit_root == deposit_root
     assert state.eth1_data.deposit_count == deposit_count
     assert state.eth1_data.block_hash == eth1_block_hash
+    assert spec.get_total_active_balance(state) == deposit_count * spec.MAX_EFFECTIVE_BALANCE
+
+    # yield state
+    yield 'state', state
+
+
+@with_phases(['phase0'])
+@spec_test
+def test_initialize_beacon_state_some_small_balances(spec):
+    main_deposit_count = spec.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT
+    main_deposits, _, deposit_data_list = prepare_genesis_deposits(spec, main_deposit_count,
+                                                              spec.MAX_EFFECTIVE_BALANCE, signed=True)
+    # For deposits above, and for another deposit_count, add a balance of EFFECTIVE_BALANCE_INCREMENT
+    small_deposit_count = main_deposit_count * 2
+    small_deposits, deposit_root, _ = prepare_genesis_deposits(spec, small_deposit_count,
+                                                               spec.MIN_DEPOSIT_AMOUNT,
+                                                               signed=True,
+                                                               deposit_data_list=deposit_data_list)
+    deposits = main_deposits + small_deposits
+
+    eth1_block_hash = b'\x12' * 32
+    eth1_timestamp = spec.MIN_GENESIS_TIME
+
+    yield 'eth1_block_hash', eth1_block_hash
+    yield 'eth1_timestamp', eth1_timestamp
+    yield 'deposits', deposits
+
+    # initialize beacon_state
+    state = spec.initialize_beacon_state_from_eth1(eth1_block_hash, eth1_timestamp, deposits)
+
+    assert state.genesis_time == eth1_timestamp - eth1_timestamp % spec.SECONDS_PER_DAY + 2 * spec.SECONDS_PER_DAY
+    assert len(state.validators) == small_deposit_count
+    assert state.eth1_data.deposit_root == deposit_root
+    assert state.eth1_data.deposit_count == len(deposits)
+    assert state.eth1_data.block_hash == eth1_block_hash
+    # only main deposits participate to the active balance
+    assert spec.get_total_active_balance(state) == main_deposit_count * spec.MAX_EFFECTIVE_BALANCE
 
     # yield state
     yield 'state', state

--- a/test_libs/pyspec/eth2spec/test/genesis/test_initialization.py
+++ b/test_libs/pyspec/eth2spec/test/genesis/test_initialization.py
@@ -36,7 +36,7 @@ def test_initialize_beacon_state_from_eth1(spec):
 def test_initialize_beacon_state_some_small_balances(spec):
     main_deposit_count = spec.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT
     main_deposits, _, deposit_data_list = prepare_genesis_deposits(spec, main_deposit_count,
-                                                              spec.MAX_EFFECTIVE_BALANCE, signed=True)
+                                                                   spec.MAX_EFFECTIVE_BALANCE, signed=True)
     # For deposits above, and for another deposit_count, add a balance of EFFECTIVE_BALANCE_INCREMENT
     small_deposit_count = main_deposit_count * 2
     small_deposits, deposit_root, _ = prepare_genesis_deposits(spec, small_deposit_count,

--- a/test_libs/pyspec/eth2spec/test/genesis/test_validity.py
+++ b/test_libs/pyspec/eth2spec/test/genesis/test_validity.py
@@ -6,7 +6,7 @@ from eth2spec.test.helpers.deposits import (
 
 def create_valid_beacon_state(spec):
     deposit_count = spec.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT
-    deposits, _ = prepare_genesis_deposits(spec, deposit_count, spec.MAX_EFFECTIVE_BALANCE, signed=True)
+    deposits, _, _ = prepare_genesis_deposits(spec, deposit_count, spec.MAX_EFFECTIVE_BALANCE, signed=True)
 
     eth1_block_hash = b'\x12' * 32
     eth1_timestamp = spec.MIN_GENESIS_TIME
@@ -65,7 +65,7 @@ def test_is_valid_genesis_state_true_more_balance(spec):
 @spec_test
 def test_is_valid_genesis_state_true_one_more_validator(spec):
     deposit_count = spec.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT + 1
-    deposits, _ = prepare_genesis_deposits(spec, deposit_count, spec.MAX_EFFECTIVE_BALANCE, signed=True)
+    deposits, _, _ = prepare_genesis_deposits(spec, deposit_count, spec.MAX_EFFECTIVE_BALANCE, signed=True)
 
     eth1_block_hash = b'\x12' * 32
     eth1_timestamp = spec.MIN_GENESIS_TIME
@@ -78,7 +78,7 @@ def test_is_valid_genesis_state_true_one_more_validator(spec):
 @spec_test
 def test_is_valid_genesis_state_false_not_enough_validator(spec):
     deposit_count = spec.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT - 1
-    deposits, _ = prepare_genesis_deposits(spec, deposit_count, spec.MAX_EFFECTIVE_BALANCE, signed=True)
+    deposits, _, _ = prepare_genesis_deposits(spec, deposit_count, spec.MAX_EFFECTIVE_BALANCE, signed=True)
 
     eth1_block_hash = b'\x12' * 32
     eth1_timestamp = spec.MIN_GENESIS_TIME

--- a/test_libs/pyspec/eth2spec/test/helpers/deposits.py
+++ b/test_libs/pyspec/eth2spec/test/helpers/deposits.py
@@ -55,8 +55,9 @@ def build_deposit(spec,
     return deposit, root, deposit_data_list
 
 
-def prepare_genesis_deposits(spec, genesis_validator_count, amount, signed=False):
-    deposit_data_list = []
+def prepare_genesis_deposits(spec, genesis_validator_count, amount, signed=False, deposit_data_list=None):
+    if deposit_data_list is None:
+        deposit_data_list = []
     genesis_deposits = []
     for validator_index in range(genesis_validator_count):
         pubkey = pubkeys[validator_index]
@@ -75,7 +76,7 @@ def prepare_genesis_deposits(spec, genesis_validator_count, amount, signed=False
         )
         genesis_deposits.append(deposit)
 
-    return genesis_deposits, root
+    return genesis_deposits, root, deposit_data_list
 
 
 def prepare_state_and_deposit(spec, state, validator_index, amount, withdrawal_credentials=None, signed=False):

--- a/test_libs/pyspec/eth2spec/test/helpers/genesis.py
+++ b/test_libs/pyspec/eth2spec/test/helpers/genesis.py
@@ -18,7 +18,7 @@ def build_mock_validator(spec, i: int, balance: int):
     )
 
 
-def create_genesis_state(spec, num_validators):
+def create_genesis_state(spec, num_validators, validator_balance):
     deposit_root = b'\x42' * 32
 
     state = spec.BeaconState(
@@ -34,12 +34,12 @@ def create_genesis_state(spec, num_validators):
 
     # We "hack" in the initial validators,
     #  as it is much faster than creating and processing genesis deposits for every single test case.
-    state.balances = [spec.MAX_EFFECTIVE_BALANCE] * num_validators
+    state.balances = [validator_balance] * num_validators
     state.validators = [build_mock_validator(spec, i, state.balances[i]) for i in range(num_validators)]
 
     # Process genesis activations
     for validator in state.validators:
-        if validator.effective_balance >= spec.MAX_EFFECTIVE_BALANCE:
+        if validator.effective_balance >= validator_balance:
             validator.activation_eligibility_epoch = spec.GENESIS_EPOCH
             validator.activation_epoch = spec.GENESIS_EPOCH
 

--- a/test_libs/pyspec/eth2spec/test/phase_0/block_processing/test_process_attestation.py
+++ b/test_libs/pyspec/eth2spec/test/phase_0/block_processing/test_process_attestation.py
@@ -1,4 +1,5 @@
-from eth2spec.test.context import spec_state_test, expect_assertion_error, always_bls, with_all_phases, with_phases
+from eth2spec.test.context import spec_state_test, spec_state_low_balance_test, expect_assertion_error, always_bls, \
+    with_all_phases, with_phases
 from eth2spec.test.helpers.attestations import (
     get_valid_attestation,
     sign_aggregate_attestation,
@@ -50,6 +51,16 @@ def run_attestation_processing(spec, state, attestation, valid=True):
 @with_all_phases
 @spec_state_test
 def test_success(spec, state):
+    attestation = get_valid_attestation(spec, state, signed=True)
+    state.slot += spec.MIN_ATTESTATION_INCLUSION_DELAY
+
+    yield from run_attestation_processing(spec, state, attestation)
+
+
+@with_all_phases
+@spec_state_low_balance_test
+def test_success_multi_proposer_index_iterations(spec, state):
+    state.slot += spec.SLOTS_PER_EPOCH * 2
     attestation = get_valid_attestation(spec, state, signed=True)
     state.slot += spec.MIN_ATTESTATION_INCLUSION_DELAY
 

--- a/test_libs/pyspec/eth2spec/test/phase_0/block_processing/test_process_attestation.py
+++ b/test_libs/pyspec/eth2spec/test/phase_0/block_processing/test_process_attestation.py
@@ -1,5 +1,5 @@
-from eth2spec.test.context import spec_state_test, spec_state_low_balance_test, expect_assertion_error, always_bls, \
-    with_all_phases, with_phases
+from eth2spec.test.context import spec_state_test, expect_assertion_error, always_bls, \
+    with_all_phases, with_phases, spec_test, low_balances, with_custom_state
 from eth2spec.test.helpers.attestations import (
     get_valid_attestation,
     sign_aggregate_attestation,
@@ -58,7 +58,8 @@ def test_success(spec, state):
 
 
 @with_all_phases
-@spec_state_low_balance_test
+@spec_test
+@with_custom_state(balances_fn=low_balances, threshold_fn=lambda spec: spec.EJECTION_BALANCE)
 def test_success_multi_proposer_index_iterations(spec, state):
     state.slot += spec.SLOTS_PER_EPOCH * 2
     attestation = get_valid_attestation(spec, state, signed=True)

--- a/test_libs/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_rewards_and_penalties.py
+++ b/test_libs/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_rewards_and_penalties.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 
-from eth2spec.test.context import spec_state_test, with_all_phases
+from eth2spec.test.context import spec_state_test, spec_state_misc_balances_test, with_all_phases
 from eth2spec.test.helpers.state import (
     next_epoch,
     next_slot,
@@ -84,6 +84,40 @@ def test_full_attestations(spec, state):
             assert state.balances[index] > pre_state.balances[index]
         else:
             assert state.balances[index] < pre_state.balances[index]
+
+
+@with_all_phases
+@spec_state_misc_balances_test
+def test_full_attestations_misc_balances(spec, state):
+    attestations = []
+    for slot in range(spec.SLOTS_PER_EPOCH + spec.MIN_ATTESTATION_INCLUSION_DELAY):
+        # create an attestation for each slot in epoch
+        if slot < spec.SLOTS_PER_EPOCH:
+            attestation = get_valid_attestation(spec, state, signed=True)
+            attestations.append(attestation)
+        # fill each created slot in state after inclusion delay
+        if slot - spec.MIN_ATTESTATION_INCLUSION_DELAY >= 0:
+            include_att = attestations[slot - spec.MIN_ATTESTATION_INCLUSION_DELAY]
+            add_attestations_to_state(spec, state, [include_att], state.slot)
+        next_slot(spec, state)
+
+    assert spec.compute_epoch_of_slot(state.slot) == spec.GENESIS_EPOCH + 1
+    assert len(state.previous_epoch_attestations) == spec.SLOTS_PER_EPOCH
+
+    pre_state = deepcopy(state)
+
+    yield from run_process_rewards_and_penalties(spec, state)
+
+    attesting_indices = spec.get_unslashed_attesting_indices(state, attestations)
+    assert len(attesting_indices) > 0
+    assert len(attesting_indices) != len(pre_state.validators)
+    for index in range(len(pre_state.validators)):
+        if index in attesting_indices:
+            assert state.balances[index] > pre_state.balances[index]
+        elif spec.is_active_validator(pre_state.validators[index], spec.compute_epoch_of_slot(state.slot)):
+            assert state.balances[index] < pre_state.balances[index]
+        else:
+            assert state.balances[index] == pre_state.balances[index]
 
 
 @with_all_phases

--- a/test_libs/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_rewards_and_penalties.py
+++ b/test_libs/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_rewards_and_penalties.py
@@ -183,11 +183,11 @@ def test_attestations_some_slashed(spec, state):
             add_attestations_to_state(spec, state, [include_att], state.slot)
         next_slot(spec, state)
 
-    attesting_indices_before_slashings = spec.get_unslashed_attesting_indices(state, attestations)
+    attesting_indices_before_slashings = list(spec.get_unslashed_attesting_indices(state, attestations))
 
     # Slash maximum amount of validators allowed per epoch.
     for i in range(spec.MIN_PER_EPOCH_CHURN_LIMIT):
-        spec.slash_validator(state, list(attesting_indices_before_slashings)[i])
+        spec.slash_validator(state, attesting_indices_before_slashings[i])
 
     assert spec.compute_epoch_of_slot(state.slot) == spec.GENESIS_EPOCH + 1
     assert len(state.previous_epoch_attestations) == spec.SLOTS_PER_EPOCH


### PR DESCRIPTION
See #1420 

This PR includes the suggested code de-duplication, a few minor fixes, and only enables a new minimal-mode generator, as the mainnet mode for it is not fast enough yet (full filled 64-slot long epochs are too heavy for unoptimized pyspec)

