### PR TITLE
Add libp2p-noise specification

### DIFF
--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -149,9 +149,11 @@ The following SecIO parameters MUST be supported by all stacks:
 
 #### Mainnet
 
-[Noise Framework](http://www.noiseprotocol.org/) handshakes will be used for mainnet. libp2p Noise support [is in the process of being standardized](https://github.com/libp2p/specs/issues/195) in the libp2p project.
+The [Libp2p-noise](https://github.com/libp2p/specs/tree/master/noise) secure
+channel handshake with `secp256k1` identities will be used for mainnet.
 
-Noise support will presumably include IX, IK, and XX handshake patterns, and may rely on Curve25519 keys, ChaCha20 and Poly1305 ciphers, and SHA-256 as a hash function. These aspects are being actively debated in the referenced issue (Eth2 implementers are welcome to comment and contribute to the discussion).
+As specified in the libp2p specification, clients MUST support the `XX` handshake pattern and
+can optionally implement the `IK` and `XXfallback` patterns for optimistic 0-RTT.
 
 ## Protocol Negotiation
 


### PR DESCRIPTION
## Description 

Libp2p has added a specification for the noise handshake. This PR references this specification for our mainnet configuration. 

There are two interesting points here:
- I've suggested that we continue to use `secp256k1` peer identities as these keys are currently specified for ENR's in discv5 and allows us to the use the same identity for both discovery and the rest of the libp2p stack.
- The libp2p-noise specification indicates that libp2p implementations support the `XX` handshake and optionally the `IK` and `XXfallback`. I've explicitly mentioned this in the eth2.0 specs making it clear for eth2.0 implementers. The added handshakes provide an optimisation in some circumstances and clients can optionally add these in the future.

As always, open to feedback/suggestions on this PR. 