### PR TITLE
Properly handle skip slots in fork choice

### DIFF
--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -279,9 +279,13 @@ def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
     assert get_current_slot(store) >= block.slot
     # Add new block to the store
     store.blocks[hash_tree_root(block)] = block
-    # Check block is a descendant of the finalized block
+
+    # Check that block is later than the finalized epoch slot (optimization to reduce calls to get_ancestor)
     finalized_slot = compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)
+    assert block.slot > finalized_slot
+    # Check block is a descendant of the finalized block
     assert get_ancestor(store, hash_tree_root(block), finalized_slot) == store.finalized_checkpoint.root
+
     # Check the block is valid and compute the post-state
     state = state_transition(pre_state, signed_block, True)
     # Add new state for this block to the store

--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -283,7 +283,7 @@ def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
     # Check that block is later than the finalized epoch slot (optimization to reduce calls to get_ancestor)
     finalized_slot = compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)
     assert block.slot > finalized_slot
-    # Check block is a descendant of the finalized block
+    # Check block is a descendant of the finalized block at the checkpoint finalized slot
     assert get_ancestor(store, hash_tree_root(block), finalized_slot) == store.finalized_checkpoint.root
 
     # Check the block is valid and compute the post-state

--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -136,7 +136,8 @@ def get_ancestor(store: Store, root: Root, slot: Slot) -> Root:
     elif block.slot == slot:
         return root
     else:
-        return Bytes32()  # root is older than queried slot: no results. 
+        # root is older than queried slot, thus a skip slot. Return earliest root prior to slot
+        return root
 ```
 
 #### `get_latest_attesting_balance`
@@ -239,13 +240,8 @@ def should_update_justified_checkpoint(store: Store, new_justified_checkpoint: C
     if compute_slots_since_epoch_start(get_current_slot(store)) < SAFE_SLOTS_TO_UPDATE_JUSTIFIED:
         return True
 
-    new_justified_block = store.blocks[new_justified_checkpoint.root]
-    if new_justified_block.slot <= compute_start_slot_at_epoch(store.justified_checkpoint.epoch):
-        return False
-    if not (
-        get_ancestor(store, new_justified_checkpoint.root, store.blocks[store.justified_checkpoint.root].slot)
-        == store.justified_checkpoint.root
-    ):
+    justified_slot = compute_start_slot_at_epoch(store.justified_checkpoint.epoch)
+    if not get_ancestor(store, new_justified_checkpoint.root, justified_slot) == store.justified_checkpoint.root:
         return False
 
     return True
@@ -284,12 +280,8 @@ def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
     # Add new block to the store
     store.blocks[hash_tree_root(block)] = block
     # Check block is a descendant of the finalized block
-    assert (
-        get_ancestor(store, hash_tree_root(block), store.blocks[store.finalized_checkpoint.root].slot) ==
-        store.finalized_checkpoint.root
-    )
-    # Check that block is later than the finalized epoch slot
-    assert block.slot > compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)
+    finalized_slot = compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)
+    assert get_ancestor(store, hash_tree_root(block), finalized_slot) == store.finalized_checkpoint.root
     # Check the block is valid and compute the post-state
     state = state_transition(pre_state, signed_block, True)
     # Add new state for this block to the store


### PR DESCRIPTION
Due to the way epoch pairs are justified/finalized and how we handle skipped slots in the consensus, we have to be careful to ensure not only that the justified/finalized block is in the chain, but that it is in the chain at the precise justified/finalized epoch (accounting for skip slots in exceptional cases)

Previously I erroneously put in conditions such the following:
```python
assert block.slot > compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)
```

This just ensured that the block was in fact later than the finalized epoch, but not that the finalized root was in the chain (potentially at a skip slot) at that epoch.

To fix this, we modify `get_ancestor` to return the latest root at or before the queried slot in the chain in question. This mimics the behavior of how we save roots in state and how we vote on roots, and it very nicely fixes this corner case.


-------

Helps properly handle cases in which we justify/finalize blocks after skipped epochs like in the following:

![Screen Shot 2020-01-20 at 6 02 21 PM](https://user-images.githubusercontent.com/1433595/72766881-0ce6f680-3baf-11ea-98dc-1fb2cb085024.jpg)

Say block 64 at epoch 2 is finalized. Blocks that build off of block 64 at epoch 1 should _not_ be considered in the fork choice. the modificaiton to `get_ancestor` protect against this case
