### PR TITLE
MetaData and Ping

### DIFF
--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -601,6 +601,69 @@ Clients MUST support requesting blocks since the latest finalized epoch.
 
 Clients MUST respond with at least one block, if they have it. Clients MAY limit the number of blocks in the response.
 
+#### Ping
+
+**Protocol ID:** `/eth2/beacon_chain/req/ping/1/`
+
+Request Content:
+
+```
+(
+  uint64
+)
+```
+
+Response Content:
+
+```
+(
+  uint64
+)
+```
+
+Sent intermittently, the PING protocol checks liveness of connected peers.
+Peers send and respond with their local ENR sequence number.
+
+A client may then determine if their local record of a peer's ENR is up to date
+and may request an updated version via the ENR RPC method if not.
+
+The request MUST be encoded as an SSZ-field.
+
+The response MUST consist of a single `response_chunk`.
+
+#### Enr
+
+**Protocol ID:** `/eth2/beacon_chain/req/enr/1/`
+
+No Request Content.
+
+
+Response Content:
+
+```
+(
+  enr: Bytes,
+  subnet_expiries: []Slot
+)
+```
+
+Requests the ENR of a peer. The request opens and negotiates the stream without
+sending any request content. Once established the receiving peer responds with
+it's local up-to-date ENR along with a list of `Slot` corresponding to
+the expiry of all long-lived subnets specified by the `attnets` field in the
+sent ENR.
+
+The `subnet_expiries` list MUST have a length corresponding to the number of
+true values in the `attnets` bitfield. The order of the slots in `subnet_expiries`
+MUST correspond to the order of long-lived subnets specified in the `attnets`
+bitfield.
+
+The `enr` field represents the rlp-encoded bytes of the local ENR.
+
+The response MUST be encoded as an SSZ-container.
+
+The response MUST consist of a single `response_chunk`.
+
 ## The discovery domain: discv5
 
 Discovery Version 5 ([discv5](https://github.com/ethereum/devp2p/blob/master/discv5/discv5.md)) is used for peer discovery, both in the interoperability testnet and mainnet.

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -214,6 +214,8 @@ Where
 - `seq_number` is a `uint64` starting at `0` used to version the node's metadata. If any other field in the local `MetaData` changes, the node MUST increment `seq_number` by 1.
 - `attnets` is a `Bitvector` representing the node's persistent attestation subnet subscriptions.
 
+*Note*: `MetaData.seq_number` is used for versioning of the node's metadata, is entirely independent of the ENR sequence number, and will in most cases be out of sync with the ENR sequence number.
+
 ## The gossip domain: gossipsub
 
 Clients MUST support the [gossipsub](https://github.com/libp2p/specs/tree/master/pubsub/gossipsub) libp2p protocol.
@@ -641,7 +643,7 @@ Response Content:
 ```
 
 Sent intermittently, the `Ping` protocol checks liveness of connected peers.
-Peers send and respond with their local metadata sequence number (`MetaData.seq_number`).
+Peers request and respond with their local metadata sequence number (`MetaData.seq_number`).
 
 If the peer does not respond to the `Ping` request, the client MAY disconnect from the peer.
 

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -202,7 +202,7 @@ Specifically a validator should:
 * Call `get_committee_assignment(state, next_epoch, validator_index)` when checking for next epoch assignments.
 * Join the pubsub topic -- `committee_index{committee_index % ATTESTATION_SUBNET_COUNT}_beacon_attestation`.
     * For any current peer subscribed to the topic, the validator simply sends a `subscribe` message for the new topic.
-    * If an _insufficient_ number of current peers are subscribed to the topic, the validator must discover new peers on this topic. Via the discovery protocol, find peers with an ENR containing the `attnets` entry such that `ENR["attnets"][committee_index % ATTESTATION_SUBNET_COUNT] == True`.
+    * If an _insufficient_ number of current peers are subscribed to the topic, the validator must discover new peers on this topic. Via the discovery protocol, find peers with an ENR containing the `attnets` entry such that `ENR["attnets"][committee_index % ATTESTATION_SUBNET_COUNT] == True`. Then validate that the peers are still persisted on the desired topic by sending a `GetMetaData` and checking the resulting `attnets` field.
 
 ## Beacon chain responsibilities
 


### PR DESCRIPTION
Based on @AgeManning's #1673 and the discussion on the [recent networking call](https://hackmd.io/@benjaminion/rkEn7C_88#Networking-edge-cases).

* Add local notion of "MetaData" that has a sequence number. Currently just includes `attnets`
* Add `Ping` that sends back and forth `meta_data.seq_number`
* Add `GetMetaData` RPC method to request a nodes most recent `MetaData`
* Clarify when the ENR `attnets` field is optional
