### PR TITLE
Forkchoice mods

### DIFF
--- a/specs/core/0_fork-choice.md
+++ b/specs/core/0_fork-choice.md
@@ -238,6 +238,12 @@ def on_block(store: Store, block: BeaconBlock) -> None:
 
 ```python
 def on_attestation(store: Store, attestation: Attestation) -> None:
+    """
+    Run ``on_attestation`` upon receiving a new ``attestation`` from either within a block or directly on the wire.
+
+    An ``attestation`` that is asserted as invalid may be valid at a later time,
+    consider scheduling it for later processing in such case.
+    """
     target = attestation.data.target
 
     # Attestations must be from the current or previous epoch 

--- a/specs/core/0_fork-choice.md
+++ b/specs/core/0_fork-choice.md
@@ -248,9 +248,16 @@ def on_attestation(store: Store, attestation: Attestation) -> None:
     # Cannot calculate the current shuffling if have not seen the target
     assert target.root in store.blocks
 
+    # Attestations target be for a known block. If target block is unknown, delay consideration until the block is found
+    assert target.root in store.blocks
     # Attestations cannot be from future epochs. If they are, delay consideration until the epoch arrives
     base_state = store.block_states[target.root].copy()
     assert store.time >= base_state.genesis_time + compute_start_slot_at_epoch(target.epoch) * SECONDS_PER_SLOT
+
+    # Attestations must be for a known block. If block is unknown, delay consideration until the block is found
+    assert attestation.data.beacon_block_root in store.blocks
+    # Attestations must not be for blocks in the future. If not, the attestation should not be considered
+    assert store.blocks[attestation.data.beacon_block_root].slot <= attestation.data.slot
 
     # Store target checkpoint state if not yet seen
     if target not in store.checkpoint_states:

--- a/test_libs/pyspec/eth2spec/test/helpers/state.py
+++ b/test_libs/pyspec/eth2spec/test/helpers/state.py
@@ -14,6 +14,16 @@ def next_slot(spec, state):
     spec.process_slots(state, state.slot + 1)
 
 
+def transition_to(spec, state, slot):
+    """
+    Transition to ``slot``.
+    """
+    assert state.slot <= slot
+    for _ in range(slot - state.slot):
+        next_slot(spec, state)
+    assert state.slot == slot
+
+
 def next_epoch(spec, state):
     """
     Transition to the start slot of the next epoch


### PR DESCRIPTION
* Ensure `attestation.data.target.root` is known
* Ensure `attestation.data.beacon_block_root` is known
* Do not allow attestations to vote for blocks from future slots (#1406)
