### PR TITLE
Avoid Hash <> hash() type and func confusion

### DIFF
--- a/scripts/build_spec.py
+++ b/scripts/build_spec.py
@@ -79,26 +79,26 @@ def ceillog2(x: uint64) -> int:
 SUNDRY_FUNCTIONS = '''
 # Monkey patch hash cache
 _hash = hash
-hash_cache: Dict[bytes, Hash] = {}
+hash_cache: Dict[bytes, Bytes32] = {}
 
 
-def get_eth1_data(distance: uint64) -> Hash:
+def get_eth1_data(distance: uint64) -> Bytes32:
     return hash(distance)
 
 
-def hash(x: bytes) -> Hash:
+def hash(x: bytes) -> Bytes32:
     if x not in hash_cache:
-        hash_cache[x] = Hash(_hash(x))
+        hash_cache[x] = Bytes32(_hash(x))
     return hash_cache[x]
 
 
 # Monkey patch validator compute committee code
 _compute_committee = compute_committee
-committee_cache: Dict[Tuple[Hash, Hash, int, int], Sequence[ValidatorIndex]] = {}
+committee_cache: Dict[Tuple[Bytes32, Bytes32, int, int], Sequence[ValidatorIndex]] = {}
 
 
 def compute_committee(indices: Sequence[ValidatorIndex],  # type: ignore
-                      seed: Hash,
+                      seed: Bytes32,
                       index: int,
                       count: int) -> Sequence[ValidatorIndex]:
     param_hash = (hash(b''.join(index.to_bytes(length=4, byteorder='little') for index in indices)), seed, index, count)
@@ -210,7 +210,7 @@ def combine_constants(old_constants: Dict[str, str], new_constants: Dict[str, st
 
 
 ignored_dependencies = [
-    'bit', 'boolean', 'Vector', 'List', 'Container', 'Hash', 'BLSPubkey', 'BLSSignature', 'Bytes', 'BytesN'
+    'bit', 'boolean', 'Vector', 'List', 'Container', 'Root', 'BLSPubkey', 'BLSSignature', 'Bytes', 'BytesN'
     'Bytes1', 'Bytes4', 'Bytes32', 'Bytes48', 'Bytes96', 'Bitlist', 'Bitvector',
     'uint8', 'uint16', 'uint32', 'uint64', 'uint128', 'uint256',
     'bytes', 'byte', 'BytesN'  # to be removed after updating spec doc

--- a/specs/core/0_fork-choice.md
+++ b/specs/core/0_fork-choice.md
@@ -57,7 +57,7 @@ The head block root associated with a `store` is defined as `get_head(store)`. A
 @dataclass(eq=True, frozen=True)
 class LatestMessage(object):
     epoch: Epoch
-    root: Hash
+    root: Root
 ```
 
 #### `Store`
@@ -70,8 +70,8 @@ class Store(object):
     justified_checkpoint: Checkpoint
     finalized_checkpoint: Checkpoint
     best_justified_checkpoint: Checkpoint
-    blocks: Dict[Hash, BeaconBlock] = field(default_factory=dict)
-    block_states: Dict[Hash, BeaconState] = field(default_factory=dict)
+    blocks: Dict[Root, BeaconBlock] = field(default_factory=dict)
+    block_states: Dict[Root, BeaconState] = field(default_factory=dict)
     checkpoint_states: Dict[Checkpoint, BeaconState] = field(default_factory=dict)
     latest_messages: Dict[ValidatorIndex, LatestMessage] = field(default_factory=dict)
 ```
@@ -113,7 +113,7 @@ def compute_slots_since_epoch_start(slot: Slot) -> int:
 #### `get_ancestor`
 
 ```python
-def get_ancestor(store: Store, root: Hash, slot: Slot) -> Hash:
+def get_ancestor(store: Store, root: Root, slot: Slot) -> Root:
     block = store.blocks[root]
     if block.slot > slot:
         return get_ancestor(store, block.parent_root, slot)
@@ -126,7 +126,7 @@ def get_ancestor(store: Store, root: Hash, slot: Slot) -> Hash:
 #### `get_latest_attesting_balance`
 
 ```python
-def get_latest_attesting_balance(store: Store, root: Hash) -> Gwei:
+def get_latest_attesting_balance(store: Store, root: Root) -> Gwei:
     state = store.checkpoint_states[store.justified_checkpoint]
     active_indices = get_active_validator_indices(state, get_current_epoch(state))
     return Gwei(sum(
@@ -139,7 +139,7 @@ def get_latest_attesting_balance(store: Store, root: Hash) -> Gwei:
 #### `get_head`
 
 ```python
-def get_head(store: Store) -> Hash:
+def get_head(store: Store) -> Root:
     # Execute the LMD-GHOST fork choice
     head = store.justified_checkpoint.root
     justified_slot = compute_start_slot_at_epoch(store.justified_checkpoint.epoch)

--- a/specs/core/1_beacon-chain-misc.md
+++ b/specs/core/1_beacon-chain-misc.md
@@ -62,7 +62,7 @@ class ShardReceiptDelta(Container):
 ```python
 class ShardReceiptProof(Container):
     shard: Shard
-    proof: List[Hash, PLACEHOLDER]
+    proof: List[Bytes32, PLACEHOLDER]
     receipt: List[ShardReceiptDelta, PLACEHOLDER]
 ```
 
@@ -109,7 +109,7 @@ def committee_to_compact_committee(state: BeaconState, committee: Sequence[Valid
 #### `verify_merkle_proof`
 
 ```python
-def verify_merkle_proof(leaf: Hash, proof: Sequence[Hash], index: GeneralizedIndex, root: Hash) -> bool:
+def verify_merkle_proof(leaf: Bytes32, proof: Sequence[Bytes32], index: GeneralizedIndex, root: Root) -> bool:
     assert len(proof) == get_generalized_index_length(index)
     for i, h in enumerate(proof):
         if get_generalized_index_bit(index, i):
@@ -199,7 +199,7 @@ Add the following fields to the end of the specified container objects.
 ```python
 class BeaconState(Container):
     # Period committees
-    period_committee_roots: Vector[Hash, PERIOD_COMMITTEE_ROOT_LENGTH]
+    period_committee_roots: Vector[Root, PERIOD_COMMITTEE_ROOT_LENGTH]
     next_shard_receipt_period: Vector[uint64, SHARD_COUNT]
 ```
 

--- a/specs/core/1_custody-game.md
+++ b/specs/core/1_custody-game.md
@@ -170,7 +170,7 @@ class CustodyChunkChallengeRecord(Container):
     challenger_index: ValidatorIndex
     responder_index: ValidatorIndex
     inclusion_epoch: Epoch
-    data_root: Hash
+    data_root: Root
     depth: uint64
     chunk_index: uint64
 ```
@@ -183,9 +183,9 @@ class CustodyBitChallengeRecord(Container):
     challenger_index: ValidatorIndex
     responder_index: ValidatorIndex
     inclusion_epoch: Epoch
-    data_root: Hash
+    data_root: Root
     chunk_count: uint64
-    chunk_bits_merkle_root: Hash
+    chunk_bits_merkle_root: Root
     responder_key: BLSSignature
 ```
 
@@ -196,8 +196,8 @@ class CustodyResponse(Container):
     challenge_index: uint64
     chunk_index: uint64
     chunk: BytesN[BYTES_PER_CUSTODY_CHUNK]
-    data_branch: List[Hash, CUSTODY_DATA_DEPTH]
-    chunk_bits_branch: List[Hash, CUSTODY_CHUNK_BIT_DEPTH]
+    data_branch: List[Bytes32, CUSTODY_DATA_DEPTH]
+    chunk_bits_branch: List[Bytes32, CUSTODY_CHUNK_BIT_DEPTH]
     chunk_bits_leaf: Bitvector[256]
 ```
 
@@ -228,7 +228,7 @@ class EarlyDerivedSecretReveal(Container):
     # Index of the validator who revealed (whistleblower)
     masker_index: ValidatorIndex
     # Mask used to hide the actual reveal signature (prevent reveal from being stolen)
-    mask: Hash
+    mask: Bytes32
 ```
 
 ### Phase 0 container updates
@@ -283,11 +283,11 @@ def ceillog2(x: uint64) -> int:
 ### `is_valid_merkle_branch_with_mixin`
 
 ```python
-def is_valid_merkle_branch_with_mixin(leaf: Hash,
-                                      branch: Sequence[Hash],
+def is_valid_merkle_branch_with_mixin(leaf: Bytes32,
+                                      branch: Sequence[Bytes32],
                                       depth: uint64,
                                       index: uint64,
-                                      root: Hash,
+                                      root: Root,
                                       mixin: uint64) -> bool:
     value = leaf
     for i in range(depth):
@@ -672,7 +672,7 @@ def process_chunk_challenge_response(state: BeaconState,
     # Verify chunk index
     assert response.chunk_index == challenge.chunk_index
     # Verify bit challenge data is null
-    assert response.chunk_bits_branch == [] and response.chunk_bits_leaf == Hash()
+    assert response.chunk_bits_branch == [] and response.chunk_bits_leaf == Bytes32()
     # Verify minimum delay
     assert get_current_epoch(state) >= challenge.inclusion_epoch + MAX_SEED_LOOKAHEAD
     # Verify the chunk matches the crosslink data root

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -118,9 +118,9 @@ class Crosslink(Container):
 class ShardBlock(Container):
     shard: Shard
     slot: ShardSlot
-    beacon_block_root: Hash
-    parent_root: Hash
-    state_root: Hash
+    beacon_block_root: Root
+    parent_root: Root
+    state_root: Root
     body: List[byte, MAX_SHARD_BLOCK_SIZE - SHARD_HEADER_SIZE]
     block_size_sum: uint64
     aggregation_bits: Bitvector[2 * MAX_PERIOD_COMMITTEE_SIZE]
@@ -134,10 +134,10 @@ class ShardBlock(Container):
 class ShardBlockHeader(Container):
     shard: Shard
     slot: ShardSlot
-    beacon_block_root: Hash
-    parent_root: Hash
-    state_root: Hash
-    body_root: Hash
+    beacon_block_root: Root
+    parent_root: Root
+    state_root: Root
+    body_root: Root
     block_size_sum: uint64
     aggregation_bits: Bitvector[2 * MAX_PERIOD_COMMITTEE_SIZE]
     attestations: BLSSignature
@@ -150,7 +150,7 @@ class ShardBlockHeader(Container):
 class ShardState(Container):
     shard: Shard
     slot: ShardSlot
-    history_accumulator: Vector[Hash, HISTORY_ACCUMULATOR_DEPTH]
+    history_accumulator: Vector[Bytes32, HISTORY_ACCUMULATOR_DEPTH]
     latest_block_header: ShardBlockHeader
     block_size_sum: uint64
     # Fees and rewards
@@ -166,7 +166,7 @@ class ShardState(Container):
 ```python
 class ShardAttestationData(Container):
     slot: ShardSlot
-    parent_root: Hash
+    parent_root: Root
 ```
 
 ## Helper functions

--- a/specs/light_client/merkle_proofs.md
+++ b/specs/light_client/merkle_proofs.md
@@ -59,9 +59,9 @@ In a binary Merkle tree, we define a "generalized index" of a node as `2**depth 
 Note that the generalized index has the convenient property that the two children of node `k` are `2k` and `2k+1`, and also that it equals the position of a node in the linear representation of the Merkle tree that's computed by this function:
 
 ```python
-def merkle_tree(leaves: Sequence[Hash]) -> Sequence[Hash]:
+def merkle_tree(leaves: Sequence[Bytes32]) -> Sequence[Bytes32]:
     padded_length = get_next_power_of_two(len(leaves))
-    o = [Hash()] * padded_length + list(leaves) + [Hash()] * (padded_length - len(leaves))
+    o = [Bytes32()] * padded_length + list(leaves) + [Bytes32()] * (padded_length - len(leaves))
     for i in range(padded_length - 1, 0, -1):
         o[i] = hash(o[i * 2] + o[i * 2 + 1])
     return o
@@ -289,7 +289,7 @@ def get_helper_indices(indices: Sequence[GeneralizedIndex]) -> Sequence[Generali
 Now we provide the Merkle proof verification functions. First, for single item proofs:
 
 ```python
-def calculate_merkle_root(leaf: Hash, proof: Sequence[Hash], index: GeneralizedIndex) -> Hash:
+def calculate_merkle_root(leaf: Bytes32, proof: Sequence[Bytes32], index: GeneralizedIndex) -> Root:
     assert len(proof) == get_generalized_index_length(index)
     for i, h in enumerate(proof):
         if get_generalized_index_bit(index, i):
@@ -300,16 +300,16 @@ def calculate_merkle_root(leaf: Hash, proof: Sequence[Hash], index: GeneralizedI
 ```
 
 ```python
-def verify_merkle_proof(leaf: Hash, proof: Sequence[Hash], index: GeneralizedIndex, root: Hash) -> bool:
+def verify_merkle_proof(leaf: Bytes32, proof: Sequence[Bytes32], index: GeneralizedIndex, root: Root) -> bool:
     return calculate_merkle_root(leaf, proof, index) == root
 ```
 
 Now for multi-item proofs:
 
 ```python
-def calculate_multi_merkle_root(leaves: Sequence[Hash],
-                                proof: Sequence[Hash],
-                                indices: Sequence[GeneralizedIndex]) -> Hash:
+def calculate_multi_merkle_root(leaves: Sequence[Bytes32],
+                                proof: Sequence[Bytes32],
+                                indices: Sequence[GeneralizedIndex]) -> Root:
     assert len(leaves) == len(indices)
     helper_indices = get_helper_indices(indices)
     assert len(proof) == len(helper_indices)
@@ -332,10 +332,10 @@ def calculate_multi_merkle_root(leaves: Sequence[Hash],
 ```
 
 ```python
-def verify_merkle_multiproof(leaves: Sequence[Hash],
-                             proof: Sequence[Hash],
+def verify_merkle_multiproof(leaves: Sequence[Bytes32],
+                             proof: Sequence[Bytes32],
                              indices: Sequence[GeneralizedIndex],
-                             root: Hash) -> bool:
+                             root: Root) -> bool:
     return calculate_multi_merkle_root(leaves, proof, indices) == root
 ```
 

--- a/specs/light_client/sync_protocol.md
+++ b/specs/light_client/sync_protocol.md
@@ -49,16 +49,16 @@ We define the following Python custom types for type hinting and readability:
 ```python
 class LightClientUpdate(container):
     # Shard block root (and authenticating signature data)
-    shard_block_root: Hash
+    shard_block_root: Root
     fork_version: Version
     aggregation_bits: Bitlist[MAX_VALIDATORS_PER_COMMITTEE]
     signature: BLSSignature
     # Updated beacon header (and authenticating branch)
     header: BeaconBlockHeader
-    header_branch: Vector[Hash, BEACON_CHAIN_ROOT_IN_SHARD_BLOCK_HEADER_DEPTH]
+    header_branch: Vector[Bytes32, BEACON_CHAIN_ROOT_IN_SHARD_BLOCK_HEADER_DEPTH]
     # Updated period committee (and authenticating branch)
     committee: CompactCommittee
-    committee_branch: Vector[Hash, PERIOD_COMMITTEE_ROOT_IN_BEACON_STATE_DEPTH + log_2(SHARD_COUNT)]
+    committee_branch: Vector[Bytes32, PERIOD_COMMITTEE_ROOT_IN_BEACON_STATE_DEPTH + log_2(SHARD_COUNT)]
 ```
 
 ## Helpers

--- a/test_libs/pyspec/eth2spec/test/helpers/block.py
+++ b/test_libs/pyspec/eth2spec/test/helpers/block.py
@@ -59,7 +59,7 @@ def build_empty_block(spec, state, slot=None, signed=False):
     empty_block.slot = slot
     empty_block.body.eth1_data.deposit_count = state.eth1_deposit_index
     previous_block_header = deepcopy(state.latest_block_header)
-    if previous_block_header.state_root == spec.Hash():
+    if previous_block_header.state_root == spec.Root():
         previous_block_header.state_root = state.hash_tree_root()
     empty_block.parent_root = signing_root(previous_block_header)
 

--- a/test_libs/pyspec/eth2spec/test/phase_0/block_processing/test_process_deposit.py
+++ b/test_libs/pyspec/eth2spec/test/phase_0/block_processing/test_process_deposit.py
@@ -195,7 +195,7 @@ def test_bad_merkle_proof(spec, state):
     deposit = prepare_state_and_deposit(spec, state, validator_index, amount)
 
     # mess up merkle branch
-    deposit.proof[5] = spec.Hash()
+    deposit.proof[5] = spec.Bytes32()
 
     sign_deposit_data(spec, deposit.data, privkeys[validator_index], state=state)
 

--- a/test_libs/pyspec/eth2spec/test/sanity/test_blocks.py
+++ b/test_libs/pyspec/eth2spec/test/sanity/test_blocks.py
@@ -63,7 +63,7 @@ def test_empty_block_transition(spec, state):
 
     assert len(state.eth1_data_votes) == pre_eth1_votes + 1
     assert spec.get_block_root_at_slot(state, pre_slot) == block.parent_root
-    assert spec.get_randao_mix(state, spec.get_current_epoch(state)) != spec.Root()
+    assert spec.get_randao_mix(state, spec.get_current_epoch(state)) != spec.Bytes32()
 
 
 @with_all_phases

--- a/test_libs/pyspec/eth2spec/test/sanity/test_blocks.py
+++ b/test_libs/pyspec/eth2spec/test/sanity/test_blocks.py
@@ -63,7 +63,7 @@ def test_empty_block_transition(spec, state):
 
     assert len(state.eth1_data_votes) == pre_eth1_votes + 1
     assert spec.get_block_root_at_slot(state, pre_slot) == block.parent_root
-    assert spec.get_randao_mix(state, spec.get_current_epoch(state)) != spec.Hash()
+    assert spec.get_randao_mix(state, spec.get_current_epoch(state)) != spec.Root()
 
 
 @with_all_phases
@@ -98,7 +98,7 @@ def test_skipped_slots(spec, state):
     yield 'post', state
 
     assert state.slot == block.slot
-    assert spec.get_randao_mix(state, spec.get_current_epoch(state)) != spec.Hash()
+    assert spec.get_randao_mix(state, spec.get_current_epoch(state)) != spec.Bytes32()
     for slot in range(pre_slot, state.slot):
         assert spec.get_block_root_at_slot(state, slot) == block.parent_root
 

--- a/test_libs/pyspec/eth2spec/utils/ssz/test_ssz_typing.py
+++ b/test_libs/pyspec/eth2spec/utils/ssz/test_ssz_typing.py
@@ -208,13 +208,13 @@ def test_bytesn_subclass():
     assert issubclass(BytesN[32](b'\xab' * 32).type(), Bytes32)
     assert issubclass(BytesN[32], Bytes32)
 
-    class Hash(Bytes32):
+    class Root(Bytes32):
         pass
 
-    assert isinstance(Hash(b'\xab' * 32), Bytes32)
-    assert not isinstance(Hash(b'\xab' * 32), Bytes48)
-    assert issubclass(Hash(b'\xab' * 32).type(), Bytes32)
-    assert issubclass(Hash, Bytes32)
+    assert isinstance(Root(b'\xab' * 32), Bytes32)
+    assert not isinstance(Root(b'\xab' * 32), Bytes48)
+    assert issubclass(Root(b'\xab' * 32).type(), Bytes32)
+    assert issubclass(Root, Bytes32)
 
     assert not issubclass(Bytes48, Bytes32)
 


### PR DESCRIPTION
Why:
- `hash()` is the SHA-256 of empty input. `Hash()` is the default instantiation of the `Bytes32` alias, i.e. 32 zeroed bytes.
- `Hash(*input*)` casts the input to the `Bytes32` alias (not changing the contents!). Whereas `hash(*input*)` hashes the input to a `Hash` (with SHA-256).

Changelog (no functional changes):
- remove `Hash` alias of `Bytes32`
- introduce `Root` alias of `Bytes32`
- change roots to `Root`
- change non-roots to `Bytes32`

Difficult choices:
- a `Bytes32` inside a proof is technically also a combination of nodes. But not necessarily so for the very bottom sibling. So not a `Root` or `Hash`
  - Also, `Hash` is especially confusing, as a leaf item is packed into 32 bytes but not hashed.
- There are a bunch of hashes that are not SSZ roots that we start calling `Bytes32` now:
  - Eth1 block hash
  - Randao mix / seeds
  - `withdrawal_credentials`

I am opposed to making a separation between `SigningRoot` and `HashRoot`: the roots should be typed by the (summary) type they represent, not the function that is used.

`signing_root` already is a hack to make the same object definition work for multiple purposes. But really signatures shouldn't be part of the tree, unless intended so. A SSZ type simply cannot be represented by the same immutable cached (each node) tree, covering both signing-root and hash-tree-root, as the tree structure is dfifferent.
And since we are using `signing_root` and `hash_tree_root` pretty much exclusively, I would prefer to just do away with `signing_root`. Maybe in favor of a way to represent a container with a signature as a serialization-only thing.

Open for suggestions/comments.