### PR TITLE
is_valid_fraud_proof bug fixes

### DIFF
--- a/specs/phase1/shard-transition.md
+++ b/specs/phase1/shard-transition.md
@@ -136,7 +136,7 @@ def is_valid_fraud_proof(beacon_state: BeaconState,
     if offset_index == 0:
         shard = get_shard(beacon_state, attestation)
         shard_states = beacon_parent_block.body.shard_transitions[shard].shard_states
-        shard_state = shard_states[len(shard_states)-1]
+        shard_state = shard_states[len(shard_states) - 1]
     else:
         shard_state = transition.shard_states[offset_index - 1]  # Not doing the actual state updates here.
 

--- a/specs/phase1/shard-transition.md
+++ b/specs/phase1/shard-transition.md
@@ -127,7 +127,7 @@ def is_valid_fraud_proof(beacon_state: BeaconState,
                          beacon_parent_block: BeaconBlock) -> bool:
     # 1. Check if `custody_bits[offset_index][j] != generate_custody_bit(subkey, block_contents)` for any `j`.
     custody_bits = attestation.custody_bits_blocks
-    for j in range(custody_bits[offset_index]):
+    for j in range(len(custody_bits[offset_index])):
         if custody_bits[offset_index][j] != generate_custody_bit(subkey, block):
             return True
 
@@ -135,7 +135,8 @@ def is_valid_fraud_proof(beacon_state: BeaconState,
     # `transition.shard_states[offset_index - 1]` to `transition.shard_states[offset_index]`.
     if offset_index == 0:
         shard = get_shard(beacon_state, attestation)
-        shard_state = beacon_parent_block.shard_transitions[shard].shard_states[-1]
+        shard_states = beacon_parent_block.body.shard_transitions[shard].shard_states
+        shard_state = shard_states[len(shard_states)-1]
     else:
         shard_state = transition.shard_states[offset_index - 1]  # Not doing the actual state updates here.
 


### PR DESCRIPTION
There are several problems in `is_valid_fraud_proof` illustrated by the test:
```python
from eth2spec.phase1 import spec

beacon_state = spec.BeaconState(shard_states = spec.List[spec.ShardState,spec.MAX_SHARDS](spec.ShardState()))
attestation = spec.Attestation(custody_bits_blocks=spec.List[spec.Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE], spec.MAX_SHARD_BLOCKS_PER_ATTESTATION](spec.Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE]()))
offset_index = 0
transition = spec.ShardTransition(shard_states=spec.List[spec.ShardState,spec.MAX_SHARD_BLOCKS_PER_ATTESTATION](spec.ShardState()))
block = spec.ShardBlock()
beacon_parent_block = spec.BeaconBlock()
beacon_parent_block.body.shard_transitions[0].shard_states = spec.List[spec.ShardState,spec.MAX_SHARD_BLOCKS_PER_ATTESTATION]([spec.ShardState()])
assert spec.is_valid_fraud_proof(beacon_state,attestation,offset_index,transition,block,spec.BLSPubkey(),beacon_parent_block)
```

The PR fixes the problems, so that the test works ok.