### PR TITLE
Bounce attack resistance

### DIFF
--- a/configs/mainnet.yaml
+++ b/configs/mainnet.yaml
@@ -23,6 +23,11 @@ MIN_GENESIS_ACTIVE_VALIDATOR_COUNT: 65536
 MIN_GENESIS_TIME: 1578009600
 
 
+# Fork Choice
+# ---------------------------------------------------------------
+# 2**3 (= 8)
+SAFE_SLOTS_TO_UPDATE_JUSTIFIED: 8
+
 
 # Deposit contract
 # ---------------------------------------------------------------

--- a/configs/minimal.yaml
+++ b/configs/minimal.yaml
@@ -21,6 +21,12 @@ MIN_GENESIS_ACTIVE_VALIDATOR_COUNT: 64
 # Jan 3, 2020
 MIN_GENESIS_TIME: 1578009600
 
+#
+#
+# Fork Choice
+# ---------------------------------------------------------------
+# 2**1 (= 1)
+SAFE_SLOTS_TO_UPDATE_JUSTIFIED: 2
 
 
 # Deposit contract

--- a/specs/core/0_fork-choice.md
+++ b/specs/core/0_fork-choice.md
@@ -47,7 +47,7 @@ The head block root associated with a `store` is defined as `get_head(store)`. A
 
 | Name | Value | Unit | Duration |
 | - | - | :-: | :-: |
-| `SAFE_SLOTS_TO_UPDATE_JUSTIFIED` | `2**3 (= 8)` | slots | 96 seconds |
+| `SAFE_SLOTS_TO_UPDATE_JUSTIFIED` | `2**3` (= 8) | slots | 96 seconds |
 
 ### Helpers
 

--- a/specs/core/0_fork-choice.md
+++ b/specs/core/0_fork-choice.md
@@ -148,8 +148,6 @@ def get_head(store: Store) -> Hash:
 
 ```python
 def should_update_justified_checkpoint(store: Store, justified_checkpoint: Checkpoint) -> bool:
-    current_epoch = compute_epoch_at_slot(get_current_slot(store))
-
     if get_current_slot(store) % SLOTS_PER_EPOCH < SAFE_SLOTS_TO_UPDATE_JUSTIFIED:
         return True
 

--- a/specs/core/0_fork-choice.md
+++ b/specs/core/0_fork-choice.md
@@ -96,9 +96,18 @@ def get_genesis_store(genesis_state: BeaconState) -> Store:
     )
 ```
 
+#### `get_current_slot`
+
 ```python
 def get_current_slot(store: Store) -> Slot:
     return Slot((store.time - store.genesis_time) // SECONDS_PER_SLOT)
+```
+
+#### `compute_slots_since_epoch_start`
+
+```python
+def compute_slots_since_epoch_start(slot: Slot) -> int:
+    return slot - compute_start_slot_at_epoch(compute_epoch_at_slot(slot))
 ```
 
 #### `get_ancestor`
@@ -149,7 +158,7 @@ def get_head(store: Store) -> Hash:
 
 ```python
 def should_update_justified_checkpoint(store: Store, new_justified_checkpoint: Checkpoint) -> bool:
-    if get_current_slot(store) % SLOTS_PER_EPOCH < SAFE_SLOTS_TO_UPDATE_JUSTIFIED:
+    if compute_slots_since_epoch_start(get_current_slot(store)) < SAFE_SLOTS_TO_UPDATE_JUSTIFIED:
         return True
 
     new_justified_block = store.blocks[new_justified_checkpoint.root]

--- a/specs/core/0_fork-choice.md
+++ b/specs/core/0_fork-choice.md
@@ -47,7 +47,7 @@ The head block root associated with a `store` is defined as `get_head(store)`. A
 
 | Name | Value | Unit | Duration |
 | - | - | :-: | :-: |
-| `SAFE_SLOTS_TO_UPDATE_JUSTIFIED` | `9` | slots | 108 seconds |
+| `SAFE_SLOTS_TO_UPDATE_JUSTIFIED` | `2**3 (= 8)` | slots | 96 seconds |
 
 ### Helpers
 
@@ -174,14 +174,15 @@ def on_tick(store: Store, time: uint64) -> None:
     store.time = time
 
     current_slot = get_current_slot(store)
-    # not a new epoch, return
+    # Not a new epoch, return
     if not (current_slot > previous_slot and current_slot % SLOTS_PER_EPOCH == 0):
         return
-    # if new epoch and there are queued_justified_checkpoints, update if any is better than the best in store
+    # If new epoch and there are queued_justified_checkpoints, update if any is better than the best in store
     if any(store.queued_justified_checkpoints):
         best_justified_checkpoint = max(store.queued_justified_checkpoints, key=lambda checkpoint: checkpoint.epoch)
         if best_justified_checkpoint.epoch > store.justified_checkpoint.epoch:
             store.justified_checkpoint = best_justified_checkpoint
+    store.queued_justified_checkpoints = []
 ```
 
 #### `on_block`

