### PR TITLE
fix queue efficiency bug

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1311,17 +1311,16 @@ def process_registry_updates(state: BeaconState) -> None:
         if is_active_validator(validator, get_current_epoch(state)) and validator.effective_balance <= EJECTION_BALANCE:
             initiate_validator_exit(state, ValidatorIndex(index))
 
-    # Queue validators eligible for activation and not dequeued for activation prior to finalized epoch
+    # Queue validators eligible for activation and not yet dequeued for activation prior
     activation_queue = sorted([
         index for index, validator in enumerate(state.validators)
         if validator.activation_eligibility_epoch != FAR_FUTURE_EPOCH
-        and validator.activation_epoch >= compute_activation_exit_epoch(state.finalized_checkpoint.epoch)
+        and validator.activation_epoch == FAR_FUTURE_EPOCH
     ], key=lambda index: state.validators[index].activation_eligibility_epoch)
-    # Dequeued validators for activation up to churn limit (without resetting activation epoch)
+    # Dequeued validators for activation up to churn limit
     for index in activation_queue[:get_validator_churn_limit(state)]:
         validator = state.validators[index]
-        if validator.activation_epoch == FAR_FUTURE_EPOCH:
-            validator.activation_epoch = compute_activation_exit_epoch(get_current_epoch(state))
+        validator.activation_epoch = compute_activation_exit_epoch(get_current_epoch(state))
 ```
 
 #### Slashings

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1311,7 +1311,7 @@ def process_registry_updates(state: BeaconState) -> None:
         if is_active_validator(validator, get_current_epoch(state)) and validator.effective_balance <= EJECTION_BALANCE:
             initiate_validator_exit(state, ValidatorIndex(index))
 
-    # Queue validators eligible for activation and not yet dequeued for activation prior
+    # Queue validators eligible for activation and not yet dequeued for activation
     activation_queue = sorted([
         index for index, validator in enumerate(state.validators)
         if validator.activation_eligibility_epoch != FAR_FUTURE_EPOCH


### PR DESCRIPTION
addresses #1511 

After digging around, I am 95% sure that this captures the original intent of the queue and also resolves the issue found in #1511. My main concern was if activations should be delayed wrt finality conditions, but I (1) found no historic evidence of this in the discussion and (2) have done due diligence in reasoning about it and confirm that the behavior specified now is safe and intended.

The behavior in this PR actually represents the original coded behavior before a series of small tweaks were made.

For (1), the comment "not dequeued for activation prior to finalized epoch" appears to show that there is an intended behavior in rate limiting wrt finality, but this comment was actually added after-the-fact as descriptive of the behavior of the code, not as an original comment describing the intended behavior of the system.