### PR TITLE
Fork choice: Remove redundant check in validate_on_attestation

### DIFF
--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -278,8 +278,6 @@ def validate_on_attestation(store: Store, attestation: Attestation) -> None:
 
     # Attestations target be for a known block. If target block is unknown, delay consideration until the block is found
     assert target.root in store.blocks
-    # Attestations cannot be from future epochs. If they are, delay consideration until the epoch arrives
-    assert get_current_slot(store) >= compute_start_slot_at_epoch(target.epoch)
 
     # Attestations must be for a known block. If block is unknown, delay consideration until the block is found
     assert attestation.data.beacon_block_root in store.blocks

--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -273,6 +273,7 @@ def validate_on_attestation(store: Store, attestation: Attestation) -> None:
     current_epoch = compute_epoch_at_slot(get_current_slot(store))
     # Use GENESIS_EPOCH for previous when genesis to avoid underflow
     previous_epoch = current_epoch - 1 if current_epoch > GENESIS_EPOCH else GENESIS_EPOCH
+    # If attestation target is from a future epoch, delay consideration until the epoch arrives
     assert target.epoch in [current_epoch, previous_epoch]
     assert target.epoch == compute_epoch_at_slot(attestation.data.slot)
 


### PR DESCRIPTION
Removes a redundant check from fork choice `validate_on_attestation`.

`assert target.epoch in [current_epoch, previous_epoch]` already asserts this.

I've raised this for a few reasons:

- To ensure I'm not missing something.
- If it's impossible to hit then it's impossible to test and I think we should remove it.
- The "... delay consideration ..." note becomes ineffective if we can never reach it.