### PR TITLE
genesis: clarify that eth1 timestamp can be less than min genesis time

### DIFF
--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -1170,6 +1170,8 @@ def initialize_beacon_state_from_eth1(eth1_block_hash: Bytes32,
     return state
 ```
 
+*Note*: The ETH1 block with `eth1_timestamp` meeting the minimum genesis active validator count criteria can also occur before `MIN_GENESIS_TIME`.
+
 ### Genesis state
 
 Let `genesis_state = candidate_state` whenever `is_valid_genesis_state(candidate_state) is True` for the first time.


### PR DESCRIPTION
ref https://github.com/prysmaticlabs/prysm/issues/5616 https://github.com/sigp/lighthouse/issues/1051