### PR TITLE
Fix broken test generators

### DIFF
--- a/tests/generators/bls/main.py
+++ b/tests/generators/bls/main.py
@@ -115,7 +115,7 @@ def case02_message_hash_G2_compressed():
 
 
 def case03_private_to_public_key():
-    pubkeys = [bls.G2Basic.PrivToPub(privkey) for privkey in PRIVKEYS]
+    pubkeys = [bls. G2ProofOfPossession.PrivToPub(privkey) for privkey in PRIVKEYS]
     pubkeys_serial = ['0x' + pubkey.hex() for pubkey in pubkeys]
     for privkey, pubkey_serial in zip(PRIVKEYS, pubkeys_serial):
         yield f'priv_to_pub_{int_to_hex(privkey)}', {

--- a/tests/generators/ssz_generic/ssz_container.py
+++ b/tests/generators/ssz_generic/ssz_container.py
@@ -1,6 +1,6 @@
 from ssz_test_case import invalid_test_case, valid_test_case
 from eth2spec.utils.ssz.ssz_typing import SSZType, Container, byte, uint8, uint16, \
-    uint32, uint64, List, Bytes, Vector, Bitvector, Bitlist
+    uint32, uint64, List, ByteList, Vector, Bitvector, Bitlist
 from eth2spec.utils.ssz.ssz_impl import serialize
 from random import Random
 from typing import Dict, Tuple, Sequence, Callable
@@ -32,7 +32,7 @@ class ComplexTestStruct(Container):
     A: uint16
     B: List[uint16, 128]
     C: uint8
-    D: Bytes[256]
+    D: ByteList[256]
     E: VarTestStruct
     F: Vector[FixedTestStruct, 4]
     G: Vector[VarTestStruct, 2]


### PR DESCRIPTION
* Fix BLS test generator by utilizing new py_ecc functions, types, etc. Strip down test cases to only test the 5 BLS functions in the spec
* Fix ssz_generic test generator with a simple import fix (`Bytes` -> `ByteList`)