### PR TITLE
[for discussion] Use all attestation subnets in phase 0

### DIFF
--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -220,12 +220,14 @@ The payload is carried in the `data` field of a gossipsub message, and varies de
 
 | Name                                           | Message Type            |
 |------------------------------------------------|-------------------------|
-| beacon\_block                                  | SignedBeaconBlock       |
-| beacon\_aggregate\_and\_proof                  | SignedAggregateAndProof |
-| beacon_attestation\_{subnet\_id}               | Attestation             |
-| voluntary\_exit                                | SignedVoluntaryExit     |
-| proposer\_slashing                             | ProposerSlashing        |
-| attester\_slashing                             | AttesterSlashing        |
+| Name                             | Message Type              |
+|----------------------------------|---------------------------|
+| `beacon_block`                   | `SignedBeaconBlock`       |
+| `beacon_aggregate_and_proof`     | `SignedAggregateAndProof` |
+| `beacon_attestation_{subnet_id}` | `Attestation`             |
+| `voluntary_exit`                 | `SignedVoluntaryExit`     |
+| `proposer_slashing`              | `ProposerSlashing`        |
+| `attester_slashing`              | `AttesterSlashing`        |
 
 Clients MUST reject (fail validation) messages containing an incorrect type, or invalid payload.
 

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -151,7 +151,6 @@ This section outlines constants that are used in this spec.
 |---|---|---|
 | `GOSSIP_MAX_SIZE` | `2**20` (= 1048576, 1 MiB) | The maximum allowed size of uncompressed gossip messages. |
 | `MAX_CHUNK_SIZE` | `2**20` (1048576, 1 MiB) | The maximum allowed size of uncompressed req/resp chunked responses. |
-| `ATTESTATION_SUBNET_COUNT` | `64` | The number of attestation subnets used in the gossipsub protocol. |
 | `TTFB_TIMEOUT` | `5s` | The maximum time to wait for first byte of request response (time-to-first-byte). |
 | `RESP_TIMEOUT` | `10s` | The maximum time for complete response transfer. |
 | `ATTESTATION_PROPAGATION_SLOT_RANGE` | `32` | The maximum number of slots during which an attestation can be propagated. |
@@ -221,12 +220,12 @@ The payload is carried in the `data` field of a gossipsub message, and varies de
 
 | Name                                           | Message Type            |
 |------------------------------------------------|-------------------------|
-| beacon_block                                   | SignedBeaconBlock       |
-| beacon_aggregate_and_proof                     | SignedAggregateAndProof |
-| committee_index{subnet_id}\_beacon_attestation | Attestation             |
-| voluntary_exit                                 | SignedVoluntaryExit     |
-| proposer_slashing                              | ProposerSlashing        |
-| attester_slashing                              | AttesterSlashing        |
+| beacon\_block                                  | SignedBeaconBlock       |
+| beacon\_aggregate\_and\_proof                  | SignedAggregateAndProof |
+| beacon_attestation\_{subnet\_id}               | Attestation             |
+| voluntary\_exit                                | SignedVoluntaryExit     |
+| proposer\_slashing                             | ProposerSlashing        |
+| attester\_slashing                             | AttesterSlashing        |
 
 Clients MUST reject (fail validation) messages containing an incorrect type, or invalid payload.
 
@@ -273,8 +272,8 @@ Additional global topics are used to propagate lower frequency validator message
 
 Attestation subnets are used to propagate unaggregated attestations to subsections of the network. Their `Name`s are:
 
