### PR TITLE
Allow configuration of genesis fork version

### DIFF
--- a/configs/mainnet.yaml
+++ b/configs/mainnet.yaml
@@ -63,6 +63,8 @@ EFFECTIVE_BALANCE_INCREMENT: 1000000000
 # ---------------------------------------------------------------
 # 0, GENESIS_EPOCH is derived from this constant
 GENESIS_SLOT: 0
+# Mainnet initial fork version, recommend altering for testnets
+GENESIS_FORK_VERSION: 0x00000000
 BLS_WITHDRAWAL_PREFIX: 0x00
 
 

--- a/configs/minimal.yaml
+++ b/configs/minimal.yaml
@@ -63,6 +63,8 @@ EFFECTIVE_BALANCE_INCREMENT: 1000000000
 # ---------------------------------------------------------------
 # 0, GENESIS_EPOCH is derived from this constant
 GENESIS_SLOT: 0
+# Highest byte set to 0x01 to avoid collisions with mainnet versioning
+GENESIS_FORK_VERSION: 0x00000001
 BLS_WITHDRAWAL_PREFIX: 0x00
 
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -199,6 +199,7 @@ The following values are (non-configurable) constants used throughout the specif
 | - | - |
 | `GENESIS_SLOT` | `Slot(0)` |
 | `GENESIS_EPOCH` | `Epoch(0)` |
+| `GENESIS_FORK_VERSION` | `Version('0x00000000')` |
 | `BLS_WITHDRAWAL_PREFIX` | `Bytes1('0x00')` |
 
 ### Time parameters
@@ -780,7 +781,7 @@ def compute_activation_exit_epoch(epoch: Epoch) -> Epoch:
 #### `compute_domain`
 
 ```python
-def compute_domain(domain_type: DomainType, fork_version: Version=Version()) -> Domain:
+def compute_domain(domain_type: DomainType, fork_version: Version=GENESIS_FORK_VERSION) -> Domain:
     """
     Return the domain for the ``domain_type`` and ``fork_version``.
     """
@@ -1063,8 +1064,14 @@ Before the Ethereum 2.0 genesis has been triggered, and for every Ethereum 1.0 b
 def initialize_beacon_state_from_eth1(eth1_block_hash: Bytes32,
                                       eth1_timestamp: uint64,
                                       deposits: Sequence[Deposit]) -> BeaconState:
+    fork = Fork(
+        previous_version=GENESIS_FORK_VERSION,
+        current_version=GENESIS_FORK_VERSION,
+        epoch=GENESIS_EPOCH,
+    )
     state = BeaconState(
         genesis_time=eth1_timestamp - eth1_timestamp % SECONDS_PER_DAY + 2 * SECONDS_PER_DAY,
+        fork=fork,
         eth1_data=Eth1Data(block_hash=eth1_block_hash, deposit_count=len(deposits)),
         latest_block_header=BeaconBlockHeader(body_root=hash_tree_root(BeaconBlockBody())),
         randao_mixes=[eth1_block_hash] * EPOCHS_PER_HISTORICAL_VECTOR,  # Seed RANDAO with Eth1 entropy

--- a/specs/validator/0_beacon-chain-validator.md
+++ b/specs/validator/0_beacon-chain-validator.md
@@ -117,7 +117,7 @@ To submit a deposit:
 - Set `deposit_data.withdrawal_credentials` to `withdrawal_credentials`.
 - Set `deposit_data.amount` to `amount`.
 - Let `deposit_message` be a `DepositMessage` with all the `DepositData` contents except the `signature`.
-- Let `signature` be the result of `bls_sign` of the `hash_tree_root(deposit_message)` with `domain=compute_domain(DOMAIN_DEPOSIT)`. (Deposits are valid regardless of fork version, `compute_domain` will default to zeroes there).
+- Let `signature` be the result of `bls_sign` of the `hash_tree_root(deposit_message)` with `domain=compute_domain(DOMAIN_DEPOSIT)`. (_Warning_: Deposits _must_ be signed with `GENESIS_FORK_VERSION`, calling `compute_domain` without a second argument defaults to the correct version).
 - Let `deposit_data_root` be `hash_tree_root(deposit_data)`.
 - Send a transaction on the Ethereum 1.0 chain to `DEPOSIT_CONTRACT_ADDRESS` executing `def deposit(pubkey: bytes[48], withdrawal_credentials: bytes[32], signature: bytes[96], deposit_data_root: bytes32)` along with a deposit of `amount` Gwei.
 


### PR DESCRIPTION
Closes #1548 

* Add `GENESIS_FORK_VERSION`
* Modify `GENESIS_FORK_VERSION` in `minimal` config
* Add warning about valid fork version for Deposits in Validator guide