### PR TITLE
avoid div by zero in extreme balance case

### DIFF
--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -996,10 +996,11 @@ def get_beacon_proposer_index(state: BeaconState) -> ValidatorIndex:
 ```python
 def get_total_balance(state: BeaconState, indices: Set[ValidatorIndex]) -> Gwei:
     """
-    Return the combined effective balance of the ``indices``. (1 Gwei minimum to avoid divisions by zero.)
+    Return the combined effective balance of the ``indices``.
+    ``EFFECTIVE_BALANCE_INCREMENT`` Gwei minimum to avoid divisions by zero.
     Math safe up to ~10B ETH, afterwhich this overflows uint64.
     """
-    return Gwei(max(1, sum([state.validators[index].effective_balance for index in indices])))
+    return Gwei(max(EFFECTIVE_BALANCE_INCREMENT, sum([state.validators[index].effective_balance for index in indices])))
 ```
 
 #### `get_total_active_balance`

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -1009,6 +1009,7 @@ def get_total_balance(state: BeaconState, indices: Set[ValidatorIndex]) -> Gwei:
 def get_total_active_balance(state: BeaconState) -> Gwei:
     """
     Return the combined effective balance of the active validators.
+    Note: ``get_total_balance`` returns ``EFFECTIVE_BALANCE_INCREMENT`` Gwei minimum to avoid divisions by zero.
     """
     return get_total_balance(state, set(get_active_validator_indices(state, get_current_epoch(state))))
 ```
@@ -1290,6 +1291,10 @@ def get_unslashed_attesting_indices(state: BeaconState,
 
 ```python
 def get_attesting_balance(state: BeaconState, attestations: Sequence[PendingAttestation]) -> Gwei:
+    """
+    Return the combined effective balance of the set of unslashed validators participating in ``attestations``.
+    Note: ``get_total_balance`` returns ``EFFECTIVE_BALANCE_INCREMENT`` Gwei minimum to avoid divisions by zero.
+    """
     return get_total_balance(state, get_unslashed_attesting_indices(state, attestations))
 ```
 

--- a/tests/core/pyspec/eth2spec/test/context.py
+++ b/tests/core/pyspec/eth2spec/test/context.py
@@ -71,6 +71,14 @@ def default_activation_threshold(spec):
     return spec.MAX_EFFECTIVE_BALANCE
 
 
+def zero_activation_threshold(spec):
+    """
+    Helper method to use the default balance activation threshold for state creation for tests.
+    Usage: `@with_custom_state(threshold_fn=one_gwei_activation_threshold, ...)`
+    """
+    return 0
+
+
 def default_balances(spec):
     """
     Helper method to create a series of default balances.
@@ -102,6 +110,14 @@ def misc_balances(spec):
     num_validators = spec.SLOTS_PER_EPOCH * 8
     num_misc_validators = spec.SLOTS_PER_EPOCH
     return [spec.MAX_EFFECTIVE_BALANCE] * num_validators + [spec.MIN_DEPOSIT_AMOUNT] * num_misc_validators
+
+
+def low_single_balance(spec):
+    """
+    Helper method to create a single of balance of 1 Gwei.
+    Usage: `@with_custom_state(balances_fn=low_single_balance, ...)`
+    """
+    return [1]
 
 
 def single_phase(fn):

--- a/tests/core/pyspec/eth2spec/test/context.py
+++ b/tests/core/pyspec/eth2spec/test/context.py
@@ -73,8 +73,8 @@ def default_activation_threshold(spec):
 
 def zero_activation_threshold(spec):
     """
-    Helper method to use the default balance activation threshold for state creation for tests.
-    Usage: `@with_custom_state(threshold_fn=one_gwei_activation_threshold, ...)`
+    Helper method to use 0 gwei as the activation threshold for state creation for tests.
+    Usage: `@with_custom_state(threshold_fn=zero_activation_threshold, ...)`
     """
     return 0
 

--- a/tests/core/pyspec/eth2spec/test/helpers/attestations.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/attestations.py
@@ -39,7 +39,7 @@ def build_attestation_data(spec, state, slot, index):
     )
 
 
-def get_valid_attestation(spec, state, slot=None, index=None, signed=False):
+def get_valid_attestation(spec, state, slot=None, index=None, empty=False, signed=False):
     if slot is None:
         slot = state.slot
     if index is None:
@@ -59,7 +59,8 @@ def get_valid_attestation(spec, state, slot=None, index=None, signed=False):
         aggregation_bits=aggregation_bits,
         data=attestation_data,
     )
-    fill_aggregate_attestation(spec, state, attestation)
+    if not empty:
+        fill_aggregate_attestation(spec, state, attestation)
     if signed:
         sign_attestation(spec, state, attestation)
     return attestation

--- a/tests/core/pyspec/eth2spec/test/phase_0/block_processing/test_process_attestation.py
+++ b/tests/core/pyspec/eth2spec/test/phase_0/block_processing/test_process_attestation.py
@@ -292,13 +292,11 @@ def test_bad_source_root(spec, state):
 @with_all_phases
 @spec_state_test
 def test_empty_aggregation_bits(spec, state):
-    attestation = get_valid_attestation(spec, state)
+    attestation = get_valid_attestation(spec, state, empty=True)
     state.slot += spec.MIN_ATTESTATION_INCLUSION_DELAY
 
-    attestation.aggregation_bits = Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](
+    assert attestation.aggregation_bits == Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](
         *([0b0] * len(attestation.aggregation_bits)))
-
-    sign_attestation(spec, state, attestation)
 
     yield from run_attestation_processing(spec, state, attestation)
 


### PR DESCRIPTION
Address #1663

* `get_total_balance` returns a minimum of `EFFECTIVE_BALANCE_INCREMENT` to avoid div by zero in extreme cases
* add rewards test vector to test for this extreme case (it did in fact div by 0 before the fix was in place)
* Add another rewards test for empty attestations (because I noticed it was needed... )