### PR TITLE
Fix some phase 0 typing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,7 @@ SSZObject = TypeVar('SSZObject', bound=View)
 PHASE1_IMPORTS = '''from eth2spec.phase0 import spec as phase0
 from eth2spec.config.config_util import apply_constants_config
 from typing import (
-    Any, Dict, Set, Sequence, NewType, Tuple, TypeVar, Callable
+    Any, Dict, Set, Sequence, NewType, Tuple, TypeVar, Callable, Optional
 )
 
 from dataclasses import (
@@ -146,8 +146,11 @@ _hash = hash
 hash_cache: Dict[bytes, Bytes32] = {}
 
 
-def get_eth1_data(distance: uint64) -> Bytes32:
-    return hash(distance)
+def get_eth1_data(block: Eth1Block) -> Eth1Data:
+    """
+    A stub function return mocking Eth1Data.
+    """
+    return Eth1Data(block_hash=hash_tree_root(block))
 
 
 def hash(x: bytes) -> Bytes32:  # type: ignore
@@ -373,6 +376,7 @@ class PySpecCommand(Command):
                 self.md_doc_paths = """
                     specs/phase0/beacon-chain.md
                     specs/phase0/fork-choice.md
+                    specs/phase0/validator.md
                     specs/phase1/custody-game.md
                     specs/phase1/beacon-chain.md
                     specs/phase1/fraud-proofs.md

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -1125,7 +1125,7 @@ def slash_validator(state: BeaconState,
     whistleblower_reward = Gwei(validator.effective_balance // WHISTLEBLOWER_REWARD_QUOTIENT)
     proposer_reward = Gwei(whistleblower_reward // PROPOSER_REWARD_QUOTIENT)
     increase_balance(state, proposer_index, proposer_reward)
-    increase_balance(state, whistleblower_index, whistleblower_reward - proposer_reward)
+    increase_balance(state, whistleblower_index, Gwei(whistleblower_reward - proposer_reward))
 ```
 
 ## Genesis
@@ -1229,7 +1229,7 @@ def process_slots(state: BeaconState, slot: Slot) -> None:
         # Process epoch on the start slot of the next epoch
         if (state.slot + 1) % SLOTS_PER_EPOCH == 0:
             process_epoch(state)
-        state.slot += Slot(1)
+        state.slot = Slot(state.slot + 1)
 ```
 
 ```python

--- a/tests/core/pyspec/eth2spec/config/config_util.py
+++ b/tests/core/pyspec/eth2spec/config/config_util.py
@@ -24,12 +24,12 @@ def apply_constants_config(spec_globals: Dict[str, Any], warn_if_unknown: bool =
 
 # Load presets from a file, and then prepares the global config setting. This does not apply the config.
 # To apply the config, reload the spec module (it will re-initialize with the config taken from here).
-def prepare_config(configs_path, config_name):
+def prepare_config(configs_path: str, config_name: str) -> None:
     global config
     config = load_config_file(configs_path, config_name)
 
 
-def load_config_file(configs_dir, presets_name) -> Dict[str, Any]:
+def load_config_file(configs_dir: str, presets_name: str) -> Dict[str, Any]:
     """
     Loads the given preset
     :param presets_name: The name of the presets. (lowercase snake_case)
@@ -38,7 +38,7 @@ def load_config_file(configs_dir, presets_name) -> Dict[str, Any]:
     path = Path(join(configs_dir, presets_name + '.yaml'))
     yaml = YAML(typ='base')
     loaded = yaml.load(path)
-    out = dict()
+    out: Dict[str, Any] = dict()
     for k, v in loaded.items():
         if isinstance(v, list):
             # Clean up integer values. YAML parser renders lists of ints as list of str

--- a/tests/core/pyspec/eth2spec/utils/hash_function.py
+++ b/tests/core/pyspec/eth2spec/utils/hash_function.py
@@ -1,28 +1,17 @@
 from hashlib import sha256
+from typing import Dict, Union
 
 ZERO_BYTES32 = b'\x00' * 32
 
 
-def _hash(x):
+def _hash(x: Union[bytes, bytearray, memoryview]) -> bytes:
     return sha256(x).digest()
 
 
-# Minimal collection of (key, value) pairs, for fast hash-retrieval, to save on repetitive computation cost.
-# Key = the hash input
-# Value = the hash output
-hash_cache = []
+hash_cache: Dict[bytes, bytes] = {}
 
 
-def add_zero_hashes_to_cache():
-    zerohashes = [(None, ZERO_BYTES32)]
-    for layer in range(1, 32):
-        k = zerohashes[layer - 1][1] + zerohashes[layer - 1][1]
-        zerohashes.append((k, _hash(k)))
-    hash_cache.extend(zerohashes[1:])
-
-
-def hash(x):
-    for (k, h) in hash_cache:
-        if x == k:
-            return h
+def hash(x: bytes) -> bytes:
+    if x in hash_cache:
+        return hash_cache[x]
     return _hash(x)


### PR DESCRIPTION
This PR fixes some typing issues found in #1707.
1. Fix the mocking `get_eth1_data` in `setup.py`
2. Fix the outdated/missing typing
    - `utils.hash_function`
    - `config.config_util`
3. Fix some missing type castings in `beacon-chain.md` 


No substantive change.