### PR TITLE
Fix period tail in get_eth1_vote

### DIFF
--- a/specs/validator/0_beacon-chain-validator.md
+++ b/specs/validator/0_beacon-chain-validator.md
@@ -236,11 +236,13 @@ def get_eth1_vote(state: BeaconState, previous_eth1_distance: uint64) -> Eth1Dat
     new_eth1_data = [get_eth1_data(distance) for distance in range(ETH1_FOLLOW_DISTANCE, 2 * ETH1_FOLLOW_DISTANCE)]
     all_eth1_data = [get_eth1_data(distance) for distance in range(ETH1_FOLLOW_DISTANCE, previous_eth1_distance)]
 
-    valid_votes = []
-    for slot, vote in enumerate(state.eth1_data_votes):
-        period_tail = slot % SLOTS_PER_ETH1_VOTING_PERIOD >= integer_squareroot(SLOTS_PER_ETH1_VOTING_PERIOD)
-        if vote in new_eth1_data or (period_tail and vote in all_eth1_data):
-            valid_votes.append(vote)
+    period_tail = state.slot % SLOTS_PER_ETH1_VOTING_PERIOD >= integer_squareroot(SLOTS_PER_ETH1_VOTING_PERIOD)
+    if period_tail:
+        votes_to_consider = all_eth1_data
+    else:
+        votes_to_consider = new_eth1_data
+
+    valid_votes = [vote for vote in state.eth1_data_votes if vote in votes_to_consider]
 
     return max(
         valid_votes,


### PR DESCRIPTION
This is a cleanup of `get_eth1_vote` inspired by @paulhauner's PR #1463 and subsequent conversation.

The previous version was incorrectly assuming that there was an `eth1_data_vote` per slot, but this is not the case when 100% of proposers don't get blocks into the chain. Instead the period tail should be based upon the actual slot.

This PR simplifies the logic so that in the early slots of a voting period, you only consider `new_eth1_data` when deciding your vote, but in the period tail to encourage settling on a vote, you consider `all_eth1_data`.