### PR TITLE
Fix #1735—remove redundant check

### DIFF
--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -684,14 +684,10 @@ def is_slashable_attestation_data(data_1: AttestationData, data_2: AttestationDa
 ```python
 def is_valid_indexed_attestation(state: BeaconState, indexed_attestation: IndexedAttestation) -> bool:
     """
-    Check if ``indexed_attestation`` has valid indices and signature.
+    Check if ``indexed_attestation`` has sorted and unique indices and a valid aggregate signature.
     """
-    indices = indexed_attestation.attesting_indices
-
-    # Verify max number of indices
-    if not len(indices) <= MAX_VALIDATORS_PER_COMMITTEE:
-        return False
     # Verify indices are sorted and unique
+    indices = indexed_attestation.attesting_indices
     if not indices == sorted(set(indices)):
         return False
     # Verify aggregate signature


### PR DESCRIPTION
As per #1735 the check `if not len(indices) <= MAX_VALIDATORS_PER_COMMITTEE: return False` is redundant. As such this PR should be purely cosmetic.