### PR TITLE
update remerkleable; mul/div bound checks, update config loading

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -499,7 +499,7 @@ setup(
         "pycryptodome==3.9.4",
         "py_ecc==2.0.0",
         "dataclasses==0.6",
-        "remerkleable==0.1.12",
+        "remerkleable==0.1.13",
         "ruamel.yaml==0.16.5",
         "lru-dict==1.1.6"
     ]

--- a/tests/core/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_justification_and_finalization.py
+++ b/tests/core/pyspec/eth2spec/test/phase_0/epoch_processing/test_process_justification_and_finalization.py
@@ -24,7 +24,7 @@ def add_mock_attestations(spec, state, epoch, source, target, sufficient_support
         raise Exception(f"cannot include attestations in epoch ${epoch} from epoch ${current_epoch}")
 
     total_balance = spec.get_total_active_balance(state)
-    remaining_balance = total_balance * 2 // 3
+    remaining_balance = int(total_balance * 2 // 3)  # can become negative
 
     start_slot = spec.compute_start_slot_at_epoch(epoch)
     for slot in range(start_slot, start_slot + spec.SLOTS_PER_EPOCH):
@@ -42,7 +42,7 @@ def add_mock_attestations(spec, state, epoch, source, target, sufficient_support
             aggregation_bits = [0] * len(committee)
             for v in range(len(committee) * 2 // 3 + 1):
                 if remaining_balance > 0:
-                    remaining_balance -= state.validators[v].effective_balance
+                    remaining_balance -= int(state.validators[v].effective_balance)
                     aggregation_bits[v] = 1
                 else:
                     break


### PR DESCRIPTION
Update the SSZ library from v0.1.12 to v0.1.13, now with bound checks and type preservation on mul and floordiv. To catch overflow/underflow cases better. See #1701 

This remerkleable release is fully backwards compatible.

Updating one test helper value that was supposed to be a signed integer, and was previously (mul output was an `int`), but needed to be updated.

And updating the config loader to load config values with their existing types, and ignore unknown config keys (we do not want phase1 keys to leak into phase0 unnecessarily). An optional argument can make the ignored values explicit for debugging.

----

*Notes about new remerkleable functionality:*

One other new feature is that it offers some `readonly_iter()` iterators to allow for much faster stack-based iteration of compound views. Useful for users outside of the spec that want things to run faster. I am considering making this the default, but what should be noted here is that "readonly" means that updates/removals/additions of items in the iterated container during iteration cannot be seen until after the iteration is done. Maybe not so bad, given that many program languages default to not allowing modifications at all, or do the same?

Additionally, this readonly iter is the default for `Container` (since we don't normally iterate it dynamically), and enables fast unpacking:
```
class Foo(Container):
    a: uint64
    b: uint8
    c: Vector[uint16, 123]

foo = Foo(b=42)
a, b, c = foo
assert b == 42
```
