### PR TITLE
Put back in a requirement to store recent signed blocks 

### DIFF
--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -548,7 +548,7 @@ The request MUST be encoded as an SSZ-container.
 
 The response MUST consist of zero or more `response_chunk`. Each _successful_ `response_chunk` MUST contain a single `SignedBeaconBlock` payload.
 
-Clients MUST keep a record of signed blocks seen since the since the start of the weak subjectivity period and MUST support requesting blocks up to the given `head_block_root`.
+Clients MUST keep a record of signed blocks seen since the since the start of the weak subjectivity period and MUST support serving requests of blocks up to their own `head_block_root`.
 
 Clients MUST respond with at least one block, if they have it and it exists in the range. Clients MAY limit the number of blocks in the response.
 

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -547,7 +547,8 @@ Requests count beacon blocks from the peer starting from `start_slot`, leading u
 The request MUST be encoded as an SSZ-container.
 
 The response MUST consist of zero or more `response_chunk`. Each _successful_ `response_chunk` MUST contain a single `SignedBeaconBlock` payload.
-Clients MUST support requesting blocks since the start of the weak subjectivity period and up to the given `head_block_root`.
+
+Clients MUST keep a record of signed blocks seen since the since the start of the weak subjectivity period and MUST support requesting blocks up to the given `head_block_root`.
 
 Clients MUST respond with at least one block, if they have it and it exists in the range. Clients MAY limit the number of blocks in the response.
 


### PR DESCRIPTION
In spec 0.9.2 and earlier, the signature was in BeaconBlock, which was recorded in Store, so clients would generally have the blocks available to service requests (i.e. pass the "if they have it" criteria).

However since SignedBeaconBlock was introduced there has been no explicit storage of signed blocks received.

While the specification says "MUST support requesting" it is qualified by "respond .. if they have it".

This change removes any confusion by putting back in an explicit requirement to store blocks (although the mechanism is not specified, i.e. they are no longer necessarily in Store).

Further information is in issue #1641 