### PR TITLE
Allow aggregate where aggregator has not attested

### DIFF
--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -293,7 +293,7 @@ There are two primary global topics used to propagate beacon blocks and aggregat
     - The `aggregate` is the first valid aggregate received for the aggregator with index `aggregate_and_proof.aggregator_index` for the epoch `aggregate.data.target.epoch`.
     - The block being voted for (`aggregate.data.beacon_block_root`) passes validation.
     - `aggregate_and_proof.selection_proof` selects the validator as an aggregator for the slot -- i.e. `is_aggregator(state, aggregate.data.slot, aggregate.data.index, aggregate_and_proof.selection_proof)` returns `True`.
-    - The aggregator's validator index is within the aggregate's committee -- i.e. `aggregate_and_proof.aggregator_index in get_attesting_indices(state, aggregate.data, aggregate.aggregation_bits)`.
+    - The aggregator's validator index is within the aggregate's committee -- i.e. `aggregate_and_proof.aggregator_index in get_beacon_committee(state, aggregate.data.slot, aggregate.data.index)`.
     - The `aggregate_and_proof.selection_proof` is a valid signature of the `aggregate.data.slot` by the validator with index `aggregate_and_proof.aggregator_index`.
     - The aggregator signature, `signed_aggregate_and_proof.signature`, is valid.
     - The signature of `aggregate` is valid.


### PR DESCRIPTION
Presently an `aggregate_and_proof` must include three signatures from the aggregator:

1. `aggregate_and_proof.signature`
1. `aggregate_and_proof.message.selection_proof`
1. `aggregate_and_proof.message.aggregate.signature`

I propose that we remove the requirement for (3).

Consider the following scenario where a validator client (VC) is connected to a failing beacon node (BN) `A` but knows a backup BN `B`:

- Start of slot
  - VC is connected to BN `A`.
- 1/3 through slot
  - VC creates an unaggregated attestation with BN `A`
- 1/2 through slot
  - VC decides that BN `A` is trash and switches to BN `B`.
- 2/3 through slot
  - VC produces and publishes an aggregated attestation using BN `B`.

If BN `B` hasn't seen the first unaggregated attestation published by BN `A` (it is trash, after all) then requirement (3) will cause the aggregated attestation from BN `B` to be invalid. Whilst this is a shame for the VC, the network is deprived of a potentially useful aggregate.

