### PR TITLE
Make the phase names (fork names) into constants

### DIFF
--- a/tests/core/pyspec/eth2spec/test/context.py
+++ b/tests/core/pyspec/eth2spec/test/context.py
@@ -7,7 +7,7 @@ from .helpers.genesis import create_genesis_state
 from .utils import vector_test, with_meta_tags
 
 from random import Random
-from typing import Any, Callable, Sequence, TypedDict, Protocol
+from typing import Any, Callable, NewType, Sequence, TypedDict, Protocol
 
 from importlib import reload
 
@@ -19,25 +19,33 @@ def reload_specs():
 
 # Some of the Spec module functionality is exposed here to deal with phase-specific changes.
 
+SpecForkName = NewType("SpecForkName", str)
+
+PHASE0 = SpecForkName('phase0')
+PHASE1 = SpecForkName('phase1')
+ALL_PHASES = (PHASE0, PHASE1)
+
 # TODO: currently phases are defined as python modules.
 # It would be better if they would be more well-defined interfaces for stronger typing.
+
+
 class Spec(Protocol):
     version: str
 
 
-class Phase0(Spec):
+class SpecPhase0(Spec):
     ...
 
 
-class Phase1(Spec):
+class SpecPhase1(Spec):
     def upgrade_to_phase1(self, state: spec_phase0.BeaconState) -> spec_phase1.BeaconState:
         ...
 
 
 # add transfer, bridge, etc. as the spec evolves
 class SpecForks(TypedDict, total=False):
