### PR TITLE
[WIP] fix default value when voting on eth1data

### DIFF
--- a/specs/validator/0_beacon-chain-validator.md
+++ b/specs/validator/0_beacon-chain-validator.md
@@ -283,16 +283,20 @@ def is_candidate_block(block: Eth1Block, period_start: uint64) -> bool:
 ```python
 def get_eth1_vote(state: BeaconState, eth1_chain: Sequence[Eth1Block]) -> Eth1Data:
     period_start = voting_period_start_time(state)
-    # `eth1_chain` abstractly represents all blocks in the eth1 chain.
+    # `eth1_chain` abstractly represents all blocks in the eth1 chain sorted by ascending block height
     votes_to_consider = [get_eth1_data(block) for block in eth1_chain if
                          is_candidate_block(block, period_start)]
 
+    # Valid votes already cast during this period
     valid_votes = [vote for vote in state.eth1_data_votes if vote in votes_to_consider]
+
+    # Default vote on latest eth1 block data in the period range unless eth1 chain is not live
+    default_vote = votes_to_consider[-1] if any(votes_to_consider) else state.eth1_data
 
     return max(
         valid_votes,
         key=lambda v: (valid_votes.count(v), -valid_votes.index(v)),  # Tiebreak by smallest distance
-        default=get_eth1_data(ETH1_FOLLOW_DISTANCE),
+        default=default_vote
     )
 ```
 


### PR DESCRIPTION
Thank you @cemozerr for finding and reporting this.

If the eth1 chain is live and well connected, the validator votes on the 0th block in the acceptable voting period when no other valid votes already exist. 

If the eth1 chain is not live, the validator defaults to voting on the previous eth1data which is a no-op