### PR TITLE
[Minor] Fix config readme example to not assign a return value.

### DIFF
--- a/tests/core/pyspec/eth2spec/config/README.md
+++ b/tests/core/pyspec/eth2spec/config/README.md
@@ -12,7 +12,7 @@ configs_path = 'configs/'
 from eth2spec.config import config_util
 from eth2spec.phase0 import spec
 from importlib import reload
-my_presets = config_util.prepare_config(configs_path, 'mainnet')
+config_util.prepare_config(configs_path, 'mainnet')
 # reload spec to make loaded config effective
 reload(spec)
 ```


### PR DESCRIPTION
`config_util.prepare_config()` no longer returns a value.