### PR TITLE
Unified equivocation slashing

### DIFF
--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -46,7 +46,7 @@
     - [`BeaconBlock`](#beaconblock)
   - [Beacon state](#beacon-state)
     - [`BeaconState`](#beaconstate)
-  - [Signatures](#signed-envelopes)
+  - [Signed envelopes](#signed-envelopes)
     - [`SignedVoluntaryExit`](#signedvoluntaryexit)
     - [`SignedBeaconBlock`](#signedbeaconblock)
 - [Helper functions](#helper-functions)

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -1562,8 +1562,8 @@ def process_equivocation(state: BeaconState, equivocation: Equivocation) -> None
     # Verify that the equivocation root is not all zero bytes
     assert equivocation.equivocation_root != Root()
     # Verify that the signing roots are distinct
-    signing_root_1 = hash_tree_root(SigningData(equivocation.object_root_1), equivocation_root, domain)
-    signing_root_2 = hash_tree_root(SigningData(equivocation.object_root_2), equivocation_root, domain)
+    signing_root_1 = hash_tree_root(SigningData(equivocation.object_root_1, equivocation_root, domain))
+    signing_root_2 = hash_tree_root(SigningData(equivocation.object_root_2, equivocation_root, domain))
     assert signing_root_1 != signing_root_2
     # Verify that the signatures are valid
     validator = state.validators[equivocation.validator_index]

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -846,7 +846,7 @@ def compute_domain(domain_type: DomainType, fork_version: Version=None, genesis_
 ```python
 def compute_signing_root(ssz_object: SSZObject, domain: Domain, equivocation_root: Root=Root()) -> Root:
     """
-    Return the signing root corresponding ot the signing data.
+    Return the signing root corresponding to the signing data.
     """
     return hash_tree_root(SigningData(
         object_root=hash_tree_root(ssz_object),


### PR DESCRIPTION
See https://github.com/ethereum/eth2.0-specs/issues/1387. Special thanks to @hwwhww for pinging me :)

**TLDR**: Unify all forms of slashing from equivocation (in particular equivocation through beacon proposing in phase 0, or through shard proposing and shard attesting in phase 1) into a single equivocation slashing condition.

**rationale**: This is a significant simplification to the slashing logic for phase 1. Each slashing condition costs about 50 lines of consensus code and needs to be separately tested. All in all we save about 100 lines of consensus code for phase 1. Avoiding two slashing conditions in phase 1 correspondingly simplifies testing.

**substantive changes**:

* Introduce `equivocation_root` in signing root
* Replace `process_proposer_slashing` by `process_equivocation`

**cosmetic changes**:

* Move `BeaconBlockHeader` aside `BeaconBlockBody` and `BeaconBlock`
* Rename `SigningRoot` to `SigningData`
* Remove a couple of unnecessary new lines

cc @vbuterin, @djrtwo