### PR TITLE
Attestation reward bug

### DIFF
--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -1372,7 +1372,7 @@ def get_attestation_deltas(state: BeaconState) -> Tuple[Sequence[Gwei], Sequence
             if index in unslashed_attesting_indices:
                 increment = EFFECTIVE_BALANCE_INCREMENT  # Factored out from balance totals to avoid uint64 overflow
                 reward_numerator = get_base_reward(state, index) * (attesting_balance // increment)
-                rewards[index] = reward_numerator // (total_balance // increment)
+                rewards[index] += reward_numerator // (total_balance // increment)
             else:
                 penalties[index] += get_base_reward(state, index)
 


### PR DESCRIPTION
[replaces #1680]

Bug found by @michaelsproul in rewards calculations introduced in `v0.11.0`.
PR to `v011x` for immediate release