### PR TITLE
Minor refactor aggregation strategy

### DIFF
--- a/specs/networking/p2p-interface.md
+++ b/specs/networking/p2p-interface.md
@@ -174,9 +174,9 @@ There are two primary global topics used to propagate beacon blocks and aggregat
     - The aggregate attestation defined by `hash_tree_root(aggregate_and_proof.aggregate)` has _not_ already been seen (via aggregate gossip, within a block, or through the creation of an equivalent aggregate locally).
     - The block being voted for (`aggregate_and_proof.aggregate.data.beacon_block_root`) passes validation.
     - `aggregate_and_proof.aggregate.data.slot` is within the last `ATTESTATION_PROPAGATION_SLOT_RANGE` slots (`aggregate_and_proof.aggregate.data.slot + ATTESTATION_PROPAGATION_SLOT_RANGE >= current_slot >= aggregate_and_proof.aggregate.data.slot`).
-    - The validator index is within the aggregate's committee -- i.e. `aggregate_and_proof.index in get_attesting_indices(state, aggregate_and_proof.aggregate.data, aggregate_and_proof.aggregate.aggregation_bits)`.
+    - The validator index is within the aggregate's committee -- i.e. `aggregate_and_proof.aggregator_index in get_attesting_indices(state, aggregate_and_proof.aggregate.data, aggregate_and_proof.aggregate.aggregation_bits)`.
     - `aggregate_and_proof.selection_proof` selects the validator as an aggregator for the slot -- i.e. `is_aggregator(state, aggregate_and_proof.aggregate.data.index, aggregate_and_proof.selection_proof)` returns `True`.
-    - The `aggregate_and_proof.selection_proof` is a valid signature of the `aggregate_and_proof.aggregate.data.slot` by the validator with index `aggregate_and_proof.index`.
+    - The `aggregate_and_proof.selection_proof` is a valid signature of the `aggregate_and_proof.aggregate.data.slot` by the validator with index `aggregate_and_proof.aggregator_index`.
     - The signature of `aggregate_and_proof.aggregate` is valid.
 
 Additional global topics are used to propagate lower frequency validator messages. Their `TopicName`s are:

--- a/specs/validator/0_beacon-chain-validator.md
+++ b/specs/validator/0_beacon-chain-validator.md
@@ -365,7 +365,7 @@ Some validators are selected to locally aggregate attestations with a similar `a
 A validator is selected to aggregate based upon the return value of `is_aggregator()`.
 
 ```python
-def slot_signature(state: BeaconState, slot: Slot, privkey: int) -> BLSSignature:
+def get_slot_signature(state: BeaconState, slot: Slot, privkey: int) -> BLSSignature:
     domain = get_domain(state, DOMAIN_BEACON_ATTESTER, compute_epoch_at_slot(slot))
     return bls_sign(privkey, hash_tree_root(slot), domain)
 ```
@@ -411,15 +411,15 @@ Aggregate attestations are broadcast as `AggregateAndProof` objects to prove to 
 
 ```python
 class AggregateAndProof(Container):
-    index: ValidatorIndex
-    selection_proof: BLSSignature
+    aggregator_index: ValidatorIndex
     aggregate: Attestation
+    selection_proof: BLSSignature
 ```
 
 Where
-* `index` is the validator's `validator_index`.
-* `selection_proof` is the signature of the slot (`slot_signature()`).
+* `aggregator_index` is the validator's `ValidatorIndex`.
 * `aggregate` is the `aggregate_attestation` constructed in the previous section.
+* `selection_proof` is the signature of the slot (`get_slot_signature()`).
 
 ## Phase 0 attestation subnet stability
 


### PR DESCRIPTION
1. Update `AggregateAndProof` and 
    1. Reorder the fields to fit the container name
    2. Rename `AggregateAndProof.index: ValidatorIndex` to `AggregateAndProof.aggregator_index: ValidatorIndex`
        - Resonale: we have similar naming style like
`ProposerSlashing.proposer_index` or `VoluntaryExit.validator_index`
3. Rename `slot_signature` to `get_slot_signature`.