-    phase0: Phase0
-    phase1: Phase1
+    PHASE0: SpecPhase0
+    PHASE1: SpecPhase1
 
 
 def with_custom_state(balances_fn: Callable[[Any], Sequence[int]],
@@ -45,16 +53,16 @@ def with_custom_state(balances_fn: Callable[[Any], Sequence[int]],
     def deco(fn):
         def entry(*args, spec: Spec, phases: SpecForks, **kw):
             try:
-                p0 = phases["phase0"]
+                p0 = phases[PHASE0]
                 balances = balances_fn(p0)
                 activation_threshold = threshold_fn(p0)
 
                 state = create_genesis_state(spec=p0, validator_balances=balances,
                                              activation_threshold=activation_threshold)
-                if spec.fork == 'phase1':
+                if spec.fork == PHASE1:
                     # TODO: instead of upgrading a test phase0 genesis state we can also write a phase1 state helper.
                     # Decide based on performance/consistency results later.
-                    state = phases["phase1"].upgrade_to_phase1(state)
+                    state = phases[PHASE1].upgrade_to_phase1(state)
 
                 kw['state'] = state
             except KeyError:
@@ -217,14 +225,11 @@ def bls_switch(fn):
     return entry
 
 
-all_phases = ['phase0', 'phase1']
-
-
 def with_all_phases(fn):
     """
     A decorator for running a test with every phase
     """
-    return with_phases(all_phases)(fn)
+    return with_phases(ALL_PHASES)(fn)
 
 
 def with_all_phases_except(exclusion_phases):
@@ -232,7 +237,7 @@ def with_all_phases_except(exclusion_phases):
     A decorator factory for running a tests with every phase except the ones listed
     """
     def decorator(fn):
-        return with_phases([phase for phase in all_phases if phase not in exclusion_phases])(fn)
+        return with_phases([phase for phase in ALL_PHASES if phase not in exclusion_phases])(fn)
     return decorator
 
 
@@ -258,18 +263,18 @@ def with_phases(phases, other_phases=None):
 
             # TODO: test state is dependent on phase0 but is immediately transitioned to phase1.
             #  A new state-creation helper for phase 1 may be in place, and then phase1+ tests can run without phase0
-            available_phases.add('phase0')
+            available_phases.add(PHASE0)
 
             phase_dir = {}
-            if 'phase0' in available_phases:
-                phase_dir['phase0'] = spec_phase0
-            if 'phase1' in available_phases:
-                phase_dir['phase1'] = spec_phase1
+            if PHASE0 in available_phases:
+                phase_dir[PHASE0] = spec_phase0
+            if PHASE1 in available_phases:
+                phase_dir[PHASE1] = spec_phase1
 
             # return is ignored whenever multiple phases are ran. If
-            if 'phase0' in run_phases:
+            if PHASE0 in run_phases:
                 ret = fn(spec=spec_phase0, phases=phase_dir, *args, **kw)
-            if 'phase1' in run_phases:
+            if PHASE1 in run_phases:
                 ret = fn(spec=spec_phase1, phases=phase_dir, *args, **kw)
             return ret
         return wrapper

--- a/tests/core/pyspec/eth2spec/test/fork_choice/test_on_attestation.py
+++ b/tests/core/pyspec/eth2spec/test/fork_choice/test_on_attestation.py
@@ -1,4 +1,4 @@
-from eth2spec.test.context import with_all_phases, spec_state_test
+from eth2spec.test.context import PHASE0, with_all_phases, spec_state_test
 from eth2spec.test.helpers.block import build_empty_block_for_next_slot
 from eth2spec.test.helpers.attestations import get_valid_attestation, sign_attestation
 from eth2spec.test.helpers.state import transition_to, state_transition_and_sign_block
@@ -16,7 +16,7 @@ def run_on_attestation(spec, state, store, attestation, valid=True):
     indexed_attestation = spec.get_indexed_attestation(state, attestation)
     spec.on_attestation(store, attestation)
 
-    if spec.fork == 'phase0':
+    if spec.fork == PHASE0:
         sample_index = indexed_attestation.attesting_indices[0]
     else:
         attesting_indices = [

--- a/tests/core/pyspec/eth2spec/test/genesis/test_initialization.py
+++ b/tests/core/pyspec/eth2spec/test/genesis/test_initialization.py
@@ -1,10 +1,10 @@
-from eth2spec.test.context import spec_test, with_phases, single_phase
+from eth2spec.test.context import PHASE0, spec_test, with_phases, single_phase
 from eth2spec.test.helpers.deposits import (
     prepare_genesis_deposits,
 )
 
 
-@with_phases(['phase0'])
+@with_phases(([PHASE0]))
 @spec_test
 @single_phase
 def test_initialize_beacon_state_from_eth1(spec):
@@ -32,7 +32,7 @@ def test_initialize_beacon_state_from_eth1(spec):
     yield 'state', state
 
 
-@with_phases(['phase0'])
+@with_phases([PHASE0])
 @spec_test
 @single_phase
 def test_initialize_beacon_state_some_small_balances(spec):

--- a/tests/core/pyspec/eth2spec/test/genesis/test_validity.py
+++ b/tests/core/pyspec/eth2spec/test/genesis/test_validity.py
@@ -1,4 +1,4 @@
-from eth2spec.test.context import spec_test, with_phases, single_phase
+from eth2spec.test.context import PHASE0, spec_test, with_phases, single_phase
 from eth2spec.test.helpers.deposits import (
     prepare_genesis_deposits,
 )
@@ -25,7 +25,7 @@ def run_is_valid_genesis_state(spec, state, valid=True):
     assert is_valid == valid
 
 
-@with_phases(['phase0'])
+@with_phases([PHASE0])
 @spec_test
 @single_phase
 def test_is_valid_genesis_state_true(spec):
@@ -34,7 +34,7 @@ def test_is_valid_genesis_state_true(spec):
     yield from run_is_valid_genesis_state(spec, state, valid=True)
 
 
-@with_phases(['phase0'])
+@with_phases([PHASE0])
 @spec_test
 @single_phase
 def test_is_valid_genesis_state_false_invalid_timestamp(spec):
@@ -44,7 +44,7 @@ def test_is_valid_genesis_state_false_invalid_timestamp(spec):
     yield from run_is_valid_genesis_state(spec, state, valid=False)
 
 
-@with_phases(['phase0'])
+@with_phases([PHASE0])
 @spec_test
 @single_phase
 def test_is_valid_genesis_state_true_more_balance(spec):
@@ -55,7 +55,7 @@ def test_is_valid_genesis_state_true_more_balance(spec):
 
 
 # TODO: not part of the genesis function yet. Erroneously merged.
-# @with_phases(['phase0'])
+# @with_phases([PHASE0])
 # @spec_test
 # def test_is_valid_genesis_state_false_not_enough_balance(spec):
 #     state = create_valid_beacon_state(spec)
@@ -64,7 +64,7 @@ def test_is_valid_genesis_state_true_more_balance(spec):
 #     yield from run_is_valid_genesis_state(spec, state, valid=False)
 
 
-@with_phases(['phase0'])
+@with_phases([PHASE0])
 @spec_test
 @single_phase
 def test_is_valid_genesis_state_true_one_more_validator(spec):
@@ -78,7 +78,7 @@ def test_is_valid_genesis_state_true_one_more_validator(spec):
     yield from run_is_valid_genesis_state(spec, state, valid=True)
 
 
-@with_phases(['phase0'])
+@with_phases([PHASE0])
 @spec_test
 @single_phase
 def test_is_valid_genesis_state_false_not_enough_validator(spec):

--- a/tests/core/pyspec/eth2spec/test/helpers/attestations.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/attestations.py
@@ -1,5 +1,6 @@
 from typing import List
 
+from eth2spec.test.context import PHASE0
 from eth2spec.test.helpers.block import build_empty_block_for_next_slot, transition_unsigned_block, \
     build_empty_block
 from eth2spec.test.helpers.keys import privkeys
@@ -78,12 +79,12 @@ def sign_aggregate_attestation(spec, state, attestation_data, participants: List
                 privkey
             )
         )
-    # TODO: we should try signing custody bits if spec.fork == 'phase1'
+    # TODO: we should try signing custody bits if spec.fork == PHASE1
     return bls.Aggregate(signatures)
 
 
 def sign_indexed_attestation(spec, state, indexed_attestation):
-    if spec.fork == 'phase0':
+    if spec.fork == PHASE0:
         participants = indexed_attestation.attesting_indices
         data = indexed_attestation.data
         indexed_attestation.signature = sign_aggregate_attestation(spec, state, data, participants)

--- a/tests/core/pyspec/eth2spec/test/helpers/attester_slashings.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/attester_slashings.py
@@ -1,3 +1,4 @@
+from eth2spec.test.context import PHASE1
 from eth2spec.test.helpers.attestations import get_valid_attestation, sign_attestation
 
 
@@ -20,7 +21,7 @@ def get_indexed_attestation_participants(spec, indexed_att):
     """
     Wrapper around index-attestation to return the list of participant indices, regardless of spec phase.
     """
-    if spec.fork == "phase1":
+    if spec.fork == PHASE1:
         return list(spec.get_indices_from_committee(
             indexed_att.committee,
             indexed_att.attestation.aggregation_bits,
@@ -33,21 +34,21 @@ def set_indexed_attestation_participants(spec, indexed_att, participants):
     """
     Wrapper around index-attestation to return the list of participant indices, regardless of spec phase.
     """
-    if spec.fork == "phase1":
+    if spec.fork == PHASE1:
         indexed_att.attestation.aggregation_bits = [bool(i in participants) for i in indexed_att.committee]
     else:
         indexed_att.attesting_indices = participants
 
 
 def get_attestation_1_data(spec, att_slashing):
-    if spec.fork == "phase1":
+    if spec.fork == PHASE1:
         return att_slashing.attestation_1.attestation.data
     else:
         return att_slashing.attestation_1.data
 
 
 def get_attestation_2_data(spec, att_slashing):
-    if spec.fork == "phase1":
+    if spec.fork == PHASE1:
         return att_slashing.attestation_2.attestation.data
     else:
         return att_slashing.attestation_2.data

--- a/tests/core/pyspec/eth2spec/test/phase_0/block_processing/test_process_attester_slashing.py
+++ b/tests/core/pyspec/eth2spec/test/phase_0/block_processing/test_process_attester_slashing.py
@@ -1,4 +1,7 @@
-from eth2spec.test.context import spec_state_test, expect_assertion_error, always_bls, with_all_phases, with_phases
+from eth2spec.test.context import (
+    PHASE0, PHASE1,
+    spec_state_test, expect_assertion_error, always_bls, with_all_phases, with_phases
+)
 from eth2spec.test.helpers.attestations import sign_indexed_attestation
 from eth2spec.test.helpers.attester_slashings import get_valid_attester_slashing, \
     get_indexed_attestation_participants, get_attestation_2_data, get_attestation_1_data
@@ -161,7 +164,7 @@ def test_same_data(spec, state):
 
     indexed_att_1 = attester_slashing.attestation_1
     att_2_data = get_attestation_2_data(spec, attester_slashing)
-    if spec.fork == 'phase1':
+    if spec.fork == PHASE1:
         indexed_att_1.attestation.data = att_2_data
     else:
         indexed_att_1.data = att_2_data
@@ -199,7 +202,7 @@ def test_participants_already_slashed(spec, state):
 # Some of the following tests are phase0 only: phase 1 lists participants with bitfields instead of index list.
 
 
-@with_phases(['phase0'])
+@with_phases([PHASE0])
 @spec_state_test
 @always_bls
 def test_att1_bad_extra_index(spec, state):
@@ -215,7 +218,7 @@ def test_att1_bad_extra_index(spec, state):
     yield from run_attester_slashing_processing(spec, state, attester_slashing, False)
 
 
-@with_phases(['phase0'])
+@with_phases([PHASE0])
 @spec_state_test
 @always_bls
 def test_att1_bad_replaced_index(spec, state):
@@ -231,7 +234,7 @@ def test_att1_bad_replaced_index(spec, state):
     yield from run_attester_slashing_processing(spec, state, attester_slashing, False)
 
 
-@with_phases(['phase0'])
+@with_phases([PHASE0])
 @spec_state_test
 @always_bls
 def test_att2_bad_extra_index(spec, state):
@@ -247,7 +250,7 @@ def test_att2_bad_extra_index(spec, state):
     yield from run_attester_slashing_processing(spec, state, attester_slashing, False)
 
 
-@with_phases(['phase0'])
+@with_phases([PHASE0])
 @spec_state_test
 @always_bls
 def test_att2_bad_replaced_index(spec, state):
@@ -263,7 +266,7 @@ def test_att2_bad_replaced_index(spec, state):
     yield from run_attester_slashing_processing(spec, state, attester_slashing, False)
 
 
-@with_phases(['phase0'])
+@with_phases([PHASE0])
 @spec_state_test
 @always_bls
 def test_att1_duplicate_index_normal_signed(spec, state):
@@ -283,7 +286,7 @@ def test_att1_duplicate_index_normal_signed(spec, state):
     yield from run_attester_slashing_processing(spec, state, attester_slashing, False)
 
 
-@with_phases(['phase0'])
+@with_phases([PHASE0])
 @spec_state_test
 @always_bls
 def test_att2_duplicate_index_normal_signed(spec, state):
@@ -303,7 +306,7 @@ def test_att2_duplicate_index_normal_signed(spec, state):
     yield from run_attester_slashing_processing(spec, state, attester_slashing, False)
 
 
-@with_phases(['phase0'])
+@with_phases([PHASE0])
 @spec_state_test
 @always_bls
 def test_att1_duplicate_index_double_signed(spec, state):
@@ -318,7 +321,7 @@ def test_att1_duplicate_index_double_signed(spec, state):
     yield from run_attester_slashing_processing(spec, state, attester_slashing, False)
 
 
-@with_phases(['phase0'])
+@with_phases([PHASE0])
 @spec_state_test
 @always_bls
 def test_att2_duplicate_index_double_signed(spec, state):
@@ -333,7 +336,7 @@ def test_att2_duplicate_index_double_signed(spec, state):
     yield from run_attester_slashing_processing(spec, state, attester_slashing, False)
 
 
-@with_phases(['phase0'])
+@with_phases([PHASE0])
 @spec_state_test
 def test_unsorted_att_1(spec, state):
     attester_slashing = get_valid_attester_slashing(spec, state, signed_1=False, signed_2=True)
@@ -346,7 +349,7 @@ def test_unsorted_att_1(spec, state):
     yield from run_attester_slashing_processing(spec, state, attester_slashing, False)
 
 
-@with_phases(['phase0'])
+@with_phases([PHASE0])
 @spec_state_test
 def test_unsorted_att_2(spec, state):
     attester_slashing = get_valid_attester_slashing(spec, state, signed_1=True, signed_2=False)

--- a/tests/core/pyspec/eth2spec/test/phase_1/block_processing/test_process_custody_key_reveal.py
+++ b/tests/core/pyspec/eth2spec/test/phase_1/block_processing/test_process_custody_key_reveal.py
@@ -1,5 +1,6 @@
 from eth2spec.test.helpers.custody import get_valid_custody_key_reveal
 from eth2spec.test.context import (
+    PHASE0,
     with_all_phases_except,
     spec_state_test,
     expect_assertion_error,
@@ -54,7 +55,7 @@ def run_custody_key_reveal_processing(spec, state, custody_key_reveal, valid=Tru
     yield 'post', state
 
 
-@with_all_phases_except(['phase0'])
+@with_all_phases_except([PHASE0])
 @spec_state_test
 @always_bls
 def test_success(spec, state):
@@ -64,7 +65,7 @@ def test_success(spec, state):
     yield from run_custody_key_reveal_processing(spec, state, custody_key_reveal)
 
 
-@with_all_phases_except(['phase0'])
+@with_all_phases_except([PHASE0])
 @spec_state_test
 @always_bls
 def test_reveal_too_early(spec, state):
@@ -73,7 +74,7 @@ def test_reveal_too_early(spec, state):
     yield from run_custody_key_reveal_processing(spec, state, custody_key_reveal, False)
 
 
-@with_all_phases_except(['phase0'])
+@with_all_phases_except([PHASE0])
 @spec_state_test
 @always_bls
 def test_wrong_period(spec, state):
@@ -82,7 +83,7 @@ def test_wrong_period(spec, state):
     yield from run_custody_key_reveal_processing(spec, state, custody_key_reveal, False)
 
 
-@with_all_phases_except(['phase0'])
+@with_all_phases_except([PHASE0])
 @spec_state_test
 @always_bls
 def test_late_reveal(spec, state):
@@ -92,7 +93,7 @@ def test_late_reveal(spec, state):
     yield from run_custody_key_reveal_processing(spec, state, custody_key_reveal)
 
 
-@with_all_phases_except(['phase0'])
+@with_all_phases_except([PHASE0])
 @spec_state_test
 @always_bls
 def test_double_reveal(spec, state):
@@ -104,7 +105,7 @@ def test_double_reveal(spec, state):
     yield from run_custody_key_reveal_processing(spec, state, custody_key_reveal, False)
 
 
-@with_all_phases_except(['phase0'])
+@with_all_phases_except([PHASE0])
 @spec_state_test
 @always_bls
 def test_max_decrement(spec, state):

--- a/tests/core/pyspec/eth2spec/test/phase_1/block_processing/test_process_early_derived_secret_reveal.py
+++ b/tests/core/pyspec/eth2spec/test/phase_1/block_processing/test_process_early_derived_secret_reveal.py
@@ -2,6 +2,7 @@ from eth2spec.test.helpers.custody import get_valid_early_derived_secret_reveal
 from eth2spec.test.helpers.block import apply_empty_block
 from eth2spec.test.helpers.state import next_epoch, get_balance
 from eth2spec.test.context import (
+    PHASE0,
     with_all_phases_except,
     spec_state_test,
     expect_assertion_error,
@@ -41,7 +42,7 @@ def run_early_derived_secret_reveal_processing(spec, state, randao_key_reveal, v
     yield 'post', state
 
 
-@with_all_phases_except(['phase0'])
+@with_all_phases_except([PHASE0])
 @spec_state_test
 @always_bls
 def test_success(spec, state):
@@ -50,7 +51,7 @@ def test_success(spec, state):
     yield from run_early_derived_secret_reveal_processing(spec, state, randao_key_reveal)
 
 
-@with_all_phases_except(['phase0'])
+@with_all_phases_except([PHASE0])
 @spec_state_test
 @never_bls
 def test_reveal_from_current_epoch(spec, state):
@@ -59,7 +60,7 @@ def test_reveal_from_current_epoch(spec, state):
     yield from run_early_derived_secret_reveal_processing(spec, state, randao_key_reveal, False)
 
 
-@with_all_phases_except(['phase0'])
+@with_all_phases_except([PHASE0])
 @spec_state_test
 @never_bls
 def test_reveal_from_past_epoch(spec, state):
@@ -70,7 +71,7 @@ def test_reveal_from_past_epoch(spec, state):
     yield from run_early_derived_secret_reveal_processing(spec, state, randao_key_reveal, False)
 
 
-@with_all_phases_except(['phase0'])
+@with_all_phases_except([PHASE0])
 @spec_state_test
 @always_bls
 def test_reveal_with_custody_padding(spec, state):
@@ -82,7 +83,7 @@ def test_reveal_with_custody_padding(spec, state):
     yield from run_early_derived_secret_reveal_processing(spec, state, randao_key_reveal, True)
 
 
-@with_all_phases_except(['phase0'])
+@with_all_phases_except([PHASE0])
 @spec_state_test
 @always_bls
 def test_reveal_with_custody_padding_minus_one(spec, state):
@@ -94,7 +95,7 @@ def test_reveal_with_custody_padding_minus_one(spec, state):
     yield from run_early_derived_secret_reveal_processing(spec, state, randao_key_reveal, True)
 
 
-@with_all_phases_except(['phase0'])
+@with_all_phases_except([PHASE0])
 @spec_state_test
 @never_bls
 def test_double_reveal(spec, state):
@@ -115,7 +116,7 @@ def test_double_reveal(spec, state):
     yield from run_early_derived_secret_reveal_processing(spec, state, randao_key_reveal2, False)
 
 
-@with_all_phases_except(['phase0'])
+@with_all_phases_except([PHASE0])
 @spec_state_test
 @never_bls
 def test_revealer_is_slashed(spec, state):
@@ -125,7 +126,7 @@ def test_revealer_is_slashed(spec, state):
     yield from run_early_derived_secret_reveal_processing(spec, state, randao_key_reveal, False)
 
 
-@with_all_phases_except(['phase0'])
+@with_all_phases_except([PHASE0])
 @spec_state_test
 @never_bls
 def test_far_future_epoch(spec, state):

--- a/tests/generators/bls/main.py
+++ b/tests/generators/bls/main.py
@@ -13,6 +13,7 @@ from gen_base import gen_runner, gen_typing
 from py_ecc import bls
 from hashlib import sha256
 
+from eth2spec.test.context import PHASE0
 
 def hash(x):
     return sha256(x).digest()
@@ -202,7 +203,7 @@ def create_provider(handler_name: str,
             print(data)
             (case_name, case_content) = data
             yield gen_typing.TestCase(
-                fork_name='phase0',
+                fork_name=PHASE0,
                 runner_name='bls',
                 handler_name=handler_name,
                 suite_name='small',

--- a/tests/generators/epoch_processing/main.py
+++ b/tests/generators/epoch_processing/main.py
@@ -13,6 +13,7 @@ from gen_base import gen_runner, gen_typing
 from gen_from_tests.gen import generate_from_tests
 from importlib import reload
 from eth2spec.config import config_util
+from eth2spec.test.context import PHASE0
 
 
 def create_provider(handler_name: str, tests_src, config_name: str) -> gen_typing.TestProvider:
@@ -28,7 +29,7 @@ def create_provider(handler_name: str, tests_src, config_name: str) -> gen_typin
             runner_name='epoch_processing',
             handler_name=handler_name,
             src=tests_src,
-            fork_name='phase0'
+            fork_name=PHASE0,
         )
 
     return gen_typing.TestProvider(prepare=prepare_fn, make_cases=cases_fn)

--- a/tests/generators/genesis/main.py
+++ b/tests/generators/genesis/main.py
@@ -1,5 +1,6 @@
 from typing import Iterable
 
+from eth2spec.test.context import PHASE0
 from eth2spec.test.genesis import test_initialization, test_validity
 
 from gen_base import gen_runner, gen_typing
@@ -21,7 +22,7 @@ def create_provider(handler_name: str, tests_src, config_name: str) -> gen_typin
             runner_name='genesis',
             handler_name=handler_name,
             src=tests_src,
-            fork_name='phase0'
+            fork_name=PHASE0,
         )
 
     return gen_typing.TestProvider(prepare=prepare_fn, make_cases=cases_fn)

--- a/tests/generators/operations/main.py
+++ b/tests/generators/operations/main.py
@@ -15,6 +15,7 @@ from importlib import reload
 from eth2spec.config import config_util
 from eth2spec.phase0 import spec as spec_phase0
 from eth2spec.phase1 import spec as spec_phase1
+from eth2spec.test.context import PHASE0
 
 
 def create_provider(handler_name: str, tests_src, config_name: str) -> gen_typing.TestProvider:
@@ -30,7 +31,7 @@ def create_provider(handler_name: str, tests_src, config_name: str) -> gen_typin
             runner_name='operations',
             handler_name=handler_name,
             src=tests_src,
-            fork_name='phase0'
+            fork_name=PHASE0,
         )
 
     return gen_typing.TestProvider(prepare=prepare_fn, make_cases=cases_fn)

--- a/tests/generators/sanity/main.py
+++ b/tests/generators/sanity/main.py
@@ -4,6 +4,7 @@ from importlib import reload
 from gen_base import gen_runner, gen_typing
 from gen_from_tests.gen import generate_from_tests
 
+from eth2spec.test.context import PHASE0
 from eth2spec.test.sanity import test_blocks, test_slots
 from eth2spec.config import config_util
 from eth2spec.phase0 import spec as spec_phase0
@@ -23,7 +24,7 @@ def create_provider(handler_name: str, tests_src, config_name: str) -> gen_typin
             runner_name='sanity',
             handler_name=handler_name,
             src=tests_src,
-            fork_name='phase0'
+            fork_name=PHASE0,
         )
 
     return gen_typing.TestProvider(prepare=prepare_fn, make_cases=cases_fn)

--- a/tests/generators/shuffling/main.py
+++ b/tests/generators/shuffling/main.py
@@ -6,6 +6,7 @@ from gen_base import gen_runner, gen_typing
 
 from eth2spec.config import config_util
 from eth2spec.phase0 import spec as spec
+from eth2spec.test.context import PHASE0
 
 
 def shuffling_case_fn(seed, count):
@@ -37,7 +38,7 @@ def create_provider(config_name: str) -> gen_typing.TestProvider:
     def cases_fn() -> Iterable[gen_typing.TestCase]:
         for (case_name, case_fn) in shuffling_test_cases():
             yield gen_typing.TestCase(
-                fork_name='phase0',
+                fork_name=PHASE0,
                 runner_name='shuffling',
                 handler_name='core',
                 suite_name='shuffle',

--- a/tests/generators/ssz_generic/main.py
+++ b/tests/generators/ssz_generic/main.py
@@ -6,6 +6,7 @@ import ssz_bitvector
 import ssz_boolean
 import ssz_uints
 import ssz_container
+from eth2spec.test.context import PHASE0
 
 
 def create_provider(handler_name: str, suite_name: str, case_maker) -> gen_typing.TestProvider:
@@ -16,7 +17,7 @@ def create_provider(handler_name: str, suite_name: str, case_maker) -> gen_typin
     def cases_fn() -> Iterable[gen_typing.TestCase]:
         for (case_name, case_fn) in case_maker():
             yield gen_typing.TestCase(
-                fork_name='phase0',
+                fork_name=PHASE0,
                 runner_name='ssz_generic',
                 handler_name=handler_name,
                 suite_name=suite_name,

--- a/tests/generators/ssz_static/main.py
+++ b/tests/generators/ssz_static/main.py
@@ -8,6 +8,7 @@ from gen_base import gen_runner, gen_typing
 from eth2spec.debug import random_value, encode
 from eth2spec.config import config_util
 from eth2spec.phase0 import spec
+from eth2spec.test.context import PHASE0
 from eth2spec.utils.ssz.ssz_typing import Container
 from eth2spec.utils.ssz.ssz_impl import (
     hash_tree_root,
@@ -44,7 +45,7 @@ def ssz_static_cases(seed: int, name, ssz_type, mode: random_value.Randomization
 
     for i in range(count):
         yield gen_typing.TestCase(
-            fork_name='phase0',
+            fork_name=PHASE0,
             runner_name='ssz_static',
             handler_name=name,
             suite_name=f"ssz_{random_mode_name}{'_chaos' if chaos else ''}",


### PR DESCRIPTION
### Issue
It's a bit annoying to type `'phase0'`, `'phase1'` strings in spec tests. Also, it may cause potential typo problems. e.g., `@with_all_phases_except(["phase_0"])` will test on phase 0.

### How did I fix it
Use constants to define the `SpecForkName`. 