--- a/specs/core/0_fork-choice.md
+++ b/specs/core/0_fork-choice.md
@@ -150,7 +150,7 @@ def get_head(store: Store) -> Hash:
 def should_update_justified_checkpoint(store: Store, justified_checkpoint: Checkpoint) -> bool:
     current_epoch = compute_epoch_at_slot(get_current_slot(store))
 
-    if get_current_slot(store) - compute_start_slot_at_epoch(current_epoch) < SAFE_SLOTS_TO_UPDATE_JUSTIFIED:
+    if get_current_slot(store) % SLOTS_PER_EPOCH < SAFE_SLOTS_TO_UPDATE_JUSTIFIED:
         return True
 
     justified_block = store.blocks[justified_checkpoint.root]

--- a/test_libs/pyspec/eth2spec/test/fork_choice/test_on_block.py
+++ b/test_libs/pyspec/eth2spec/test/fork_choice/test_on_block.py
@@ -202,4 +202,4 @@ def test_on_block_outside_safe_slots_and_old_block(spec, state):
     run_on_block(spec, store, block)
 
     assert store.justified_checkpoint != new_justified
-    assert store.queued_justified_checkpoints[0] == new_justified
+    assert store.best_justified_checkpoint == new_justified

--- a/test_libs/pyspec/eth2spec/test/fork_choice/test_on_block.py
+++ b/test_libs/pyspec/eth2spec/test/fork_choice/test_on_block.py
@@ -132,3 +132,74 @@ def test_on_block_before_finalized(spec, state):
     block = build_empty_block_for_next_slot(spec, state)
     state_transition_and_sign_block(spec, state, block)
     run_on_block(spec, store, block, False)
+
+
+@with_all_phases
+@spec_state_test
+def test_on_block_update_justified_checkpoint_within_safe_slots(spec, state):
+    # Initialization
+    store = spec.get_genesis_store(state)
+    time = 100
+    spec.on_tick(store, time)
+
+    next_epoch(spec, state)
+    spec.on_tick(store, store.time + state.slot * spec.SECONDS_PER_SLOT)
+    state, store, last_block = apply_next_epoch_with_attestations(spec, state, store)
+    next_epoch(spec, state)
+    spec.on_tick(store, store.time + state.slot * spec.SECONDS_PER_SLOT)
+    last_block_root = signing_root(last_block)
+
+    # Mock the justified checkpoint
+    just_state = store.block_states[last_block_root]
+    new_justified = spec.Checkpoint(
+        epoch=just_state.current_justified_checkpoint.epoch + 1,
+        root=b'\x77' * 32,
+    )
+    just_state.current_justified_checkpoint = new_justified
+
+    block = build_empty_block_for_next_slot(spec, just_state)
+    state_transition_and_sign_block(spec, deepcopy(just_state), block)
+    assert spec.get_current_slot(store) % spec.SLOTS_PER_EPOCH < spec.SAFE_SLOTS_TO_UPDATE_JUSTIFIED
+    run_on_block(spec, store, block)
+
+    assert store.justified_checkpoint == new_justified
+
+
+@with_all_phases
+@spec_state_test
+def test_on_block_outside_safe_slots_and_old_block(spec, state):
+    # Initialization
+    store = spec.get_genesis_store(state)
+    time = 100
+    spec.on_tick(store, time)
+
+    next_epoch(spec, state)
+    spec.on_tick(store, store.time + state.slot * spec.SECONDS_PER_SLOT)
+    state, store, last_block = apply_next_epoch_with_attestations(spec, state, store)
+    next_epoch(spec, state)
+    spec.on_tick(store, store.time + state.slot * spec.SECONDS_PER_SLOT)
+    last_block_root = signing_root(last_block)
+
+    # Mock justified block in store
+    just_block = build_empty_block_for_next_slot(spec, state)
+    # Slot is same as justified checkpoint so does not trigger an override in the store
+    just_block.slot = spec.compute_start_slot_at_epoch(store.justified_checkpoint.epoch)
+    store.blocks[just_block.hash_tree_root()] = just_block
+
+    # Mock the justified checkpoint
+    just_state = store.block_states[last_block_root]
+    new_justified = spec.Checkpoint(
+        epoch=just_state.current_justified_checkpoint.epoch + 1,
+        root=just_block.hash_tree_root(),
+    )
+    just_state.current_justified_checkpoint = new_justified
+
+    block = build_empty_block_for_next_slot(spec, just_state)
+    state_transition_and_sign_block(spec, deepcopy(just_state), block)
+
+    spec.on_tick(store, store.time + spec.SAFE_SLOTS_TO_UPDATE_JUSTIFIED * spec.SECONDS_PER_SLOT)
+    assert spec.get_current_slot(store) % spec.SLOTS_PER_EPOCH >= spec.SAFE_SLOTS_TO_UPDATE_JUSTIFIED
+    run_on_block(spec, store, block)
+
+    assert store.justified_checkpoint != new_justified
+    assert store.queued_justified_checkpoints[0] == new_justified

