### PR TITLE
Must match target to match head

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -182,7 +182,17 @@ get_active_validator_indices = cache_this(
 _get_beacon_committee = get_beacon_committee
 get_beacon_committee = cache_this(
     lambda state, slot, index: (state.validators.hash_tree_root(), state.randao_mixes.hash_tree_root(), slot, index),
-    _get_beacon_committee)'''
+    _get_beacon_committee)
+
+_get_matching_target_attestations = get_matching_target_attestations
+get_matching_target_attestations = cache_this(
+    lambda state, epoch: (state.hash_tree_root(), epoch),
+    _get_matching_target_attestations)
+
+_get_matching_head_attestations = get_matching_head_attestations
+get_matching_head_attestations = cache_this(
+    lambda state, epoch: (state.hash_tree_root(), epoch),
+    _get_matching_head_attestations)'''
 
 
 def objects_to_spec(spec_object: SpecObject, imports: str, fork: str) -> str:

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -1235,7 +1235,7 @@ def get_matching_target_attestations(state: BeaconState, epoch: Epoch) -> Sequen
 ```python
 def get_matching_head_attestations(state: BeaconState, epoch: Epoch) -> Sequence[PendingAttestation]:
     return [
-        a for a in get_matching_source_attestations(state, epoch)
+        a for a in get_matching_target_attestations(state, epoch)
         if a.data.beacon_block_root == get_block_root_at_slot(state, a.data.slot)
     ]
 ```

--- a/tests/core/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_rewards_and_penalties.py
+++ b/tests/core/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_rewards_and_penalties.py
@@ -98,6 +98,29 @@ def test_full_attestations(spec, state):
 
 
 @with_all_phases
+@spec_state_test
+def test_full_attestations_random_incorrect_fields(spec, state):
+    attestations = prepare_state_with_full_attestations(spec, state)
+    for i, attestation in enumerate(state.previous_epoch_attestations):
+        if i % 3 == 0:
+            # Mess up some head votes
+            attestation.data.beacon_block_root = b'\x56' * 32
+        if i % 3 == 1:
+            # Message up some target votes
+            attestation.data.target.root = b'\x23' * 32
+        if i % 3 == 2:
+            # Keep some votes 100% correct
+            pass
+
+    yield from run_process_rewards_and_penalties(spec, state)
+
+    attesting_indices = spec.get_unslashed_attesting_indices(state, attestations)
+    assert len(attesting_indices) > 0
+    # No balance checks, non-trivial base on group rewards
+    # Mainly for consensus tests
+
+
+@with_all_phases
 @spec_test
 @with_custom_state(balances_fn=misc_balances, threshold_fn=default_activation_threshold)
 @single_phase


### PR DESCRIPTION
Remove a potentially degenerate path in the rewards by requiring `get_matching_head_attestations` to match target (instead of just source). This prevents a path in which a validator could still be profitable by getting source and head correct, but voting an incorrect target (and thus avoiding finality).

Add test that has full attestations but messes up random fields to ensure we get better reward coverage

[also add cache for some of these attestation helpers. Seems like it shaved a few seconds off of local test times, but nothing crazy]