### PR TITLE
Fix v093 tests: 2 pre-states missed, 1 unsigned block

### DIFF
--- a/test_libs/pyspec/eth2spec/test/sanity/test_blocks.py
+++ b/test_libs/pyspec/eth2spec/test/sanity/test_blocks.py
@@ -83,7 +83,7 @@ def test_invalid_state_root(spec, state):
 
     expect_assertion_error(lambda: spec.state_transition(state, signed_block))
 
-    yield 'blocks', [block]
+    yield 'blocks', [signed_block]
     yield 'post', None
 
 
@@ -91,6 +91,8 @@ def test_invalid_state_root(spec, state):
 @spec_state_test
 @always_bls
 def test_zero_block_sig(spec, state):
+    yield 'pre', state
+
     block = build_empty_block_for_next_slot(spec, state)
     invalid_signed_block = spec.SignedBeaconBlock(message=block)
     expect_assertion_error(lambda: spec.state_transition(state, invalid_signed_block))
@@ -103,6 +105,8 @@ def test_zero_block_sig(spec, state):
 @spec_state_test
 @always_bls
 def test_invalid_block_sig(spec, state):
+    yield 'pre', state
+
     block = build_empty_block_for_next_slot(spec, state)
     invalid_signed_block = spec.SignedBeaconBlock(
         message=block,


### PR DESCRIPTION
As the title says, small oversight in tests that only affects test-generation. With updating zrnt to v0.9.3 I can confirm that the others all work as intended.