--- a/test_libs/pyspec/eth2spec/test/fork_choice/test_on_tick.py
+++ b/test_libs/pyspec/eth2spec/test/fork_choice/test_on_tick.py
@@ -1,0 +1,72 @@
+from eth2spec.test.context import with_all_phases, spec_state_test
+
+
+def run_on_tick(spec, store, time, new_justified_checkpoint=None):
+    previous_justified_checkpoint = store.justified_checkpoint
+
+    spec.on_tick(store, time)
+
+    assert store.time == time
+
+    if new_justified_checkpoint:
+        assert store.justified_checkpoint == new_justified_checkpoint
+        assert store.justified_checkpoint.epoch > previous_justified_checkpoint.epoch
+    else:
+        assert store.justified_checkpoint == previous_justified_checkpoint
+
+
+@with_all_phases
+@spec_state_test
+def test_basic(spec, state):
+    store = spec.get_genesis_store(state)
+    run_on_tick(spec, store, store.time + 1)
+
+
+@with_all_phases
+@spec_state_test
+def test_update_justified_single(spec, state):
+    store = spec.get_genesis_store(state)
+    seconds_per_epoch = spec.SECONDS_PER_SLOT * spec.SLOTS_PER_EPOCH
+
+    new_justified = spec.Checkpoint(
+        epoch=store.justified_checkpoint.epoch + 1,
+        root=b'\x55' * 32,
+    )
+
+    store.queued_justified_checkpoints.append(new_justified)
+
+    run_on_tick(spec, store, store.time + seconds_per_epoch, new_justified)
+
+
+@with_all_phases
+@spec_state_test
+def test_update_justified_multiple(spec, state):
+    store = spec.get_genesis_store(state)
+    seconds_per_epoch = spec.SECONDS_PER_SLOT * spec.SLOTS_PER_EPOCH
+
+    new_justified = None  # remember checkpoint with latest epoch
+    for i in range(3):
+        new_justified = spec.Checkpoint(
+            epoch=store.justified_checkpoint.epoch + i + 1,
+            root=i.to_bytes(1, byteorder='big') * 32,
+        )
+        store.queued_justified_checkpoints.append(new_justified)
+
+    run_on_tick(spec, store, store.time + seconds_per_epoch, new_justified)
+
+
+@with_all_phases
+@spec_state_test
+def test_no_update_(spec, state):
+    store = spec.get_genesis_store(state)
+    seconds_per_epoch = spec.SECONDS_PER_SLOT * spec.SLOTS_PER_EPOCH
+
+    new_justified = spec.Checkpoint(
+        epoch=store.justified_checkpoint.epoch + 1,
+        root=b'\x55' * 32,
+    )
+
+    store.queued_justified_checkpoints.append(new_justified)
+
+    run_on_tick(spec, store, store.time + seconds_per_epoch, new_justified)
+

--- a/test_libs/pyspec/eth2spec/test/fork_choice/test_on_tick.py
+++ b/test_libs/pyspec/eth2spec/test/fork_choice/test_on_tick.py
@@ -1,7 +1,7 @@
 from eth2spec.test.context import with_all_phases, spec_state_test
 
 
-def run_on_tick(spec, store, time, new_justified_checkpoint=None):
+def run_on_tick(spec, store, time, new_justified_checkpoint=False):
     previous_justified_checkpoint = store.justified_checkpoint
 
     spec.on_tick(store, time)
@@ -9,8 +9,9 @@ def run_on_tick(spec, store, time, new_justified_checkpoint=None):
     assert store.time == time
 
     if new_justified_checkpoint:
-        assert store.justified_checkpoint == new_justified_checkpoint
+        assert store.justified_checkpoint == store.best_justified_checkpoint
         assert store.justified_checkpoint.epoch > previous_justified_checkpoint.epoch
+        assert store.justified_checkpoint.root != previous_justified_checkpoint.root
     else:
         assert store.justified_checkpoint == previous_justified_checkpoint
 
