### PR TITLE
Ratelimit

### DIFF
--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -371,10 +371,11 @@ The response code can have one of the following values, encoded as a single unsi
 -  0: **Success** -- a normal response follows, with contents matching the expected message schema and encoding specified in the request.
 -  1: **InvalidRequest** -- the contents of the request are semantically invalid, or the payload is malformed, or could not be understood. The response payload adheres to the `ErrorMessage` schema (described below).
 -  2: **ServerError** -- the responder encountered an error while processing the request. The response payload adheres to the `ErrorMessage` schema (described below).
+-  3: **RateLimited** -- the responder has served too many requests or sent too much data recently, either overall or to the requestor specifically. The response payload adheres to the `ErrorMessage` schema (described below).
 
 Clients MAY use response codes above `128` to indicate alternative, erroneous request-specific responses.
 
-The range `[3, 127]` is RESERVED for future usages, and should be treated as error if not recognized expressly.
+The range `[4, 127]` is RESERVED for future usages, and should be treated as error if not recognized expressly.
 
 The `ErrorMessage` schema is:
 


### PR DESCRIPTION
This adds a response code of "rate limited" for peers.

Prysm has already seen situations where a peer is swamped for requests for blocks, and has implemented a rate limiter in an attempt to alleviate this.  At current it sends back a "server error" response when replying, but this isn't really the case and causes knock-on effects such as the requestor deciding the peer is non-functional, rather than just busy.

By adding a "rate limited" response code peers can understand the difference between these two situations and act accordingly.