### PR TITLE
s/beacon_state/state for get_shard_transition

### DIFF
--- a/specs/phase1/shard-transition.md
+++ b/specs/phase1/shard-transition.md
@@ -260,7 +260,7 @@ def get_shard_state_transition_result(
 
 ### Make attestations
 
-Suppose you are a committee member on shard `shard` at slot `current_slot` and you have received shard blocks `shard_blocks` since the latest successful crosslink for `shard` into the beacon chain. Let `state` be the head beacon state you are building on, and let `QUARTER_PERIOD = SECONDS_PER_SLOT // 4`. `2 * QUARTER_PERIOD` seconds into slot `current_slot`, run `get_shard_transition(beacon_state, shard, shard_blocks)` to get `shard_transition`.
+Suppose you are a committee member on shard `shard` at slot `current_slot` and you have received shard blocks `shard_blocks` since the latest successful crosslink for `shard` into the beacon chain. Let `beacon_state` be the head beacon state you are building on, and let `QUARTER_PERIOD = SECONDS_PER_SLOT // 4`. `2 * QUARTER_PERIOD` seconds into slot `current_slot`, run `get_shard_transition(beacon_state, shard, shard_blocks)` to get `shard_transition`.
 
 ```python
 def get_shard_transition(beacon_state: BeaconState,


### PR DESCRIPTION
Replace `beacon_state` with `state` to align with `get_shard_transition`'s input argument 