### PR TITLE
Add sanity, unit test for validator guide

### DIFF
--- a/configs/minimal.yaml
+++ b/configs/minimal.yaml
@@ -89,7 +89,7 @@ MIN_SEED_LOOKAHEAD: 1
 # 2**2 (= 4) epochs
 MAX_SEED_LOOKAHEAD: 4
 # [customized] higher frequency new deposits from eth1 for testing
-EPOCHS_PER_ETH1_VOTING_PERIOD: 2
+EPOCHS_PER_ETH1_VOTING_PERIOD: 4
 # [customized] smaller state
 SLOTS_PER_HISTORICAL_ROOT: 64
 # 2**8 (= 256) epochs

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -281,8 +281,8 @@ def voting_period_start_time(state: BeaconState) -> uint64:
 ```python
 def is_candidate_block(block: Eth1Block, period_start: uint64) -> bool:
     return (
-        block.timestamp <= period_start - SECONDS_PER_ETH1_BLOCK * ETH1_FOLLOW_DISTANCE
-        and block.timestamp >= period_start - SECONDS_PER_ETH1_BLOCK * ETH1_FOLLOW_DISTANCE * 2
+        block.timestamp + SECONDS_PER_ETH1_BLOCK * ETH1_FOLLOW_DISTANCE <= period_start
+        and block.timestamp + SECONDS_PER_ETH1_BLOCK * ETH1_FOLLOW_DISTANCE * 2 >= period_start
     )
 ```
 
