### PR TITLE
Fix queue rate and only activate upon finality

### DIFF
--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1311,17 +1311,16 @@ def process_registry_updates(state: BeaconState) -> None:
         if is_active_validator(validator, get_current_epoch(state)) and validator.effective_balance <= EJECTION_BALANCE:
             initiate_validator_exit(state, ValidatorIndex(index))
 
-    # Queue validators eligible for activation and not dequeued for activation prior to finalized epoch
+    # Queue validators eligible for activation and not yet dequeued for activation prior
     activation_queue = sorted([
         index for index, validator in enumerate(state.validators)
         if validator.activation_eligibility_epoch != FAR_FUTURE_EPOCH
-        and validator.activation_epoch >= compute_activation_exit_epoch(state.finalized_checkpoint.epoch)
+        and validator.activation_epoch == FAR_FUTURE_EPOCH
     ], key=lambda index: state.validators[index].activation_eligibility_epoch)
-    # Dequeued validators for activation up to churn limit (without resetting activation epoch)
+    # Dequeued validators for activation up to churn limit
     for index in activation_queue[:get_validator_churn_limit(state)]:
         validator = state.validators[index]
-        if validator.activation_epoch == FAR_FUTURE_EPOCH:
-            validator.activation_epoch = compute_activation_exit_epoch(get_current_epoch(state))
+        validator.activation_epoch = compute_activation_exit_epoch(get_current_epoch(state))
 ```
 
 #### Slashings

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -601,6 +601,20 @@ def is_slashable_validator(validator: Validator, epoch: Epoch) -> bool:
     return (not validator.slashed) and (validator.activation_epoch <= epoch < validator.withdrawable_epoch)
 ```
 
+#### `is_eligible_for_activation_queue`
+
+```python
+def is_eligible_for_activation_queue(validator: Validator) -> bool:
+    """
+    Check if ``validator`` is eligible to be placed into the activation queue.
+    """
+    return (
+        validator.activation_eligibility_epoch == FAR_FUTURE_EPOCH
+        and validator.effective_balance == MAX_EFFECTIVE_BALANCE
+    )
+```
+
+
 #### `is_eligible_for_activation`
 
 ```python
@@ -1317,10 +1331,7 @@ def process_rewards_and_penalties(state: BeaconState) -> None:
 def process_registry_updates(state: BeaconState) -> None:
     # Process activation eligibility and ejections
     for index, validator in enumerate(state.validators):
-        if (
-            validator.activation_eligibility_epoch == FAR_FUTURE_EPOCH
-            and validator.effective_balance == MAX_EFFECTIVE_BALANCE
-        ):
+        if is_eligible_for_activation_queue(validator):
             validator.activation_eligibility_epoch = get_current_epoch(state)
 
         if is_active_validator(validator, get_current_epoch(state)) and validator.effective_balance <= EJECTION_BALANCE:

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -61,6 +61,8 @@
             - [`bls_aggregate_pubkeys`](#bls_aggregate_pubkeys)
         - [Predicates](#predicates)
             - [`is_active_validator`](#is_active_validator)
+            - [`is_eligible_for_activation_queue`](#is_eligible_for_activation_queue)
+            - [`is_eligible_for_activation`](#is_eligible_for_activation)
             - [`is_slashable_validator`](#is_slashable_validator)
             - [`is_slashable_attestation_data`](#is_slashable_attestation_data)
             - [`is_valid_indexed_attestation`](#is_valid_indexed_attestation)
@@ -591,16 +593,6 @@ def is_active_validator(validator: Validator, epoch: Epoch) -> bool:
     return validator.activation_epoch <= epoch < validator.exit_epoch
 ```
 
-#### `is_slashable_validator`
-
-```python
-def is_slashable_validator(validator: Validator, epoch: Epoch) -> bool:
-    """
-    Check if ``validator`` is slashable.
-    """
-    return (not validator.slashed) and (validator.activation_epoch <= epoch < validator.withdrawable_epoch)
-```
-
 #### `is_eligible_for_activation_queue`
 
 ```python
@@ -613,7 +605,6 @@ def is_eligible_for_activation_queue(validator: Validator) -> bool:
         and validator.effective_balance == MAX_EFFECTIVE_BALANCE
     )
 ```
-
 
 #### `is_eligible_for_activation`
 
@@ -628,6 +619,16 @@ def is_eligible_for_activation(state: BeaconState, validator: Validator) -> bool
         # Has not yet been activated
         and validator.activation_epoch == FAR_FUTURE_EPOCH
     )
