### PR TITLE
update mypy to compile pyspec well with py 3.8.0, and minor mypy fix

### DIFF
--- a/scripts/build_spec.py
+++ b/scripts/build_spec.py
@@ -82,7 +82,7 @@ def get_eth1_data(distance: uint64) -> Bytes32:
     return hash(distance)
 
 
-def hash(x: bytes) -> Bytes32:
+def hash(x: bytes) -> Bytes32:  # type: ignore
     if x not in hash_cache:
         hash_cache[x] = Bytes32(_hash(x))
     return hash_cache[x]

--- a/test_libs/pyspec/requirements-testing.txt
+++ b/test_libs/pyspec/requirements-testing.txt
@@ -2,6 +2,6 @@
 pytest>=4.4
 ../config_helpers
 flake8==3.7.7
-mypy==0.701
+mypy==0.750
 pytest-cov
 pytest-xdist


### PR DESCRIPTION
As the title says, really small change to dependency, and to ignore the override of `hash`, to fix pyspec for testing with python 3.8. (previous mypy used an incompatible older ast package).