### PR TITLE
Add latest release and pypi version badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ This repository hosts the current Eth2 specifications. Discussions about design 
 
 ## Specs
 
+[![GitHub release](https://img.shields.io/github/v/release/ethereum/eth2.0-specs)](https://github.com/ethereum/eth2.0-specs/releases/) [![PyPI version](https://badge.fury.io/py/eth2spec.svg)](https://badge.fury.io/py/eth2spec)
+
+
 Core specifications for Eth2 clients be found in [specs](specs/). These are divided into phases. Each subsequent phase depends upon the prior. The current phases specified are:
 
 ### Phase 0


### PR DESCRIPTION
## Issue
As #1788 pointed out, the latest spec version is not obvious.

## How to solve it
Add some badges 🦡 