### PR TITLE
Fix compute_custody_bit problem

### DIFF
--- a/specs/phase1/custody-game.md
+++ b/specs/phase1/custody-game.md
@@ -194,7 +194,7 @@ def compute_custody_bit(key: BLSSignature, data: bytes) -> bit:
     s = full_G2_element[0].coeffs
     custody_atoms = get_custody_atoms(data)
     n = len(custody_atoms)
-    a = sum(s[i % 2]**i * int.from_bytes(atom, "little") for i, atom in enumerate(custody_atoms) + s[n % 2]**n)
+    a = sum(s[i % 2]**i * int.from_bytes(atom, "little") for i, atom in enumerate(custody_atoms)) + s[n % 2]**n
     return legendre_bit(a, BLS12_381_Q)
 ```
 


### PR DESCRIPTION
There is a bug in `compute_custody_bit`: it tries to add `int` to a `list` (`enumerate` result).

Here is a snippet, illustrating the problem:
```python
from eth2spec.phase1 import spec

sig = spec.BLSSignature(spec.bls.Sign(1,spec.compute_signing_root(spec.BeaconBlock(), spec.compute_domain(spec.DOMAIN_BEACON_PROPOSER))))
spec.compute_custody_bit(sig, b'1111')
```
Output:
```
Traceback (most recent call last):
  File "tests/core/pyspec/testcase2.py", line 4, in <module>
    spec.compute_custody_bit(sig, b'1111')
  File "/mnt/c/Users/ericsson/IdeaProjects/eth2.0-specs/tests/core/pyspec/eth2spec/phase1/spec.py", line 1814, in compute_custody_bit
    a = sum(s[i % 2]**i * int.from_bytes(atom, "little") for i, atom in enumerate(custody_atoms) + s[n % 2]**n)
TypeError: unsupported operand type(s) for +: 'enumerate' and 'int'
```

The PR contains a suggest fix of the problem.