### PR TITLE
ensure that epoch of attestation slot matches the target epoch

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1482,6 +1482,7 @@ def process_attestation(state: BeaconState, attestation: Attestation) -> None:
     data = attestation.data
     assert data.index < get_committee_count_at_slot(state, data.slot)
     assert data.target.epoch in (get_previous_epoch(state), get_current_epoch(state))
+    assert data.target.epoch == compute_epoch_at_slot(data.slot)
     assert data.slot + MIN_ATTESTATION_INCLUSION_DELAY <= state.slot <= data.slot + SLOTS_PER_EPOCH
 
     committee = get_beacon_committee(state, data.slot, data.index)

--- a/specs/core/0_fork-choice.md
+++ b/specs/core/0_fork-choice.md
@@ -307,6 +307,7 @@ def on_attestation(store: Store, attestation: Attestation) -> None:
     # Use GENESIS_EPOCH for previous when genesis to avoid underflow
     previous_epoch = current_epoch - 1 if current_epoch > GENESIS_EPOCH else GENESIS_EPOCH
     assert target.epoch in [current_epoch, previous_epoch]
+    assert target.epoch == compute_epoch_at_slot(attestation.data.slot)
 
     # Attestations target be for a known block. If target block is unknown, delay consideration until the block is found
     assert target.root in store.blocks

--- a/test_libs/pyspec/eth2spec/test/phase_0/block_processing/test_process_attestation.py
+++ b/test_libs/pyspec/eth2spec/test/phase_0/block_processing/test_process_attestation.py
@@ -179,6 +179,20 @@ def test_invalid_index(spec, state):
 
 @with_all_phases
 @spec_state_test
+def test_mismatched_target_and_slot(spec, state):
+    next_epoch(spec, state)
+    next_epoch(spec, state)
+
+    attestation = get_valid_attestation(spec, state)
+    attestation.data.slot = attestation.data.slot - spec.SLOTS_PER_EPOCH
+
+    sign_attestation(spec, state, attestation)
+
+    yield from run_attestation_processing(spec, state, attestation, False)
+
+
+@with_all_phases
+@spec_state_test
 def test_old_target_epoch(spec, state):
     assert spec.MIN_ATTESTATION_INCLUSION_DELAY < spec.SLOTS_PER_EPOCH * 2
 


### PR DESCRIPTION
Addresses #1501

Adds a couple of asserts to ensure the attestation's slot matches the attestations target epoch.

