### PR TITLE
PySpec SSZ Bytes instantiated from hex string

### DIFF
--- a/scripts/build_spec.py
+++ b/scripts/build_spec.py
@@ -163,8 +163,6 @@ def objects_to_spec(functions: Dict[str, str],
             del functions[k]
     functions_spec = '\n\n'.join(functions.values())
     for k in list(constants.keys()):
-        if k.startswith('DOMAIN_'):
-            constants[k] = f"DomainType(({constants[k]}).to_bytes(length=4, byteorder='little'))"
         if k == "BLS12_381_Q":
             constants[k] += "  # noqa: E501"
     constants_spec = '\n'.join(map(lambda x: '%s = %s' % (x, constants[x]), constants))

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -251,11 +251,11 @@ The following values are (non-configurable) constants used throughout the specif
 
 | Name | Value |
 | - | - |
-| `DOMAIN_BEACON_PROPOSER` | `Bytes4('0x00000000')` |
-| `DOMAIN_BEACON_ATTESTER` | `Bytes4('0x01000000')` |
-| `DOMAIN_RANDAO` | `Bytes4('0x02000000')` |
-| `DOMAIN_DEPOSIT` | `Bytes4('0x03000000')` |
-| `DOMAIN_VOLUNTARY_EXIT` | `Bytes4('0x04000000')` |
+| `DOMAIN_BEACON_PROPOSER` | `DomainType('0x00000000')` |
+| `DOMAIN_BEACON_ATTESTER` | `DomainType('0x01000000')` |
+| `DOMAIN_RANDAO` | `DomainType('0x02000000')` |
+| `DOMAIN_DEPOSIT` | `DomainType('0x03000000')` |
+| `DOMAIN_VOLUNTARY_EXIT` | `DomainType('0x04000000')` |
 
 ## Containers
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -199,7 +199,7 @@ The following values are (non-configurable) constants used throughout the specif
 | - | - |
 | `GENESIS_SLOT` | `Slot(0)` |
 | `GENESIS_EPOCH` | `Epoch(0)` |
-| `BLS_WITHDRAWAL_PREFIX` | `Bytes1(b'\x00')` |
+| `BLS_WITHDRAWAL_PREFIX` | `Bytes1('0x00')` |
 
 ### Time parameters
 
@@ -249,15 +249,13 @@ The following values are (non-configurable) constants used throughout the specif
 
 ### Domain types
 
-The following types are defined, mapping into `DomainType` (little endian):
-
 | Name | Value |
 | - | - |
-| `DOMAIN_BEACON_PROPOSER` | `0` |
-| `DOMAIN_BEACON_ATTESTER` | `1` |
-| `DOMAIN_RANDAO` | `2` |
-| `DOMAIN_DEPOSIT` | `3` |
-| `DOMAIN_VOLUNTARY_EXIT` | `4` |
+| `DOMAIN_BEACON_PROPOSER` | `Bytes4('0x00000000')` |
+| `DOMAIN_BEACON_ATTESTER` | `Bytes4('0x01000000')` |
+| `DOMAIN_RANDAO` | `Bytes4('0x02000000')` |
+| `DOMAIN_DEPOSIT` | `Bytes4('0x03000000')` |
+| `DOMAIN_VOLUNTARY_EXIT` | `Bytes4('0x04000000')` |
 
 ## Containers
 

--- a/specs/core/1_custody-game.md
+++ b/specs/core/1_custody-game.md
@@ -131,7 +131,7 @@ The following types are defined, mapping into `DomainType` (little endian):
 
 | Name | Value |
 | - | - |
-| `DOMAIN_CUSTODY_BIT_CHALLENGE` | `Bytes4('0x06000000')` |
+| `DOMAIN_CUSTODY_BIT_CHALLENGE` | `DomainType('0x06000000')` |
 
 ### TODO PLACEHOLDER
 

--- a/specs/core/1_custody-game.md
+++ b/specs/core/1_custody-game.md
@@ -131,7 +131,7 @@ The following types are defined, mapping into `DomainType` (little endian):
 
 | Name | Value |
 | - | - |
-| `DOMAIN_CUSTODY_BIT_CHALLENGE` | `6` |
+| `DOMAIN_CUSTODY_BIT_CHALLENGE` | `Bytes4('0x06000000')` |
 
 ### TODO PLACEHOLDER
 

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -101,8 +101,8 @@ This document describes the shard transition function (data layer only) and the 
 
 | Name | Value |
 | - | - |
-| `DOMAIN_SHARD_PROPOSER` | `Bytes4('0x80000000')` |
-| `DOMAIN_SHARD_ATTESTER` | `Bytes4('0x81000000')` |
+| `DOMAIN_SHARD_PROPOSER` | `DomainType('0x80000000')` |
+| `DOMAIN_SHARD_ATTESTER` | `DomainType('0x81000000')` |
 
 ## Containers
 

--- a/specs/core/1_shard-data-chains.md
+++ b/specs/core/1_shard-data-chains.md
@@ -101,8 +101,8 @@ This document describes the shard transition function (data layer only) and the 
 
 | Name | Value |
 | - | - |
-| `DOMAIN_SHARD_PROPOSER` | `128` |
-| `DOMAIN_SHARD_ATTESTER` | `129` |
+| `DOMAIN_SHARD_PROPOSER` | `Bytes4('0x80000000')` |
+| `DOMAIN_SHARD_ATTESTER` | `Bytes4('0x81000000')` |
 
 ## Containers
 

--- a/test_libs/pyspec/eth2spec/utils/ssz/ssz_typing.py
+++ b/test_libs/pyspec/eth2spec/utils/ssz/ssz_typing.py
@@ -451,10 +451,15 @@ class BaseBytes(bytes, Elements, metaclass=BytesType):
     @classmethod
     def extract_args(cls, *args):
         x = args
-        if len(x) == 1 and isinstance(x[0], (GeneratorType, bytes)):
+        if len(x) == 1 and isinstance(x[0], (GeneratorType, bytes, str)):
             x = x[0]
         if isinstance(x, bytes):  # Includes BytesLike
             return x
+        if isinstance(x, str):
+            if x[:2] == '0x':
+                return bytes.fromhex(x[2:])
+            else:
+                return bytes.fromhex(x)
         else:
             return bytes(x)  # E.g. GeneratorType put into bytes.
 


### PR DESCRIPTION
This enables PySpec SSZ to instantiate Bytes from hex strings as input (both with and without leading `0x`). This removes some hackiness in the form of special cases from the spec builder. Bytes objects can then be created directly from octal strings without being exposed to python's ugly byte formatting.