### PR TITLE
Exit queue epoch fix

### DIFF
--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -1036,7 +1036,7 @@ def initiate_validator_exit(state: BeaconState, index: ValidatorIndex) -> None:
 
     # Compute exit queue epoch
     exit_epochs = [v.exit_epoch for v in state.validators if v.exit_epoch != FAR_FUTURE_EPOCH]
-    exit_queue_epoch = max(exit_epochs, default=compute_activation_exit_epoch(get_current_epoch(state)))
+    exit_queue_epoch = max(exit_epochs + [compute_activation_exit_epoch(get_current_epoch(state))])
     exit_queue_churn = len([v for v in state.validators if v.exit_epoch == exit_queue_epoch])
     if exit_queue_churn >= get_validator_churn_limit(state):
         exit_queue_epoch += Epoch(1)


### PR DESCRIPTION
Fixes the issue found by @ChihChengLiang introduced during what was supposed to be a cosmetic (non-substantive) PR.  Full explanation here: https://github.com/ethereum/eth2.0-specs/pull/1525#discussion_r368692374

* revert back to adding the activation exit epoch to the `exit_epochs` array instead of incorrectly using `default` arg in `max` (see above link for more detailed explanation).
* add an explicit test to catch this subtlety 