### PR TITLE
MAX_ATTESTER_SLASHINGS == 2 and add multiple slashings per block tests

### DIFF
--- a/configs/mainnet.yaml
+++ b/configs/mainnet.yaml
@@ -132,8 +132,8 @@ MIN_SLASHING_PENALTY_QUOTIENT: 32
 # ---------------------------------------------------------------
 # 2**4 (= 16)
 MAX_PROPOSER_SLASHINGS: 16
-# 2**0 (= 1)
-MAX_ATTESTER_SLASHINGS: 1
+# 2**1 (= 2)
+MAX_ATTESTER_SLASHINGS: 2
 # 2**7 (= 128)
 MAX_ATTESTATIONS: 128
 # 2**4 (= 16)

--- a/configs/minimal.yaml
+++ b/configs/minimal.yaml
@@ -132,8 +132,8 @@ MIN_SLASHING_PENALTY_QUOTIENT: 32
 # ---------------------------------------------------------------
 # 2**4 (= 16)
 MAX_PROPOSER_SLASHINGS: 16
-# 2**0 (= 1)
-MAX_ATTESTER_SLASHINGS: 1
+# 2**1 (= 2)
+MAX_ATTESTER_SLASHINGS: 2
 # 2**7 (= 128)
 MAX_ATTESTATIONS: 128
 # 2**4 (= 16)

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -252,7 +252,7 @@ The following values are (non-configurable) constants used throughout the specif
 | Name | Value |
 | - | - |
 | `MAX_PROPOSER_SLASHINGS` | `2**4` (= 16) |
-| `MAX_ATTESTER_SLASHINGS` | `2**0` (= 1) |
+| `MAX_ATTESTER_SLASHINGS` | `2**1` (= 2) |
 | `MAX_ATTESTATIONS` | `2**7` (= 128) |
 | `MAX_DEPOSITS` | `2**4` (= 16) |
 | `MAX_VOLUNTARY_EXITS` | `2**4` (= 16) |

--- a/tests/core/pyspec/eth2spec/test/helpers/attester_slashings.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/attester_slashings.py
@@ -1,5 +1,5 @@
 from eth2spec.test.context import PHASE1
-from eth2spec.test.helpers.attestations import get_valid_attestation, sign_attestation
+from eth2spec.test.helpers.attestations import get_valid_attestation, sign_attestation, sign_indexed_attestation
 
 
 def get_valid_attester_slashing(spec, state, signed_1=False, signed_2=False):
@@ -15,6 +15,26 @@ def get_valid_attester_slashing(spec, state, signed_1=False, signed_2=False):
         attestation_1=spec.get_indexed_attestation(state, attestation_1),
         attestation_2=spec.get_indexed_attestation(state, attestation_2),
     )
+
+
+def get_valid_attester_slashing_by_indices(spec, state, indices_1, indices_2=None, signed_1=False, signed_2=False):
+    if indices_2 is None:
+        indices_2 = indices_1
+
+    assert indices_1 == sorted(indices_1)
+    assert indices_2 == sorted(indices_2)
+
+    attester_slashing = get_valid_attester_slashing(spec, state)
+
+    attester_slashing.attestation_1.attesting_indices = indices_1
+    attester_slashing.attestation_2.attesting_indices = indices_2
+
+    if signed_1:
+        sign_indexed_attestation(spec, state, attester_slashing.attestation_1)
+    if signed_2:
+        sign_indexed_attestation(spec, state, attester_slashing.attestation_2)
+
+    return attester_slashing
 
 
 def get_indexed_attestation_participants(spec, indexed_att):

--- a/tests/core/pyspec/eth2spec/test/phase_0/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/phase_0/sanity/test_blocks.py
@@ -482,10 +482,6 @@ def test_multiple_attester_slashings_partial_overlap(spec, state):
     check_attester_slashing_effect(spec, pre_state, state, full_indices)
 
 
-# TODO: currently mainnet limits attester-slashings per block to 1.
-# When this is increased, it should be tested to cover various combinations
-# of duplicate slashings and overlaps of slashed attestations within the same block
-
 @with_all_phases
 @spec_state_test
 def test_proposer_after_inactive_index(spec, state):


### PR DESCRIPTION
* Set `MAX_ATTESTER_SLASHINGS` to 2 for both minimal and mainnet config (previously set to 1). Some quick discussion [here](https://github.com/ethereum/eth2.0-specs/issues/1760#issuecomment-623544461). Allows for better testing and allows for faster slashing of attacks on chain (at the cost of higher max block size).
* Add some tests that have multiple slashings in a single block