### PR TITLE
Fix a bug in `process_custody_slashing`

### DIFF
--- a/specs/phase1/custody-game.md
+++ b/specs/phase1/custody-game.md
@@ -364,7 +364,7 @@ def process_custody_slashing(state: BeaconState, signed_custody_slashing: Signed
     # TODO: can do a single combined merkle proof of data being attested.
     # Verify the shard transition is indeed attested by the attestation
     shard_transition = custody_slashing.shard_transition
-    assert hash_tree_root(shard_transition) == attestation.shard_transition_root
+    assert hash_tree_root(shard_transition) == attestation.data.shard_transition_root
     # Verify that the provided data matches the shard-transition
     assert hash_tree_root(custody_slashing.data) == shard_transition.shard_data_roots[custody_slashing.data_index]
 


### PR DESCRIPTION
`shard_transition_root` is a field of `AttestationData`, not `Attestation`

Here is a test case, reproducing the problem
```python
from eth2spec.phase1 import spec


SK = 1

state = spec.BeaconState(
    validators = spec.List[spec.Validator, 1099511627776](
        spec.Validator(
            pubkey=spec.bls.bls.PrivToPub(SK),
            exit_epoch=spec.Epoch(100),
            withdrawable_epoch=spec.Epoch(100)
        )
    ),
    balances=spec.List[spec.Gwei, 1099511627776](spec.MAX_EFFECTIVE_BALANCE)
)

data = spec.ByteList[spec.MAX_SHARD_BLOCK_SIZE](spec.Bytes32())

shard_transition = spec.ShardTransition(
    shard_data_roots=spec.List[spec.Bytes32, spec.MAX_SHARD_BLOCKS_PER_ATTESTATION](
        spec.hash_tree_root(data)
    ))

cbit = 0
att_data = spec.AttestationData(
        index=spec.CommitteeIndex(31),
        shard_transition_root=spec.hash_tree_root(shard_transition))
domain = spec.get_domain(state, spec.DOMAIN_BEACON_ATTESTER, att_data.target.epoch)
signing_root = spec.compute_signing_root(spec.AttestationCustodyBitWrapper(
                        attestation_data_root=spec.hash_tree_root(att_data),
                        block_index=0,
                        bit=cbit
                    ), domain)

attestation = spec.Attestation(
    aggregation_bits=spec.Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](1),
    data=att_data,
    custody_bits_blocks=spec.List[spec.Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE], spec.MAX_SHARD_BLOCKS_PER_ATTESTATION](
        spec.Bitlist[spec.MAX_VALIDATORS_PER_COMMITTEE](cbit)),
    signature=spec.bls.Sign(SK, signing_root))

malefactor_index = 0
epoch_to_sign = spec.get_randao_epoch_for_custody_period(
    spec.get_custody_period_for_validator(malefactor_index, att_data.target.epoch),
    malefactor_index
)
domain = spec.get_domain(state, spec.DOMAIN_RANDAO, epoch_to_sign)
signing_root = spec.compute_signing_root(epoch_to_sign, domain)

custody_slashing = spec.CustodySlashing(
    data=data,
    malefactor_secret=spec.bls.Sign(SK, signing_root),
    malefactor_index=malefactor_index,
    attestation=attestation,
    shard_transition=shard_transition)
whistleblower = state.validators[custody_slashing.whistleblower_index]
domain = spec.get_domain(state, spec.DOMAIN_CUSTODY_BIT_SLASHING, spec.get_current_epoch(state))
signing_root = spec.compute_signing_root(custody_slashing, domain)

signed_custody_slashing = spec.SignedCustodySlashing(
    message=custody_slashing,
    signature=spec.bls.Sign(SK, signing_root))

spec.process_custody_slashing(state, signed_custody_slashing)
```