### PR TITLE
Disallow single Eth1 block in two voting periods

### DIFF
--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -281,7 +281,7 @@ def voting_period_start_time(state: BeaconState) -> uint64:
 ```python
 def is_candidate_block(block: Eth1Block, period_start: uint64) -> bool:
     return (
-        block.timestamp <= period_start - SECONDS_PER_ETH1_BLOCK * ETH1_FOLLOW_DISTANCE
+        block.timestamp < period_start - SECONDS_PER_ETH1_BLOCK * ETH1_FOLLOW_DISTANCE
         and block.timestamp >= period_start - SECONDS_PER_ETH1_BLOCK * ETH1_FOLLOW_DISTANCE * 2
     )
 ```


### PR DESCRIPTION
The definition of a candidate block in `is_candidate_block` allows for an Eth1 block whose timestamp is exactly aligned with the start of an Eth1 voting period to be considered in two voting periods.

This patch ensures that such a block can only be included as a candidate for a single voting period.