### PR TITLE
Implement solution for #1446, based on suggested use of eth1 hash

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1112,10 +1112,8 @@ def initialize_beacon_state_from_eth1(eth1_block_hash: Hash,
         genesis_time=eth1_timestamp - eth1_timestamp % SECONDS_PER_DAY + 2 * SECONDS_PER_DAY,
         eth1_data=Eth1Data(block_hash=eth1_block_hash, deposit_count=len(deposits)),
         latest_block_header=BeaconBlockHeader(body_root=hash_tree_root(BeaconBlockBody())),
+        randao_mixes=[eth1_block_hash] * EPOCHS_PER_HISTORICAL_VECTOR,  # to limit deposit order bias in early epochs
     )
-    # Set the initial RANDAO mixes to hashes seeded by the Eth1 hash, to limit deposit ordering committee bias.
-    for i in range(MIN_SEED_LOOKAHEAD + 1):
-        state.randao_mixes[EPOCHS_PER_HISTORICAL_VECTOR - i - 1] = hash(eth1_block_hash + int_to_bytes(i, 8))
 
     # Process deposits
     leaves = list(map(lambda deposit: deposit.data, deposits))

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1112,7 +1112,7 @@ def initialize_beacon_state_from_eth1(eth1_block_hash: Hash,
         genesis_time=eth1_timestamp - eth1_timestamp % SECONDS_PER_DAY + 2 * SECONDS_PER_DAY,
         eth1_data=Eth1Data(block_hash=eth1_block_hash, deposit_count=len(deposits)),
         latest_block_header=BeaconBlockHeader(body_root=hash_tree_root(BeaconBlockBody())),
-        randao_mixes=[eth1_block_hash] * EPOCHS_PER_HISTORICAL_VECTOR,  # to limit deposit order bias in early epochs
+        randao_mixes=[eth1_block_hash] * EPOCHS_PER_HISTORICAL_VECTOR,  # Seed RANDAO with Eth1 entropy
     )
 
     # Process deposits

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1113,6 +1113,9 @@ def initialize_beacon_state_from_eth1(eth1_block_hash: Hash,
         eth1_data=Eth1Data(block_hash=eth1_block_hash, deposit_count=len(deposits)),
         latest_block_header=BeaconBlockHeader(body_root=hash_tree_root(BeaconBlockBody())),
     )
+    # Set the initial RANDAO mixes to hashes seeded by the Eth1 hash, to limit deposit ordering committee bias.
+    for i in range(MIN_SEED_LOOKAHEAD + 1):
+        state.randao_mixes[EPOCHS_PER_HISTORICAL_VECTOR - i - 1] = hash(eth1_block_hash + int_to_bytes(i, 8))
 
     # Process deposits
     leaves = list(map(lambda deposit: deposit.data, deposits))

--- a/test_libs/pyspec/eth2spec/test/helpers/genesis.py
+++ b/test_libs/pyspec/eth2spec/test/helpers/genesis.py
@@ -29,12 +29,8 @@ def create_genesis_state(spec, num_validators):
             block_hash=eth1_block_hash,
         ),
         latest_block_header=spec.BeaconBlockHeader(body_root=spec.hash_tree_root(spec.BeaconBlockBody())),
+        randao_mixes=[eth1_block_hash] * spec.EPOCHS_PER_HISTORICAL_VECTOR,
     )
-
-    # Set the initial RANDAO mixes to hashes seeded by the Eth1 hash, to limit deposit ordering committee bias.
-    for i in range(spec.MIN_SEED_LOOKAHEAD + 1):
-        state.randao_mixes[spec.EPOCHS_PER_HISTORICAL_VECTOR - i - 1] = \
-            spec.hash(eth1_block_hash + spec.int_to_bytes(i, 8))
 
     # We "hack" in the initial validators,
     #  as it is much faster than creating and processing genesis deposits for every single test case.

--- a/test_libs/pyspec/eth2spec/test/sanity/test_blocks.py
+++ b/test_libs/pyspec/eth2spec/test/sanity/test_blocks.py
@@ -509,6 +509,8 @@ def test_eth1_data_votes_no_consensus(spec, state):
     if spec.SLOTS_PER_ETH1_VOTING_PERIOD > 16:
         return
 
+    pre_eth1_hash = state.eth1_data.block_hash
+
     offset_block = build_empty_block(spec, state, slot=spec.SLOTS_PER_ETH1_VOTING_PERIOD - 1)
     sign_block(spec, state, offset_block)
     state_transition_and_sign_block(spec, state, offset_block)
@@ -528,7 +530,7 @@ def test_eth1_data_votes_no_consensus(spec, state):
         blocks.append(block)
 
     assert len(state.eth1_data_votes) == spec.SLOTS_PER_ETH1_VOTING_PERIOD
-    assert state.eth1_data.block_hash == b'\x00' * 32
+    assert state.eth1_data.block_hash == pre_eth1_hash
 
     yield 'blocks', blocks
     yield 'post', state


### PR DESCRIPTION
First of all, I am very aware that the use of block hashes does not provide great randomness.

However, the concern was that the selection of committees of the early epochs could realistically be biased by deposit ordering manipulation. Setting some initial randomness, even if biasable by a few bits, should help work around this attack vector.
This solution came out of a conversation between @paulhauner and @djrtwo in #1446, but I am open to any better alternatives.

Also note that I adapted it to:
1. Fill randao mixes based on the `LOOKAHEAD` constant
2. Use the eth1 hash ~~as seed, and set different randao mixes.~~

Alternatively we could also fill the whole mixes array with seeded hashes: no concern about exact `LOOKAHEAD` value, but much more work (mainnet history size = `2**16`). Or we do not care about different mixes, and copy over the eth1 hash.

Edit: not as seed, just plain copy, and into the full extent of the randao-mixes (less error prone, more minimal). Thanks to Justin for pointing out that `get_seed` already mixes in the epoch, for us to not care about duplicate randao mixes here, just what we need.
