### PR TITLE
Do not require non-aggregators to subscribe to attnets

### DIFF
--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -200,9 +200,9 @@ The beacon chain shufflings are designed to provide a minimum of 1 epoch lookahe
 
 Specifically a validator should:
 * Call `get_committee_assignment(state, next_epoch, validator_index)` when checking for next epoch assignments.
-* Find peers of the pubsub topic -- `committee_index{committee_index % ATTESTATION_SUBNET_COUNT}_beacon_attestation` -- and join if aggregator.
+* Find peers of the pubsub topic `committee_index{committee_index % ATTESTATION_SUBNET_COUNT}_beacon_attestation`.
     * If an _insufficient_ number of current peers are subscribed to the topic, the validator must discover new peers on this topic. Via the discovery protocol, find peers with an ENR containing the `attnets` entry such that `ENR["attnets"][committee_index % ATTESTATION_SUBNET_COUNT] == True`.
-    * If the validator is assigned to be an aggregator for the slot (see `is_aggregator()`), then for any peer subscribed to the topic the validator sends a `subscribe` message for this topic.
+    * If the validator is assigned to be an aggregator for the slot (see `is_aggregator()`), then subscribe to the topic.
 
 *Note*: If the validator is _not_ assigned to be an aggregator, the validator only needs sufficient number of peers on the topic to be able to publish messages. The validator does not need to _subscribe_ and listen to all messages on the topic.
 

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -200,9 +200,11 @@ The beacon chain shufflings are designed to provide a minimum of 1 epoch lookahe
 
 Specifically a validator should:
 * Call `get_committee_assignment(state, next_epoch, validator_index)` when checking for next epoch assignments.
-* Join the pubsub topic -- `committee_index{committee_index % ATTESTATION_SUBNET_COUNT}_beacon_attestation`.
-    * For any current peer subscribed to the topic, the validator simply sends a `subscribe` message for the new topic.
+* Find peers of the pubsub topic -- `committee_index{committee_index % ATTESTATION_SUBNET_COUNT}_beacon_attestation` -- and join if aggregator.
     * If an _insufficient_ number of current peers are subscribed to the topic, the validator must discover new peers on this topic. Via the discovery protocol, find peers with an ENR containing the `attnets` entry such that `ENR["attnets"][committee_index % ATTESTATION_SUBNET_COUNT] == True`.
+    * If the validator is assigned to be an aggregator for the slot (see `is_aggregator()`), then for any peer subscribed to the topic the validator sends a `subscribe` message for this topic.
+
+*Note*: If the validator is _not_ assigned to be an aggregator, the validator only needs sufficient number of peers on the topic to be able to publish messages. The validator does not need to _subscribe_ and listen to all messages on the topic.
 
 ## Beacon chain responsibilities
 


### PR DESCRIPTION
As suggested by @AgeManning and discussed on the recent [networking call](https://hackmd.io/@benjaminion/rkEn7C_88#Networking-edge-cases), this PR distinguishes from an aggregating and non-aggregating beacon committee member for the purposes of attestation subnets.

* Aggregators -- fully subscribe to the attestation subnet to receive newly published attestations for aggregation
* Non-aggregators -- Only find sufficient peers on the attestation subnet (rather than subscribe) to allow for publishing of attestations. Reduces bandwidth requirement on the node, and keeps attnets small for quick propagation.