### PR TITLE
Content-address gossipsub messages

### DIFF
--- a/specs/networking/p2p-interface.md
+++ b/specs/networking/p2p-interface.md
@@ -212,6 +212,13 @@ Topics are plain UTF-8 strings and are encoded on the wire as determined by prot
 
 Each gossipsub [message](https://github.com/libp2p/go-libp2p-pubsub/blob/master/pb/rpc.proto#L17-L24) has a maximum size of `GOSSIP_MAX_SIZE`. Clients MUST reject (fail validation) messages that are over this size limit. Likewise, clients MUST NOT emit or propagate messages larger than this limit.
 
+The message-id of a gossipsub message MUST be:
+
+```python
+   message-id: base64(SHA256(message.data))
+```
+where `base64` is the [URL-safe base64 alphabet](https://tools.ietf.org/html/rfc4648#section-3.2) with padding characters omitted.
+
 The payload is carried in the `data` field of a gossipsub message, and varies depending on the topic:
 
 | Topic                                  | Message Type      |


### PR DESCRIPTION
## Description

Specifies that all gossipsub messages are identified as `base64(sha256(message.data))` which prevents duplicate messages (by content) from being received at the application layer. 

For our current purposes, there is no need to address messages based on source peer and by content-addressing we can filter unnecessary duplicates before hitting the application layer.

Some examples of where messages could be duplicated:
- A validator client connected to multiple beacon nodes publishing duplicate gossip messages
- Attestation aggregation strategy where clients partially aggregate attestations and propagate them. Partial aggregates could be duplicated.
- Clients re-publishing seen messages.

This closes #1528. 