### PR TITLE
Fix memoization (base reward cache bug + add LRU)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,10 @@ test: pyspec
 	. venv/bin/activate; cd $(PY_SPEC_DIR); \
 	python -m pytest -n 4 --cov=eth2spec.phase0.spec --cov=eth2spec.phase1.spec --cov-report="html:$(COV_HTML_OUT)" --cov-branch eth2spec
 
+find_test: pyspec
+	. venv/bin/activate; cd $(PY_SPEC_DIR); \
+	python -m pytest -k=$(K) --cov=eth2spec.phase0.spec --cov=eth2spec.phase1.spec --cov-report="html:$(COV_HTML_OUT)" --cov-branch eth2spec
+
 citest: pyspec
 	mkdir -p tests/core/pyspec/test-reports/eth2spec; . venv/bin/activate; cd $(PY_SPEC_DIR); \
 	python -m pytest -n 4 --junitxml=eth2spec/test_results.xml eth2spec

--- a/setup.py
+++ b/setup.py
@@ -175,13 +175,13 @@ compute_shuffled_index = cache_this(
 
 _get_total_active_balance = get_total_active_balance
 get_total_active_balance = cache_this(
-    lambda state: (state.validators.hash_tree_root(), state.slot),
+    lambda state: (state.validators.hash_tree_root(), compute_epoch_at_slot(state.slot)),
     _get_total_active_balance, lru_size=10)
 
 _get_base_reward = get_base_reward
 get_base_reward = cache_this(
     lambda state, index: (state.validators.hash_tree_root(), state.slot, index),
-    _get_base_reward, lru_size=10)
+    _get_base_reward, lru_size=2048)
 
 _get_committee_count_at_slot = get_committee_count_at_slot
 get_committee_count_at_slot = cache_this(
@@ -209,9 +209,9 @@ get_matching_head_attestations = cache_this(
     _get_matching_head_attestations, lru_size=10)
 
 _get_attesting_indices = get_attesting_indices
-get_attesting_indices = cache_this(lambda state, data, bits:
-                                   (state.validators.hash_tree_root(), data.hash_tree_root(), bits.hash_tree_root()),
-                                   _get_attesting_indices, lru_size=SLOTS_PER_EPOCH * MAX_COMMITTEES_PER_SLOT * 3)'''
+get_attesting_indices = cache_this(
+    lambda state, data, bits: (state.validators.hash_tree_root(), data.hash_tree_root(), bits.hash_tree_root()),
+    _get_attesting_indices, lru_size=SLOTS_PER_EPOCH * MAX_COMMITTEES_PER_SLOT * 3)'''
 
 
 def objects_to_spec(spec_object: SpecObject, imports: str, fork: str) -> str:

--- a/tests/core/pyspec/eth2spec/test/context.py
+++ b/tests/core/pyspec/eth2spec/test/context.py
@@ -6,6 +6,7 @@ from .helpers.genesis import create_genesis_state
 
 from .utils import vector_test, with_meta_tags
 
+from random import Random
 from typing import Any, Callable, Sequence, TypedDict, Protocol
 
 from importlib import reload
@@ -100,8 +101,10 @@ def misc_balances(spec):
     Usage: `@with_custom_state(balances_fn=misc_balances, ...)`
     """
     num_validators = spec.SLOTS_PER_EPOCH * 8
-    num_misc_validators = spec.SLOTS_PER_EPOCH
-    return [spec.MAX_EFFECTIVE_BALANCE] * num_validators + [spec.MIN_DEPOSIT_AMOUNT] * num_misc_validators
+    balances = [spec.MAX_EFFECTIVE_BALANCE * 2 * i // num_validators for i in range(num_validators)]
+    rng = Random(1234)
+    rng.shuffle(balances)
+    return balances
 
 
 def single_phase(fn):


### PR DESCRIPTION
So while syncing the first 10,000 blocks of the lighthouse testnet, we hit a problem on the first rewards epoch transition. Not in the spec, but in the recently introduced caching of functions. After finding this, and fixing it, it happily processed the 10K blocks however.

Changes:
- Fix the base-reward caching
- Add small LRU, the cache was ever growing bigger previously
- Add more caching, it helps sync faster, and ability to process more faster helps us find bugs faster.
- Add make command to run a specific test. Setting up the pyspec context once and then debugging with IDE is nice, but a quick shorthand for checks is handy.
- Update rewards test, and corresponding context set-up, to use different balances better, with activation threshold adjusted down to actually enable them.

To reproduce:
- Edit to have no `index` in the cache key.
- Run: `make find_test K=test_full_attestations_misc_balances`

To test rewards better, splitting up the rewards function in later release would be good, as it isolates these problems better. It was considered earlier, but didn't make it through because of minimalism. I do think the "all rewards in this function here" approach can hurt though.
That said, this was only introduced in the latest release, and I am pretty sure the diff fuzzer would have hit it pretty easily. So we can focus on performance so the spec stays part of the fuzzer, and/or isolate things better.
