### PR TITLE
Rewards/penalties approach [illustrative, do not merge]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,8 +84,10 @@ apply_constants_config(globals())
 
 PHASE0_IMPORTS = '''from eth2spec.config.config_util import apply_constants_config
 from typing import (
-    Any, Callable, Dict, Set, Sequence, Tuple, Optional, TypeVar
+    Any, Callable, Dict, Set, Sequence, Tuple, Optional, TypeVar, NamedTuple
 )
+
+from itertools import repeat
 
 from dataclasses import (
     dataclass,
@@ -108,8 +110,10 @@ SSZObject = TypeVar('SSZObject', bound=View)
 PHASE1_IMPORTS = '''from eth2spec.phase0 import spec as phase0
 from eth2spec.config.config_util import apply_constants_config
 from typing import (
-    Any, Dict, Set, Sequence, NewType, Tuple, TypeVar, Callable
+    Any, Dict, Set, Sequence, NewType, Tuple, TypeVar, Callable, Optional, NamedTuple
 )
+
+from itertools import repeat
 
 from dataclasses import (
     dataclass,
@@ -178,11 +182,6 @@ get_total_active_balance = cache_this(
     lambda state: (state.validators.hash_tree_root(), compute_epoch_at_slot(state.slot)),
     _get_total_active_balance, lru_size=10)
 
-_get_base_reward = get_base_reward
-get_base_reward = cache_this(
-    lambda state, index: (state.validators.hash_tree_root(), state.slot, index),
-    _get_base_reward, lru_size=2048)
-
 _get_committee_count_at_slot = get_committee_count_at_slot
 get_committee_count_at_slot = cache_this(
     lambda state, epoch: (state.validators.hash_tree_root(), epoch),
@@ -202,11 +201,6 @@ _get_matching_target_attestations = get_matching_target_attestations
 get_matching_target_attestations = cache_this(
     lambda state, epoch: (state.hash_tree_root(), epoch),
     _get_matching_target_attestations, lru_size=10)
-
-_get_matching_head_attestations = get_matching_head_attestations
-get_matching_head_attestations = cache_this(
-    lambda state, epoch: (state.hash_tree_root(), epoch),
-    _get_matching_head_attestations, lru_size=10)
 
 _get_attesting_indices = get_attesting_indices
 get_attesting_indices = cache_this(

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -1332,11 +1332,6 @@ def process_justification_and_finalization(state: BeaconState) -> None:
 #### Rewards and penalties
 
 ```python
-# TODO
-from typing import NamedTuple, Optional
-from itertools import repeat
-
-
 class Support(NamedTuple):
     everyone: Gwei
     source: Gwei
@@ -1425,8 +1420,7 @@ def prepare_attester_status_list(state: BeaconState) -> Tuple[Support, Sequence[
     return Support(max(total_active_balance, EFFECTIVE_BALANCE_INCREMENT),
                    max(source_stake, EFFECTIVE_BALANCE_INCREMENT),
                    max(target_stake, EFFECTIVE_BALANCE_INCREMENT),
-                   max(head_stake, EFFECTIVE_BALANCE_INCREMENT)),
-           statuses
+                   max(head_stake, EFFECTIVE_BALANCE_INCREMENT)), statuses
 
 
 def transpose_deltas(per_validator: Sequence[Tuple[Gwei, Gwei]]) -> Tuple[Sequence[Gwei], Sequence[Gwei]]:


### PR DESCRIPTION
The other PR #1747  is good too, but I wanted to put out a more radical proposal before we commit to something. If we want to test rewards/penalties in greater detail, I think this is a better approach.

Ideas:
- Pre-computation is so prevalant that the spec should help test it
- Make state testable; we could test the attester status results more easily than the deltas. Since now we have concrete values to check. No guessing if the state was interpreted correctly.
- Make as many functions as possible pure: no unexpected state input. Allow to test with just those inputs, to make lots of tests with small input sizes possible
- Encapsulate reward/penalty functions. Don't do whole series at the same time, but make it fast, cause nothing new is allocated/computed per validator entry.
- Make rewards/penalties explicit: I want to know exactly how much of each reward a validator gets, or is penalized. This is nice for explorers, and good for testing. The named tuples can sum nicely as well into a single `(reward, penalty)` tuple per validator.

This is just a draft, there are several TODO points:
- Clean up dependencies
- Get minimum 1 increment for stake totals right
- Lots of naming problems
- Test if it passes the current tests, it should be the same
- Clean up support-component calculations. The head/source/target is repetitive.