@@ -350,9 +350,9 @@ def compute_new_state_root(state: BeaconState, block: BeaconBlock) -> Root:
 `signed_block = SignedBeaconBlock(message=block, signature=block_signature)`, where `block_signature` is obtained from:
 
 ```python
-def get_block_signature(state: BeaconState, header: BeaconBlockHeader, privkey: int) -> BLSSignature:
-    domain = get_domain(state, DOMAIN_BEACON_PROPOSER, compute_epoch_at_slot(header.slot))
-    signing_root = compute_signing_root(header, domain)
+def get_block_signature(state: BeaconState, block: BeaconBlock, privkey: int) -> BLSSignature:
+    domain = get_domain(state, DOMAIN_BEACON_PROPOSER, compute_epoch_at_slot(block.slot))
+    signing_root = compute_signing_root(block, domain)
     return bls.Sign(privkey, signing_root)
 ```
 

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -340,9 +340,10 @@ It is useful to be able to run a state transition function (working on a copy of
 
 ```python
 def compute_new_state_root(state: BeaconState, block: BeaconBlock) -> Root:
-    process_slots(state, block.slot)
-    process_block(state, block)
-    return hash_tree_root(state)
+    temp_state: BeaconState = state.copy()
+    signed_block = SignedBeaconBlock(message=block)
+    temp_state = state_transition(temp_state, signed_block, validate_result=False)
+    return hash_tree_root(temp_state)
 ```
 
 ##### Signature

--- a/tests/core/pyspec/eth2spec/test/validator/test_validator_unittest.py
+++ b/tests/core/pyspec/eth2spec/test/validator/test_validator_unittest.py
@@ -1,0 +1,182 @@
+from eth2spec.test.context import spec_state_test, never_bls, with_all_phases
+from eth2spec.test.helpers.block import build_empty_block
+from eth2spec.test.helpers.deposits import prepare_state_and_deposit
+from eth2spec.test.helpers.keys import privkeys, pubkeys
+from eth2spec.test.helpers.state import next_epoch
+from eth2spec.utils import bls
+
+
+def run_is_candidate_block(spec, eth1_block, period_start, success):
+    result = spec.is_candidate_block(eth1_block, period_start)
+    if success:
+        assert result
+    else:
+        assert not result
+
+
+def get_min_new_period_epochs(spec):
+    return int(
+        spec.SECONDS_PER_ETH1_BLOCK * spec.ETH1_FOLLOW_DISTANCE * 2  # to seconds
+        / spec.SECONDS_PER_SLOT / spec.SLOTS_PER_EPOCH
+    )
+
+
+#
+# Becoming a validator
+#
+
+
+@with_all_phases
+@spec_state_test
+@never_bls
+def test_check_if_validator_active(spec, state):
+    active_validator_index = len(state.validators) - 1
+    assert spec.check_if_validator_active(state, active_validator_index)
+    new_validator_index = len(state.validators)
+    amount = spec.MAX_EFFECTIVE_BALANCE
+    deposit = prepare_state_and_deposit(spec, state, new_validator_index, amount, signed=True)
+    spec.process_deposit(state, deposit)
+    assert not spec.check_if_validator_active(state, new_validator_index)
+
+
+#
+# Validator assignments
+#
+
+
+@with_all_phases
+@spec_state_test
+@never_bls
+def test_get_committee_assignment(spec, state):
+    epoch = spec.get_current_epoch(state)
+    validator_index = len(state.validators) - 1
+    assignment = spec.get_committee_assignment(state, epoch, validator_index)
+    committee, committee_index, slot = assignment
+    assert spec.compute_epoch_at_slot(slot) == epoch
+    assert committee == spec.get_beacon_committee(state, slot, committee_index)
+    assert committee_index < spec.get_committee_count_at_slot(state, slot)
+
+
+@with_all_phases
+@spec_state_test
+@never_bls
+def test_is_proposer(spec, state):
+    proposer_index = spec.get_beacon_proposer_index(state)
+    assert spec.is_proposer(state, proposer_index)
+
+    proposer_index = proposer_index + 1 % len(state.validators)
+    assert not spec.is_proposer(state, proposer_index)
+
+
+#
+# Beacon chain responsibilities
+#
+
+
+# Block proposal
+
+
+@with_all_phases
+@spec_state_test
+def test_get_epoch_signature(spec, state):
+    block = spec.BeaconBlock()
+    privkey = privkeys[0]
+    pubkey = pubkeys[0]
+    signature = spec.get_epoch_signature(state, block, privkey)
+    domain = spec.get_domain(state, spec.DOMAIN_RANDAO, spec.compute_epoch_at_slot(block.slot))
+    signing_root = spec.compute_signing_root(spec.compute_epoch_at_slot(block.slot), domain)
+    assert bls.Verify(pubkey, signing_root, signature)
+
+
+@with_all_phases
+@spec_state_test
+def test_is_candidate_block(spec, state):
+    period_start = spec.SECONDS_PER_ETH1_BLOCK * spec.ETH1_FOLLOW_DISTANCE * 2 + 1000
+    run_is_candidate_block(
+        spec,
+        spec.Eth1Block(timestamp=period_start - spec.SECONDS_PER_ETH1_BLOCK * spec.ETH1_FOLLOW_DISTANCE),
+        period_start,
+        success=True,
+    )
+    run_is_candidate_block(
+        spec,
+        spec.Eth1Block(timestamp=period_start - spec.SECONDS_PER_ETH1_BLOCK * spec.ETH1_FOLLOW_DISTANCE + 1),
+        period_start,
+        success=False,
+    )
+    run_is_candidate_block(
+        spec,
+        spec.Eth1Block(timestamp=period_start - spec.SECONDS_PER_ETH1_BLOCK * spec.ETH1_FOLLOW_DISTANCE * 2),
+        period_start,
+        success=True,
+    )
+    run_is_candidate_block(
+        spec,
+        spec.Eth1Block(timestamp=period_start - spec.SECONDS_PER_ETH1_BLOCK * spec.ETH1_FOLLOW_DISTANCE * 2 - 1),
+        period_start,
+        success=False,
+    )
+
+
+@with_all_phases
+@spec_state_test
+def test_get_eth1_data_default_vote(spec, state):
+    min_new_period_epochs = get_min_new_period_epochs(spec)
+    for _ in range(min_new_period_epochs):
+        next_epoch(spec, state)
+
+    state.eth1_data_votes = ()
+    eth1_chain = []
+    eth1_data = spec.get_eth1_vote(state, eth1_chain)
+    assert eth1_data == state.eth1_data
+
+
+@with_all_phases
+@spec_state_test
+def test_get_eth1_data_consensus_vote(spec, state):
+    min_new_period_epochs = get_min_new_period_epochs(spec)
+    for _ in range(min_new_period_epochs):
+        next_epoch(spec, state)
+
+    period_start = spec.voting_period_start_time(state)
+    votes_length = spec.get_current_epoch(state) % spec.EPOCHS_PER_ETH1_VOTING_PERIOD
+    state.eth1_data_votes = ()
+    eth1_chain = []
+    eth1_data_votes = []
+    block = spec.Eth1Block(timestamp=period_start - spec.SECONDS_PER_ETH1_BLOCK * spec.ETH1_FOLLOW_DISTANCE)
+    for i in range(votes_length):
+        eth1_chain.append(block)
+        eth1_data_votes.append(spec.get_eth1_data(block))
+
+    state.eth1_data_votes = eth1_data_votes
+    eth1_data = spec.get_eth1_vote(state, eth1_chain)
+    print(state.eth1_data_votes)
+    assert eth1_data.block_hash == block.hash_tree_root()
+
+
+@with_all_phases
+@spec_state_test
+def test_compute_new_state_root(spec, state):
+    pre_state = state.copy()
+    post_state = state.copy()
+    block = build_empty_block(spec, state, state.slot + 1)
+    state_root = spec.compute_new_state_root(state, block)
+
+    assert state_root != pre_state.hash_tree_root()
+
+    # dumb verification
+    spec.process_slots(post_state, block.slot)
+    spec.process_block(post_state, block)
+    assert state_root == post_state.hash_tree_root()
+
+
+@with_all_phases
+@spec_state_test
+def test_get_block_signature(spec, state):
+    privkey = privkeys[0]
+    pubkey = pubkeys[0]
+    block = build_empty_block(spec, state)
+    signature = spec.get_block_signature(state, block, privkey)
+    domain = spec.get_domain(state, spec.DOMAIN_BEACON_PROPOSER, spec.compute_epoch_at_slot(block.slot))
+    signing_root = spec.compute_signing_root(block, domain)
+    assert bls.Verify(pubkey, signing_root, signature)

--- a/tests/core/pyspec/eth2spec/test/validator/test_validator_unittest.py
+++ b/tests/core/pyspec/eth2spec/test/validator/test_validator_unittest.py
@@ -246,6 +246,7 @@ def test_compute_new_state_root(spec, state):
     state_root = spec.compute_new_state_root(state, block)
 
     assert state_root != pre_state.hash_tree_root()
+    assert state == pre_state
 
     # dumb verification
     spec.process_slots(post_state, block.slot)

--- a/tests/core/pyspec/eth2spec/utils/bls.py
+++ b/tests/core/pyspec/eth2spec/utils/bls.py
@@ -51,3 +51,8 @@ def Sign(SK, message):
 @only_with_bls(alt_return=STUB_COORDINATES)
 def signature_to_G2(signature):
     return _signature_to_G2(signature)
+
+
+@only_with_bls(alt_return=STUB_PUBKEY)
+def AggregatePKs(pubkeys):
+    return bls._AggregatePKs(pubkeys)


### PR DESCRIPTION
1. Add unit tests for validator guide to improve test coverage. (Fix #1352)
    * phase 0 spec.py test coverage raises from `93%` to `99%` 
    * note that these tests are not part of client test vectors
2. Validator guide update:
    1. Avoid negative computation in `is_candidate_block`
    2. Fix `get_block_signature`: avoid extra casting; it's simpler to use `BeaconBlock` instead of `BeaconHeader`.
    3. Make `compute_new_state_root` a pure function.
3. Update `minimal.config`: Increase `EPOCHS_PER_ETH1_VOTING_PERIOD` from `2` to `4` for testing eth1 votes consensus vote


