### PR TITLE
Fix bug in attestation reward calculation

### DIFF
--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -1366,7 +1366,7 @@ def get_attestation_deltas(state: BeaconState) -> Tuple[Sequence[Gwei], Sequence
             if index in unslashed_attesting_indices:
                 increment = EFFECTIVE_BALANCE_INCREMENT  # Factored out from balance totals to avoid uint64 overflow
                 reward_numerator = get_base_reward(state, index) * (attesting_balance // increment)
-                rewards[index] = reward_numerator // (total_balance // increment)
+                rewards[index] += reward_numerator // (total_balance // increment)
             else:
                 penalties[index] += get_base_reward(state, index)
 


### PR DESCRIPTION
In v0.11.0 rewards are calculated incorrectly because of a typo in `get_attestation_deltas`. Rather than accumulating rewards using `+=`, the code overwrites the previous rewards with `=` 😳