### PR TITLE
Unify equivocation slashing (substantive changes)

### DIFF
--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -1562,7 +1562,7 @@ def process_operations(state: BeaconState, body: BeaconBlockBody) -> None:
 
 ```python
 def process_proposer_slashing(state: BeaconState, proposer_slashing: ProposerSlashing) -> None:
-    # Verify that the domain is eligible for proposer_slashing slashing
+    # Verify that the domain is eligible for proposer slashing
     domain = proposer_slashing.domain
     assert domain in (DOMAIN_BEACON_PROPOSER)
     # Verify that the uniqueness root is not all zero bytes

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -1563,7 +1563,8 @@ def process_operations(state: BeaconState, body: BeaconBlockBody) -> None:
 ```python
 def process_proposer_slashing(state: BeaconState, proposer_slashing: ProposerSlashing) -> None:
     # Verify that the domain is eligible for proposer_slashing slashing
-    assert proposer_slashing.domain in (DOMAIN_BEACON_PROPOSER)
+    domain = proposer_slashing.domain
+    assert domain in (DOMAIN_BEACON_PROPOSER)
     # Verify that the uniqueness root is not all zero bytes
     assert proposer_slashing.uniqueness_root != Root()
     # Verify that the signing roots are distinct

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -402,8 +402,8 @@ class BeaconBlockHeader(Container):
 ```python
 class SigningData(Container):
     object_root: Root
-    uniqueness_root: Root
     domain: Domain
+    uniqueness_root: Root
 ```
 
 ### Beacon operations
@@ -856,8 +856,8 @@ def compute_signing_root(ssz_object: SSZObject, domain: Domain, uniqueness_root:
     """
     return hash_tree_root(SigningData(
         object_root=hash_tree_root(ssz_object),
-        uniqueness_root=uniqueness_root,
         domain=domain,
+        uniqueness_root=uniqueness_root,
     ))
 ```
 
@@ -1568,8 +1568,8 @@ def process_proposer_slashing(state: BeaconState, proposer_slashing: ProposerSla
     # Verify that the uniqueness root is not all zero bytes
     assert proposer_slashing.uniqueness_root != Root()
     # Verify that the signing roots are distinct
-    signing_root_1 = hash_tree_root(SigningData(proposer_slashing.object_root_1, uniqueness_root, domain))
-    signing_root_2 = hash_tree_root(SigningData(proposer_slashing.object_root_2, uniqueness_root, domain))
+    signing_root_1 = hash_tree_root(SigningData(proposer_slashing.object_root_1, domain, uniqueness_root))
+    signing_root_2 = hash_tree_root(SigningData(proposer_slashing.object_root_2, domain, uniqueness_root))
     assert signing_root_1 != signing_root_2
     # Verify that the signatures are valid
     validator = state.validators[proposer_slashing.validator_index]


### PR DESCRIPTION
**TLDR**: Unify all forms of slashing from equivocation into a single equivocation slashing condition. This is a simplification for phase 1. This PR is a simplification of https://github.com/ethereum/eth2.0-specs/pull/1737 focusing on substantive changes.

**substantive changes**

* introduce `uniqueness_root` in the `SigningData` container (with support in `compute_signing_root` and `verify_block_signature`)
* generalise `ProposerSlashing` and `process_proposer_slashing` to be handle any kind of equivocation

**how it works**

Signatures sign over a new `uniqueness_root` field which by default is set to `Root()` (all zero bytes). If a signed message (e.g. a signed block) has a slashing condition to protect against equivocations then the `uniqueness_root` is set to the `hash_tree_root` of the data which is meant to be unique. For example, for block proposals, a proposer must not sign two blocks with the same `slot` therefore signed blocks have `uniqueness_root` set to `hash_tree_root(Slot(signed_block.slot))`.