@@ -28,30 +29,12 @@ def test_update_justified_single(spec, state):
     store = spec.get_genesis_store(state)
     seconds_per_epoch = spec.SECONDS_PER_SLOT * spec.SLOTS_PER_EPOCH
 
-    new_justified = spec.Checkpoint(
+    store.best_justified_checkpoint = spec.Checkpoint(
         epoch=store.justified_checkpoint.epoch + 1,
         root=b'\x55' * 32,
     )
-    store.queued_justified_checkpoints.append(new_justified)
 
-    run_on_tick(spec, store, store.time + seconds_per_epoch, new_justified)
-
-
-@with_all_phases
-@spec_state_test
-def test_update_justified_multiple(spec, state):
-    store = spec.get_genesis_store(state)
-    seconds_per_epoch = spec.SECONDS_PER_SLOT * spec.SLOTS_PER_EPOCH
-
-    new_justified = None  # remember checkpoint with latest epoch
-    for i in range(3):
-        new_justified = spec.Checkpoint(
-            epoch=store.justified_checkpoint.epoch + i + 1,
-            root=i.to_bytes(1, byteorder='big') * 32,
-        )
-        store.queued_justified_checkpoints.append(new_justified)
-
-    run_on_tick(spec, store, store.time + seconds_per_epoch, new_justified)
+    run_on_tick(spec, store, store.time + seconds_per_epoch, True)
 
 
 @with_all_phases
@@ -60,11 +43,10 @@ def test_no_update_same_slot_at_epoch_boundary(spec, state):
     store = spec.get_genesis_store(state)
     seconds_per_epoch = spec.SECONDS_PER_SLOT * spec.SLOTS_PER_EPOCH
 
-    new_justified = spec.Checkpoint(
+    store.best_justified_checkpoint = spec.Checkpoint(
         epoch=store.justified_checkpoint.epoch + 1,
         root=b'\x55' * 32,
     )
-    store.queued_justified_checkpoints.append(new_justified)
 
     # set store time to already be at epoch boundary
     store.time = seconds_per_epoch
@@ -77,11 +59,10 @@ def test_no_update_same_slot_at_epoch_boundary(spec, state):
 def test_no_update_not_epoch_boundary(spec, state):
     store = spec.get_genesis_store(state)
 
-    new_justified = spec.Checkpoint(
+    store.best_justified_checkpoint = spec.Checkpoint(
         epoch=store.justified_checkpoint.epoch + 1,
         root=b'\x55' * 32,
     )
-    store.queued_justified_checkpoints.append(new_justified)
 
     run_on_tick(spec, store, store.time + spec.SECONDS_PER_SLOT)
 
@@ -92,14 +73,13 @@ def test_no_update_new_justified_equal_epoch(spec, state):
     store = spec.get_genesis_store(state)
     seconds_per_epoch = spec.SECONDS_PER_SLOT * spec.SLOTS_PER_EPOCH
 
-    new_justified = spec.Checkpoint(
+    store.best_justified_checkpoint = spec.Checkpoint(
         epoch=store.justified_checkpoint.epoch + 1,
         root=b'\x55' * 32,
     )
-    store.queued_justified_checkpoints.append(new_justified)
 
     store.justified_checkpoint = spec.Checkpoint(
-        epoch=new_justified.epoch,
+        epoch=store.best_justified_checkpoint.epoch,
         root=b'\44' * 32,
     )
 
@@ -112,14 +92,13 @@ def test_no_update_new_justified_later_epoch(spec, state):
     store = spec.get_genesis_store(state)
     seconds_per_epoch = spec.SECONDS_PER_SLOT * spec.SLOTS_PER_EPOCH
 
-    new_justified = spec.Checkpoint(
+    store.best_justified_checkpoint = spec.Checkpoint(
         epoch=store.justified_checkpoint.epoch + 1,
         root=b'\x55' * 32,
     )
-    store.queued_justified_checkpoints.append(new_justified)
 
     store.justified_checkpoint = spec.Checkpoint(
-        epoch=new_justified.epoch + 1,
+        epoch=store.best_justified_checkpoint.epoch + 1,
         root=b'\44' * 32,
     )
 


### PR DESCRIPTION
Only allow updates to the latest justified for fork choice if within the first `SAFE_SLOTS_TO_UPDATE_JUSTIFIED` slots of an epoch _or_ if the new justified does not conflict with the previous. If a new justified is learned about but doesn't satisfy these constraints, queue it up for consideration at next epoch boundary.

This addresses the bouncing attack discussed [here](https://ethresear.ch/t/prevention-of-bouncing-attack-on-ffg/6114).

Testing justification and finalization in the fork choice is painful and needs to be reconsidered