### PR TITLE
fix default value in compute_domain

### DIFF
--- a/scripts/build_spec.py
+++ b/scripts/build_spec.py
@@ -31,7 +31,7 @@ from eth2spec.utils.hash_function import hash
 SSZObject = TypeVar('SSZObject', bound=SSZType)
 '''
 PHASE1_IMPORTS = '''from typing import (
-    Any, Dict, Set, Sequence, MutableSequence, NewType, Tuple, Union, TypeVar
+    Any, Dict, Set, Sequence, MutableSequence, NewType, Optional, Tuple, Union, TypeVar
 )
 from math import (
     log2,

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -788,10 +788,12 @@ def compute_activation_exit_epoch(epoch: Epoch) -> Epoch:
 #### `compute_domain`
 
 ```python
-def compute_domain(domain_type: DomainType, fork_version: Version=GENESIS_FORK_VERSION) -> Domain:
+def compute_domain(domain_type: DomainType, fork_version: Version=None) -> Domain:
     """
     Return the domain for the ``domain_type`` and ``fork_version``.
     """
+    if fork_version is None:
+        fork_version = GENESIS_FORK_VERSION
     return Domain(domain_type + fork_version)
 ```
 

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -788,7 +788,7 @@ def compute_activation_exit_epoch(epoch: Epoch) -> Epoch:
 #### `compute_domain`
 
 ```python
-def compute_domain(domain_type: DomainType, fork_version: Version=None) -> Domain:
+def compute_domain(domain_type: DomainType, fork_version: Optional[Version]=None) -> Domain:
     """
     Return the domain for the ``domain_type`` and ``fork_version``.
     """


### PR DESCRIPTION
Fixes #1582 

Default value being passed into `compute_domain` was not being overridden when using alternative configuration files. Instead, default to `None` and conditionally set the variable if `None` to ensure get most updated version of config var

Thanks @benjaminion for reporting and solving the problem here!
