### PR TITLE
Shift IP-related ENR fields as optional

### DIFF
--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -622,6 +622,9 @@ This integration enables the libp2p stack to subsequently form connections and s
 The Ethereum Node Record (ENR) for an Ethereum 2.0 client MUST contain the following entries (exclusive of the sequence number and signature, which MUST be present in an ENR):
 
 -  The compressed secp256k1 publickey, 33 bytes (`secp256k1` field).
+
+The ENR MAY contain the following entries:
+
 -  An IPv4 address (`ip` field) and/or IPv6 address (`ip6` field).
 -  A TCP port (`tcp` field) representing the local libp2p listening port.
 -  A UDP port (`udp` field) representing the local discv5 listening port.


### PR DESCRIPTION
# Description

In Lighthouse we had these fields always defined as specified. However in a recent update to our discv5 which removes NAT'd peers from the DHT we realised it makes more sense to have nodes that have not sorted out their NAT traversal (i.e do not know or do not have external IP/PORTS that other peers can connect on) that their ENR's do not contain any IP/PORTs. 

Nodes without IP/PORTs should still be able to connect and discover other peers, but it will be less likely (depending on implementations) that these peers would be added to a local node routing table. 

It makes it clearer that nodes without an IP/PORT do not have a contactable address and will save us time trying to connect to a local IP/PORT which is not globally contactable.

Lighthouse by default, will have ENRs without any IP/PORT field (unless loaded from a previous state), although we set a TCP port (as this is not update-able from discovery). As they discover peers and their peers inform the node that they are contactable on a specific IP/PORT, the node will update it's ENR with IP/PORT field and get added to the DHT. This also ensures that the ENR doesn't get updated unless it is contactable from a wider audience.