### PR TITLE
period_tail in get_eth1_vote

### DIFF
--- a/specs/validator/0_beacon-chain-validator.md
+++ b/specs/validator/0_beacon-chain-validator.md
@@ -239,8 +239,8 @@ def get_eth1_vote(state: BeaconState, previous_eth1_distance: uint64) -> Eth1Dat
     all_eth1_data = [get_eth1_data(distance) for distance in range(ETH1_FOLLOW_DISTANCE, previous_eth1_distance)]
 
     valid_votes = []
-    for slot, vote in enumerate(state.eth1_data_votes):
-        period_tail = slot % SLOTS_PER_ETH1_VOTING_PERIOD >= integer_squareroot(SLOTS_PER_ETH1_VOTING_PERIOD)
+    for i, vote in enumerate(state.eth1_data_votes):
+        period_tail = i < integer_squareroot(SLOTS_PER_ETH1_VOTING_PERIOD)
         if vote in new_eth1_data or (period_tail and vote in all_eth1_data):
             valid_votes.append(vote)
 


### PR DESCRIPTION
The change I have suggested targets [`get_eth1_vote()`](https://github.com/ethereum/eth2.0-specs/blob/v0.8.4/specs/validator/0_beacon-chain-validator.md#eth1-data) and is the result of the following 3 (potentially incorrect) observations:  

1. `slot` seems a misleading variable name for indexing `state.eth1_data_votes`.
1. `slot % SLOTS_PER_ETH1_VOTING_PERIOD` when `len(state.eth1_data_votes) <= SLOTS_PER_ETH1_VOTING_PERIOD` is a no-op.
1. I assume the `period_tail` is designed to validate _earlier_ `eth1_data_votes` if they are in `all_eth1_data` (but not in `new_eth1_data`). However, when `period_tail = slot >= integer_squareroot(...)`, only _later_ `eth1_data_votes` are tested against `all_eth1_data`.
