### PR TITLE
[Draft] PING and ENR rpc protocol

### DIFF
--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -601,6 +601,69 @@ Clients MUST support requesting blocks since the latest finalized epoch.
 
 Clients MUST respond with at least one block, if they have it. Clients MAY limit the number of blocks in the response.
 
+#### Ping
+
+**Protocol ID:** `/eth2/beacon_chain/req/ping/1/`
+
+Request Content:
+
+```
+(
+  uint64
+)
+```
+
+Response Content:
+
+```
+(
+  uint64
+)
+```
+
+Sent intermittently, the PING protocol checks liveness of connected peers.
+Peers send and respond with their local ENR sequence number.
+
+A client may then determine if their local record of a peer's ENR is up to date
+and may request an updated version via the ENR RPC method if not.
+
+The request MUST be encoded as an SSZ-field.
+
+The response MUST consist of a single `response_chunk`.
+
+#### Enr
+
+**Protocol ID:** `/eth2/beacon_chain/req/enr/1/`
+
+No Request Content.
+
+
+Response Content:
+
+```
+(
+  enr: Bytes,
+  subnet_expiries: []Slot
+)
+```
+
+Requests the ENR of a peer. The request opens and negotiates the stream without
+sending any request content. Once established the receiving peer responds with
+it's local up-to-date ENR along with a list of `Slot` corresponding to
+the expiry of all long-lived subnets specified by the `attnets` field in the
+sent ENR.
+
+The `subnet_expiries` list MUST have a length corresponding to the number of
+true values in the `attnets` bitfield. The order of the slots in `subnet_expiries`
+MUST correspond to the order of long-lived subnets specified in the `attnets`
+bitfield.
+
+The `enr` field represents the rlp-encoded bytes of the local ENR.
+
+The response MUST be encoded as an SSZ-container.
+
+The response MUST consist of a single `response_chunk`.
+
 ## The discovery domain: discv5
 
 Discovery Version 5 ([discv5](https://github.com/ethereum/devp2p/blob/master/discv5/discv5.md)) is used for peer discovery, both in the interoperability testnet and mainnet.


### PR DESCRIPTION
_This is an initial draft aimed for discussion for adding a PING and ENR protocol to the RPC_

## Overview

For client's to adopt dynamic subnets efficiently, a mechanism is required to obtain the ENR (or subnet bitfields) from peers that connect to clients via libp2p rather than discovery (see #1637). Furthermore, we currently have not specified a PING-like protocol to check for peer liveness on the libp2p stack. 

Although we could use periodic STATUS messages to check for peer liveness, it may be beneficial to decouple the liveness check from STATUS messages, as we will also need a mechanism to update ENRs/subnet fields periodically.

## Proposed Solution

This PR provides a DRAFT version of adding a PING and ENR RPC method to our RPC. 

The PING protocol, is lightweight and is designed to send a small amount of information which indicates the current state of the node to other peers as well as checking their liveness. In it's current form, the PING protocol sends the ENR sequence number, however we may want to change this to something more general. 

Given knowledge of our peers current ENR sequence numbers (via the PING protocol) a client may then request an updated ENR from it's peers if its local record of the peers ENR is out-dated (ENR sequence is lower). This method also allows clients to request ENR's for newly connected peers if their ENR's are unknown. 

## Obvious points of modification

This is a draft aimed for discussion. Some obvious points we may want to consider changing are:
- The information sent in the PING protocol. This is currently ENR focused, we may want to make it more general.
- The structure of the ENR response. We don't have SSZ encodings for ENR. We could encode the base64 version of the ENR or use the RLP encoding. Currently this is specified to SSZ encode the response which contains the RLP encoded bytes of the ENR. 
- The ENR expiry response. Currently this is a list of Slots. Depending on implementations, long-lived subscriptions may want to end on Epoch's rather than Slots, in which case we may want to change this to Epoch. The actual structure of how to relay timeout information may want to be modified.
- ENR Request - The ENR request doesn't not send any data in the stream, which is unlike all other RPC methods. Potentially we want to send some information here.