### PR TITLE
Decoy flip flop resistance

### DIFF
--- a/specs/core/0_fork-choice.md
+++ b/specs/core/0_fork-choice.md
@@ -224,6 +224,9 @@ def on_block(store: Store, block: BeaconBlock) -> None:
 def on_attestation(store: Store, attestation: Attestation) -> None:
     target = attestation.data.target
 
+    # Attestations must be from the current or previous epoch
+    current_epoch = compute_epoch_at_slot(get_current_slot(store))
+    assert target.epoch in [current_epoch, current_epoch - 1 if current_epoch > GENESIS_EPOCH else GENESIS_EPOCH]
     # Cannot calculate the current shuffling if have not seen the target
     assert target.root in store.blocks
 

--- a/specs/core/0_fork-choice.md
+++ b/specs/core/0_fork-choice.md
@@ -233,9 +233,11 @@ def on_block(store: Store, block: BeaconBlock) -> None:
 def on_attestation(store: Store, attestation: Attestation) -> None:
     target = attestation.data.target
 
-    # Attestations must be from the current or previous epoch
+    # Attestations must be from the current or previous epoch 
     current_epoch = compute_epoch_at_slot(get_current_slot(store))
-    assert target.epoch in [current_epoch, current_epoch - 1 if current_epoch > GENESIS_EPOCH else GENESIS_EPOCH]
+    # Use GENESIS_EPOCH for previous when genesis to avoid underflow
+    previous_epoch = current_epoch - 1 if current_epoch > GENESIS_EPOCH else GENESIS_EPOCH
+    assert target.epoch in [current_epoch, previous_epoch]
     # Cannot calculate the current shuffling if have not seen the target
     assert target.root in store.blocks
 

--- a/specs/validator/0_beacon-chain-validator.md
+++ b/specs/validator/0_beacon-chain-validator.md
@@ -291,6 +291,8 @@ A validator is expected to create, sign, and broadcast an attestation during eac
 
 A validator should create and broadcast the `attestation` to the associated attestation subnet one-third of the way through the `slot` during which the validator is assigned―that is, `SECONDS_PER_SLOT / 3` seconds after the start of `slot`.
 
+*Note*: Although attestations during `GENESIS_EPOCH` do not count toward FFG finality, these initial attestations do give weight to the fork choice, are rewarded fork, and should be made.
+
 #### Attestation data
 
 First, the validator should construct `attestation_data`, an [`AttestationData`](../core/0_beacon-chain.md#attestationdata) object based upon the state at the assigned slot.


### PR DESCRIPTION
Integrate FMD GHOST into the fork choice rule to prevent "decoy flip flop attacks" discussed [here](https://ethresear.ch/t/decoy-flip-flop-attack-on-lmd-ghost/6001).

* Only consider an `attestation` in `on_attestation` if it is from the current or previous epoch (wrt wall clock time).
* add a few tests

Note: this currently has `bounce-attack` as base branch for easy review. Will swap to `v09x` once `bounce-attack` is merged