### PR TITLE
Two tests for proposer indices being off because of (in)active validators

### DIFF
--- a/test_libs/pyspec/eth2spec/test/sanity/test_blocks.py
+++ b/test_libs/pyspec/eth2spec/test/sanity/test_blocks.py
@@ -269,7 +269,7 @@ def test_proposer_after_inactive_index(spec, state):
             # found a proposer that has a higher index than a disabled validator
             yield 'pre', state
             # test if the proposer can be recognized correctly after the inactive validator
-            signed_block = sign_block(spec, state, build_empty_block(spec, state), proposer_index=proposer_index)
+            signed_block = state_transition_and_sign_block(spec, state, build_empty_block(spec, state))
             yield 'blocks', [signed_block]
             yield 'post', state
             break
@@ -295,7 +295,7 @@ def test_high_proposer_index(spec, state):
             # found a proposer that has a higher index than the active validator count
             yield 'pre', state
             # test if the proposer can be recognized correctly, even while it has a high index.
-            signed_block = sign_block(spec, state, build_empty_block(spec, state), proposer_index=proposer_index)
+            signed_block = state_transition_and_sign_block(spec, state, build_empty_block(spec, state))
             yield 'blocks', [signed_block]
             yield 'post', state
             break

--- a/test_libs/pyspec/eth2spec/test/sanity/test_blocks.py
+++ b/test_libs/pyspec/eth2spec/test/sanity/test_blocks.py
@@ -262,8 +262,11 @@ def test_proposer_after_inactive_index(spec, state):
 
     # skip forward, get brand new proposers
     state.slot = spec.SLOTS_PER_EPOCH * 2
+    block = build_empty_block_for_next_slot(spec, state)
+    state_transition_and_sign_block(spec, state, block)
 
     while True:
+        next_slot(spec, state)
         proposer_index = spec.get_beacon_proposer_index(state)
         if proposer_index > inactive_index:
             # found a proposer that has a higher index than a disabled validator
@@ -273,8 +276,6 @@ def test_proposer_after_inactive_index(spec, state):
             yield 'blocks', [signed_block]
             yield 'post', state
             break
-        else:
-            next_slot(spec, state)
 
 
 @with_all_phases
@@ -287,9 +288,12 @@ def test_high_proposer_index(spec, state):
 
     # skip forward, get brand new proposers
     state.slot = spec.SLOTS_PER_EPOCH * 2
+    block = build_empty_block_for_next_slot(spec, state)
+    state_transition_and_sign_block(spec, state, block)
 
     active_count = len(spec.get_active_validator_indices(state, current_epoch))
     while True:
+        next_slot(spec, state)
         proposer_index = spec.get_beacon_proposer_index(state)
         if proposer_index >= active_count:
             # found a proposer that has a higher index than the active validator count
@@ -299,8 +303,6 @@ def test_high_proposer_index(spec, state):
             yield 'blocks', [signed_block]
             yield 'post', state
             break
-        else:
-            next_slot(spec, state)
 
 
 @with_all_phases


### PR DESCRIPTION
fixes #1515

As described in the issue:
- test for a block with a proposer index higher than an inactive index
- test for a block with a proposer index higher than active validator count

Since we can't rely on the other tests, since transitions may not fully run and hit it, and the registry size is small enough that chances would be low for this kind of thing to happen.
