### PR TITLE
fix requirements.txt for bls generator

### DIFF
--- a/tests/generators/bls/requirements.txt
+++ b/tests/generators/bls/requirements.txt
@@ -1,3 +1,4 @@
 py_ecc==2.0.0
 eth-utils==1.6.0
 ../../core/gen_helpers
+../../../


### PR DESCRIPTION
BLS generator was broken from a bad import introduced recently.


Issue was in `tests/generators/bls/main.py`
It recently added eth2spec dependency because it imports PHASE0 constant, but this was not in the requirements.txt
