### PR TITLE
revert fork choice store.blocks to BeaconBlock

### DIFF
--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -83,7 +83,7 @@ class Store(object):
     justified_checkpoint: Checkpoint
     finalized_checkpoint: Checkpoint
     best_justified_checkpoint: Checkpoint
-    blocks: Dict[Root, BeaconBlockHeader] = field(default_factory=dict)
+    blocks: Dict[Root, BeaconBlock] = field(default_factory=dict)
     block_states: Dict[Root, BeaconState] = field(default_factory=dict)
     checkpoint_states: Dict[Checkpoint, BeaconState] = field(default_factory=dict)
     latest_messages: Dict[ValidatorIndex, LatestMessage] = field(default_factory=dict)


### PR DESCRIPTION
As pointed out by @sgryphon in #1642, `store.blocks` was semi-changed to store `BeaconBlockHeader`, but then the change didn't make it through the rest of the spec.

Although we don't use anything in `block.body`, reverting back to store `BeaconBlock` to minimize spec changes.