+```
+
+#### `is_slashable_validator`
+
+```python
+def is_slashable_validator(validator: Validator, epoch: Epoch) -> bool:
+    """
+    Check if ``validator`` is slashable.
+    """
+    return (not validator.slashed) and (validator.activation_epoch <= epoch < validator.withdrawable_epoch)
 ```
 
 #### `is_slashable_attestation_data`

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1341,7 +1341,8 @@ def process_registry_updates(state: BeaconState) -> None:
     activation_queue = sorted([
         index for index, validator in enumerate(state.validators)
         if is_eligible_for_activation(state, validator)
-    ], key=lambda index: state.validators[index].activation_eligibility_epoch)
+    # Order by the sequence of activation_eligibility_epoch setting and then index.
+    ], key=lambda index: (state.validators[index].activation_eligibility_epoch, index))
     # Dequeued validators for activation up to churn limit
     for index in activation_queue[:get_validator_churn_limit(state)]:
         validator = state.validators[index]

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1311,7 +1311,7 @@ def process_registry_updates(state: BeaconState) -> None:
         if is_active_validator(validator, get_current_epoch(state)) and validator.effective_balance <= EJECTION_BALANCE:
             initiate_validator_exit(state, ValidatorIndex(index))
 
-    # Queue validators eligible for activation and not yet dequeued for activation prior
+    # Queue validators eligible for activation and not yet dequeued for activation
     activation_queue = sorted([
         index for index, validator in enumerate(state.validators)
         if validator.activation_eligibility_epoch != FAR_FUTURE_EPOCH

--- a/test_libs/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_registry_updates.py
+++ b/test_libs/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_registry_updates.py
@@ -1,4 +1,7 @@
-from eth2spec.test.helpers.state import next_epoch
+from eth2spec.test.helpers.state import (
+    next_epoch,
+    next_epoch_with_attestations,
+)
 from eth2spec.test.context import spec_state_test, with_all_phases
 from eth2spec.test.phase_0.epoch_processing.run_epoch_process_base import run_epoch_processing_with
 
@@ -17,18 +20,71 @@ def mock_deposit(spec, state, index):
 
 @with_all_phases
 @spec_state_test
-def test_activation(spec, state):
+def test_add_to_activation_queue(spec, state):
+    # move past first two irregular epochs wrt finality
+    next_epoch(spec, state)
+    next_epoch(spec, state)
+
     index = 0
     mock_deposit(spec, state, index)
 
-    for _ in range(spec.MAX_SEED_LOOKAHEAD + 1):
-        next_epoch(spec, state)
+    yield from run_process_registry_updates(spec, state)
+
+    # validator moved into queue
+    assert state.validators[index].activation_eligibility_epoch != spec.FAR_FUTURE_EPOCH
+    assert state.validators[index].activation_epoch == spec.FAR_FUTURE_EPOCH
+    assert not spec.is_active_validator(state.validators[index], spec.get_current_epoch(state))
+
+
+@with_all_phases
+@spec_state_test
+def test_activation_queue_to_activated_if_finalized(spec, state):
+    # move past first two irregular epochs wrt finality
+    next_epoch(spec, state)
+    next_epoch(spec, state)
+
+    index = 0
+    mock_deposit(spec, state, index)
+
+    # mock validator as having been in queue since before latest finalized
+    state.finalized_checkpoint.epoch = spec.get_current_epoch(state) - 1
+    state.validators[index].activation_eligibility_epoch = state.finalized_checkpoint.epoch - 1
+
+    assert not spec.is_active_validator(state.validators[index], spec.get_current_epoch(state))
 
     yield from run_process_registry_updates(spec, state)
 
+    # validator activated for future epoch
     assert state.validators[index].activation_eligibility_epoch != spec.FAR_FUTURE_EPOCH
     assert state.validators[index].activation_epoch != spec.FAR_FUTURE_EPOCH
-    assert spec.is_active_validator(state.validators[index], spec.get_current_epoch(state))
+    assert not spec.is_active_validator(state.validators[index], spec.get_current_epoch(state))
+    assert spec.is_active_validator(
+        state.validators[index],
+        spec.compute_activation_exit_epoch(spec.get_current_epoch(state))
+    )
+
+
+@with_all_phases
+@spec_state_test
+def test_activation_queue_no_activation_no_finality(spec, state):
+    # move past first two irregular epochs wrt finality
+    next_epoch(spec, state)
+    next_epoch(spec, state)
+
+    index = 0
+    mock_deposit(spec, state, index)
+
+    # mock validator as having been in queue only since latest finalized (not before)
+    state.finalized_checkpoint.epoch = spec.get_current_epoch(state) - 1
+    state.validators[index].activation_eligibility_epoch = state.finalized_checkpoint.epoch
+
+    assert not spec.is_active_validator(state.validators[index], spec.get_current_epoch(state))
+
+    yield from run_process_registry_updates(spec, state)
+
+    # validator not activated
+    assert state.validators[index].activation_eligibility_epoch != spec.FAR_FUTURE_EPOCH
+    assert state.validators[index].activation_epoch == spec.FAR_FUTURE_EPOCH
 
 
 @with_all_phases
@@ -43,6 +99,10 @@ def test_activation_queue_sorting(spec, state):
 
     # give the last priority over the others
     state.validators[mock_activations - 1].activation_eligibility_epoch = epoch
+
+    # move state forward and finalize to allow for activations
+    state.slot += spec.SLOTS_PER_EPOCH * 3
+    state.finalized_checkpoint.epoch = epoch + 2
 
     # make sure we are hitting the churn
     churn_limit = spec.get_validator_churn_limit(state)
@@ -74,6 +134,10 @@ def test_activation_queue_efficiency(spec, state):
         mock_deposit(spec, state, i)
         state.validators[i].activation_eligibility_epoch = epoch + 1
 
+    # move state forward and finalize to allow for activations
+    state.slot += spec.SLOTS_PER_EPOCH * 3
+    state.finalized_checkpoint.epoch = epoch + 2
+
     # Run first registry update. Do not yield test vectors
     for _ in run_process_registry_updates(spec, state):
         pass
@@ -101,13 +165,11 @@ def test_ejection(spec, state):
     # Mock an ejection
     state.validators[index].effective_balance = spec.EJECTION_BALANCE
 
-    for _ in range(spec.MAX_SEED_LOOKAHEAD + 1):
-        next_epoch(spec, state)
-
     yield from run_process_registry_updates(spec, state)
 
     assert state.validators[index].exit_epoch != spec.FAR_FUTURE_EPOCH
+    assert spec.is_active_validator(state.validators[index], spec.get_current_epoch(state))
     assert not spec.is_active_validator(
         state.validators[index],
-        spec.get_current_epoch(state),
+        spec.compute_activation_exit_epoch(spec.get_current_epoch(state))
     )

--- a/test_libs/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_registry_updates.py
+++ b/test_libs/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_registry_updates.py
@@ -43,9 +43,9 @@ def test_activation_queue_to_activated_if_finalized(spec, state):
     index = 0
     mock_deposit(spec, state, index)
 
-    # mock validator as having been in queue since before latest finalized
+    # mock validator as having been in queue since latest finalized
     state.finalized_checkpoint.epoch = spec.get_current_epoch(state) - 1
-    state.validators[index].activation_eligibility_epoch = state.finalized_checkpoint.epoch - 1
+    state.validators[index].activation_eligibility_epoch = state.finalized_checkpoint.epoch
 
     assert not spec.is_active_validator(state.validators[index], spec.get_current_epoch(state))
 
@@ -71,9 +71,9 @@ def test_activation_queue_no_activation_no_finality(spec, state):
     index = 0
     mock_deposit(spec, state, index)
 
-    # mock validator as having been in queue only since latest finalized (not before)
+    # mock validator as having been in queue only after latest finalized
     state.finalized_checkpoint.epoch = spec.get_current_epoch(state) - 1
-    state.validators[index].activation_eligibility_epoch = state.finalized_checkpoint.epoch
+    state.validators[index].activation_eligibility_epoch = state.finalized_checkpoint.epoch + 1
 
     assert not spec.is_active_validator(state.validators[index], spec.get_current_epoch(state))
 
@@ -102,7 +102,7 @@ def test_activation_queue_sorting(spec, state):
 
     # move state forward and finalize to allow for activations
     state.slot += spec.SLOTS_PER_EPOCH * 3
-    state.finalized_checkpoint.epoch = epoch + 2
+    state.finalized_checkpoint.epoch = epoch + 1
 
     yield from run_process_registry_updates(spec, state)
 
@@ -132,7 +132,7 @@ def test_activation_queue_efficiency(spec, state):
 
     # move state forward and finalize to allow for activations
     state.slot += spec.SLOTS_PER_EPOCH * 3
-    state.finalized_checkpoint.epoch = epoch + 2
+    state.finalized_checkpoint.epoch = epoch + 1
 
     # Run first registry update. Do not yield test vectors
     for _ in run_process_registry_updates(spec, state):
@@ -213,7 +213,7 @@ def test_activation_queue_activation_and_ejection(spec, state):
     activation_index = 1
     mock_deposit(spec, state, activation_index)
     state.finalized_checkpoint.epoch = spec.get_current_epoch(state) - 1
-    state.validators[activation_index].activation_eligibility_epoch = state.finalized_checkpoint.epoch - 1
+    state.validators[activation_index].activation_eligibility_epoch = state.finalized_checkpoint.epoch
 
     # ready for ejection
     ejection_index = 2


### PR DESCRIPTION
addresses #1511 as well as a previously uncaught bug allowing for activations when no finality

* ensures efficient processing of activation queue
* ensures activations only happen at finality
* adds a number of explicit tests for the activation queue
* enhances `process_registry_updates` testing in general