-- `committee_index{subnet_id}_beacon_attestation` - These topics are used to propagate unaggregated attestations to the subnet `subnet_id` (typically beacon and persistent committees) to be aggregated before being gossiped to `beacon_aggregate_and_proof`. The following validations MUST pass before forwarding the `attestation` on the subnet.
-    - _[REJECT]_ The attestation's committee index (`attestation.data.index`) is for the correct subnet.
+- `beacon_attestation_{subnet_id}` - These topics are used to propagate unaggregated attestations to the subnet `subnet_id` (typically beacon and persistent committees) to be aggregated before being gossiped to `beacon_aggregate_and_proof`. The following validations MUST pass before forwarding the `attestation` on the subnet.
+    - _[REJECT]_ The attestation is for the correct subnet (i.e. `compute_subnet_for_attestation(state, attestation) == subnet_id`).
     - _[IGNORE]_ `attestation.data.slot` is within the last `ATTESTATION_PROPAGATION_SLOT_RANGE` slots (within a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance) -- i.e. `attestation.data.slot + ATTESTATION_PROPAGATION_SLOT_RANGE >= current_slot >= attestation.data.slot` (a client MAY queue future attestations for processing at the appropriate slot).
     - _[REJECT]_ The attestation is unaggregated -- that is, it has exactly one participating validator (`len([bit for bit in attestation.aggregation_bits if bit == 0b1]) == 1`).
     - _[IGNORE]_ There has been no other valid attestation seen on an attestation subnet that has an identical `attestation.data.target.epoch` and participating validator index.
@@ -283,9 +282,9 @@ Attestation subnets are used to propagate unaggregated attestations to subsectio
 
 #### Attestations and Aggregation
 
-Attestation broadcasting is grouped into subnets defined by a topic. The number of subnets is defined via `ATTESTATION_SUBNET_COUNT`. For the `committee_index{subnet_id}_beacon_attestation` topics, `subnet_id` is set to `index % ATTESTATION_SUBNET_COUNT`, where `index` is the `CommitteeIndex` of the given committee.
+Attestation broadcasting is grouped into subnets defined by a topic. The number of subnets is defined via `ATTESTATION_SUBNET_COUNT`. The correct subnet for an attestation can be calculated with `compute_subnet_for_attestation`. `beacon_attestation_{subnet_id}` topics, are rotated through throughout the epoch in a similar fashion to rotating through shards in committees in Phase 1.
 
-Unaggregated attestations are sent to the subnet topic, `committee_index{attestation.data.index % ATTESTATION_SUBNET_COUNT}_beacon_attestation` as `Attestation`s.
+Unaggregated attestations are sent to the subnet topic, `beacon_attestation_{compute_subnet_for_attestation(state, attestation)}` as `Attestation`s.
 
 Aggregated attestations are sent to the `beacon_aggregate_and_proof` topic as `AggregateAndProof`s.
 

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -423,11 +423,12 @@ Finally, the validator broadcasts `attestation` to the associated attestation su
 
 ```python
 def compute_subnet_for_attestation(state: BeaconState, attestation: Attestation) -> uint64:
+    """
+    Compute the correct subnet for an attestation for Phase 0.
+    Note, this mimics expected Phase 1 behavior where attestations will be mapped to their shard subnet.
+    """
     slots_since_epoch_start = attestation.data.slot % SLOTS_PER_EPOCH
-    committees_since_epoch_start = sum([
-        get_committee_count_at_slot(state, Slot(slot))
-        for slot in range(slots_since_epoch_start)
-    ])
+    committees_since_epoch_start = get_committee_count_at_slot(state, attestation.data.slot) * slots_since_epoch_start
 
     return (committees_since_epoch_start + attestation.data.index) % ATTESTATION_SUBNET_COUNT
 ```


### PR DESCRIPTION
An attempt to address [this](https://github.com/ethereum/eth2.0-specs/issues/1777#issuecomment-626235833). 

In Phase 1, all attestation subnets would get used even when committees_per_slot does not equal `SHARD_COUNT`. In this PR, all attestation subnets are now used by rotating through them all throughout the epoch instead of just using a subset at each slot starting at 0.

This _does_ mimic the behaviour of Phase 1 more directly, but introduces a change to broadcast logic kind of late in the game.

