### PR TITLE
move GENESIS_SLOT/EPOCH to constants

### DIFF
--- a/configs/mainnet.yaml
+++ b/configs/mainnet.yaml
@@ -63,8 +63,6 @@ EFFECTIVE_BALANCE_INCREMENT: 1000000000
 
 # Initial values
 # ---------------------------------------------------------------
-# 0, GENESIS_EPOCH is derived from this constant
-GENESIS_SLOT: 0
 # Mainnet initial fork version, recommend altering for testnets
 GENESIS_FORK_VERSION: 0x00000000
 BLS_WITHDRAWAL_PREFIX: 0x00

--- a/configs/minimal.yaml
+++ b/configs/minimal.yaml
@@ -63,8 +63,6 @@ EFFECTIVE_BALANCE_INCREMENT: 1000000000
 
 # Initial values
 # ---------------------------------------------------------------
-# 0, GENESIS_EPOCH is derived from this constant
-GENESIS_SLOT: 0
 # Highest byte set to 0x01 to avoid collisions with mainnet versioning
 GENESIS_FORK_VERSION: 0x00000001
 BLS_WITHDRAWAL_PREFIX: 0x00

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -158,6 +158,8 @@ The following values are (non-configurable) constants used throughout the specif
 
 | Name | Value |
 | - | - |
+| `GENESIS_SLOT` | `Slot(0)` |
+| `GENESIS_EPOCH` | `Epoch(0)` |
 | `FAR_FUTURE_EPOCH` | `Epoch(2**64 - 1)` |
 | `BASE_REWARDS_PER_EPOCH` | `4` |
 | `DEPOSIT_CONTRACT_TREE_DEPTH` | `2**5` (= 32) |
@@ -197,8 +199,6 @@ The following values are (non-configurable) constants used throughout the specif
 
 | Name | Value |
 | - | - |
-| `GENESIS_SLOT` | `Slot(0)` |
-| `GENESIS_EPOCH` | `Epoch(0)` |
 | `GENESIS_FORK_VERSION` | `Version('0x00000000')` |
 | `BLS_WITHDRAWAL_PREFIX` | `Bytes1('0x00')` |
 

--- a/specs/validator/0_beacon-chain-validator.md
+++ b/specs/validator/0_beacon-chain-validator.md
@@ -267,7 +267,7 @@ def compute_time_at_slot(state: BeaconState, slot: Slot) -> uint64:
 
 ```python
 def voting_period_start_time(state: BeaconState) -> uint64:
-    eth1_voting_period_start_slot = Slot(state.slot % SLOTS_PER_ETH1_VOTING_PERIOD)
+    eth1_voting_period_start_slot = Slot(state.slot - state.slot % SLOTS_PER_ETH1_VOTING_PERIOD)
     return compute_time_at_slot(state, eth1_voting_period_start_slot)
 ```
 

--- a/specs/validator/0_beacon-chain-validator.md
+++ b/specs/validator/0_beacon-chain-validator.md
@@ -263,7 +263,8 @@ An honest block proposer sets `block.body.eth1_data = get_eth1_vote(state)` wher
 ```python
 def voting_period_start_time(state: BeaconState) -> uint64:
     eth1_voting_period_start_slot = state.slot % SLOTS_PER_ETH1_VOTING_PERIOD
-    return state.genesis_time + eth1_voting_period_start_slot * SECONDS_PER_SLOT
+    time_since_genesis = (eth1_voting_period_start_slot - GENESIS_SLOT) * SECONDS_PER_SLOT
+    return state.genesis_time + time_since_genesis
 ```
 
 ```python

--- a/specs/validator/0_beacon-chain-validator.md
+++ b/specs/validator/0_beacon-chain-validator.md
@@ -261,10 +261,14 @@ Let `get_eth1_data(block: Eth1Block) -> Eth1Data` be the function that returns t
 An honest block proposer sets `block.body.eth1_data = get_eth1_vote(state)` where:
 
 ```python
+def compute_time_at_slot(state: BeaconState, slot: Slot) -> uint64:
+    return state.genesis_time + slot * SECONDS_PER_SLOT
+```
+
+```python
 def voting_period_start_time(state: BeaconState) -> uint64:
-    eth1_voting_period_start_slot = state.slot % SLOTS_PER_ETH1_VOTING_PERIOD
-    time_since_genesis = (eth1_voting_period_start_slot - GENESIS_SLOT) * SECONDS_PER_SLOT
-    return state.genesis_time + time_since_genesis
+    eth1_voting_period_start_slot = Slot(state.slot % SLOTS_PER_ETH1_VOTING_PERIOD)
+    return compute_time_at_slot(state, eth1_voting_period_start_slot)
 ```
 
 ```python


### PR DESCRIPTION
`GENESIS_SLOT` and `GENESIS_EPOCH` are not truly configurable as currently specified (ex: they aren't explicitly written into genesis block/state). Instead of making substantive changes to allow for this, instead just move them to "Constants" section.

Explicitness in helpers is still desired, so also clarify the use of `GENESIS_SLOT` in a validator helper.

Also fix a bug that was introduced in #1553. Thanks @protolambda ! 