### PR TITLE
fix ruemel.yaml dependency issue

### DIFF
--- a/test_libs/gen_helpers/requirements.txt
+++ b/test_libs/gen_helpers/requirements.txt
@@ -1,2 +1,2 @@
-ruamel.yaml==0.15.96
+ruamel.yaml==0.16.5
 eth-utils==1.6.0

--- a/test_libs/gen_helpers/setup.py
+++ b/test_libs/gen_helpers/setup.py
@@ -4,7 +4,7 @@ setup(
     name='gen_helpers',
     packages=['gen_base', 'gen_from_tests'],
     install_requires=[
-        "ruamel.yaml==0.15.96",
+        "ruamel.yaml==0.16.5",
         "eth-utils==1.6.0"
     ]
 )


### PR DESCRIPTION
Bump version number on ruemel.yaml for `gen_helpers`. The disparity between this and other packages showed up when running generators for v0.9.0 