### PR TITLE
remove IK handshake from p2p spec

### DIFF
--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -157,8 +157,7 @@ The following SecIO parameters MUST be supported by all stacks:
 The [Libp2p-noise](https://github.com/libp2p/specs/tree/master/noise) secure
 channel handshake with `secp256k1` identities will be used for mainnet.
 
-As specified in the libp2p specification, clients MUST support the `XX` handshake pattern and
-can optionally implement the `IK` and `XXfallback` patterns for optimistic 0-RTT.
+As specified in the libp2p specification, clients MUST support the `XX` handshake pattern.
 
 ## Protocol Negotiation
 


### PR DESCRIPTION
IK handshake is being removed from the libp2p noise specs for now (see here https://github.com/libp2p/specs/issues/249), so removing it as optional in our specs.

I believe the XXFallback is to be removed as well. Waiting for conf here https://github.com/libp2p/specs/issues/246#issuecomment-600181558