### PR TITLE
v0.11 multiple blocks in single slot patch

### DIFF
--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -1219,7 +1219,7 @@ def verify_block_signature(state: BeaconState, signed_block: SignedBeaconBlock) 
 
 ```python
 def process_slots(state: BeaconState, slot: Slot) -> None:
-    assert state.slot <= slot
+    assert state.slot < slot
     while state.slot < slot:
         process_slot(state)
         # Process epoch on the start slot of the next epoch

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -1494,6 +1494,8 @@ def process_block(state: BeaconState, block: BeaconBlock) -> None:
 def process_block_header(state: BeaconState, block: BeaconBlock) -> None:
     # Verify that the slots match
     assert block.slot == state.slot
+    # Verify that the block is newer than latest block header
+    assert block.slot > state.latest_block_header.slot
     # Verify that proposer index is the correct index
     assert block.proposer_index == get_beacon_proposer_index(state)
     # Verify that the parent matches

--- a/tests/core/pyspec/eth2spec/test/helpers/attestations.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/attestations.py
@@ -243,7 +243,8 @@ def fill_aggregate_attestation(spec, state, attestation, signed=False):
 
 
 def add_attestations_to_state(spec, state, attestations, slot):
-    spec.process_slots(state, slot)
+    if state.slot < slot:
+        spec.process_slots(state, slot)
     for attestation in attestations:
         spec.process_attestation(state, attestation)
 

--- a/tests/core/pyspec/eth2spec/test/helpers/block.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/block.py
@@ -53,6 +53,7 @@ def sign_block(spec, state, block, proposer_index=None):
 
 
 def transition_unsigned_block(spec, state, block):
+    assert state.slot < block.slot  # Preserve assertion from state transition to avoid strange pre-states from testing
     if state.slot < block.slot:
         spec.process_slots(state, block.slot)
     assert state.latest_block_header.slot < block.slot  # There may not already be a block in this slot or past it.
@@ -60,11 +61,11 @@ def transition_unsigned_block(spec, state, block):
     spec.process_block(state, block)
 
 
-def apply_empty_block(spec, state):
+def apply_empty_block(spec, state, slot=None):
     """
     Transition via an empty block (on current slot, assuming no block has been applied yet).
     """
-    block = build_empty_block(spec, state)
+    block = build_empty_block(spec, state, slot)
     transition_unsigned_block(spec, state, block)
 
 

--- a/tests/core/pyspec/eth2spec/test/helpers/block.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/block.py
@@ -77,11 +77,10 @@ def build_empty_block(spec, state, slot=None):
         slot = state.slot
     if slot < state.slot:
         raise Exception("build_empty_block cannot build blocks for past slots")
-    if slot > state.slot:
-        if state.slot < slot:
-            # transition forward in copied state to grab relevant data from state
-            state = state.copy()
-            spec.process_slots(state, slot)
+    if state.slot < slot:
+        # transition forward in copied state to grab relevant data from state
+        state = state.copy()
+        spec.process_slots(state, slot)
 
     empty_block = spec.BeaconBlock()
     empty_block.slot = slot

--- a/tests/core/pyspec/eth2spec/test/helpers/state.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/state.py
@@ -17,7 +17,8 @@ def next_slots(spec, state, slots):
     """
     Transition given slots forward.
     """
-    spec.process_slots(state, state.slot + slots)
+    if slots > 0:
+        spec.process_slots(state, state.slot + slots)
 
 
 def transition_to(spec, state, slot):
@@ -35,7 +36,8 @@ def next_epoch(spec, state):
     Transition to the start slot of the next epoch
     """
     slot = state.slot + spec.SLOTS_PER_EPOCH - (state.slot % spec.SLOTS_PER_EPOCH)
-    spec.process_slots(state, slot)
+    if slot > state.slot:
+        spec.process_slots(state, slot)
 
 
 def get_state_root(spec, state, slot) -> bytes:

--- a/tests/core/pyspec/eth2spec/test/helpers/state.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/state.py
@@ -1,5 +1,5 @@
 from eth2spec.test.context import expect_assertion_error
-from eth2spec.test.helpers.block import sign_block, transition_unsigned_block
+from eth2spec.test.helpers.block import apply_empty_block, sign_block, transition_unsigned_block
 
 
 def get_balance(state, index):
@@ -31,6 +31,15 @@ def transition_to(spec, state, slot):
     assert state.slot == slot
 
 
+def transition_to_slot_via_block(spec, state, slot):
+    """
+    Transition to ``slot`` via an empty block transition
+    """
+    assert state.slot < slot
+    apply_empty_block(spec, state, slot)
+    assert state.slot == slot
+
+
 def next_epoch(spec, state):
     """
     Transition to the start slot of the next epoch
@@ -38,6 +47,13 @@ def next_epoch(spec, state):
     slot = state.slot + spec.SLOTS_PER_EPOCH - (state.slot % spec.SLOTS_PER_EPOCH)
     if slot > state.slot:
         spec.process_slots(state, slot)
+
+
+def next_epoch_via_block(spec, state):
+    """
+    Transition to the start slot of the next epoch via a full block transition
+    """
+    apply_empty_block(spec, state, state.slot + spec.SLOTS_PER_EPOCH - state.slot % spec.SLOTS_PER_EPOCH)
 
 
 def get_state_root(spec, state, slot) -> bytes:

--- a/tests/core/pyspec/eth2spec/test/phase_0/block_processing/test_process_attestation.py
+++ b/tests/core/pyspec/eth2spec/test/phase_0/block_processing/test_process_attestation.py
@@ -15,10 +15,9 @@ from eth2spec.test.helpers.attestations import (
 from eth2spec.test.helpers.state import (
     next_slot,
     next_slots,
-    next_epoch,
-    transition_to,
+    next_epoch_via_block,
+    transition_to_slot_via_block,
 )
-from eth2spec.test.helpers.block import apply_empty_block
 from eth2spec.utils.ssz.ssz_typing import Bitlist
 
 
@@ -47,9 +46,7 @@ def test_success_multi_proposer_index_iterations(spec, state):
 @spec_state_test
 def test_success_previous_epoch(spec, state):
     attestation = get_valid_attestation(spec, state, signed=True, on_time=False)
-    transition_to(spec, state, spec.SLOTS_PER_EPOCH - 1)
-    next_epoch(spec, state)
-    apply_empty_block(spec, state)
+    next_epoch_via_block(spec, state)
 
     yield from run_attestation_processing(spec, state, attestation)
 
@@ -79,8 +76,7 @@ def test_after_epoch_slots(spec, state):
     attestation = get_valid_attestation(spec, state, signed=True, on_time=False)
 
     # increment past latest inclusion slot
-    transition_to(spec, state, state.slot + spec.SLOTS_PER_EPOCH + 1)
-    apply_empty_block(spec, state)
+    transition_to_slot_via_block(spec, state, state.slot + spec.SLOTS_PER_EPOCH + 1)
 
     yield from run_attestation_processing(spec, state, attestation, False)
 
@@ -151,8 +147,8 @@ def test_invalid_index(spec, state):
 @with_all_phases
 @spec_state_test
 def test_mismatched_target_and_slot(spec, state):
-    next_epoch(spec, state)
-    next_epoch(spec, state)
+    next_epoch_via_block(spec, state)
+    next_epoch_via_block(spec, state)
 
     attestation = get_valid_attestation(spec, state, on_time=False)
     attestation.data.slot = attestation.data.slot - spec.SLOTS_PER_EPOCH

--- a/tests/core/pyspec/eth2spec/test/phase_0/block_processing/test_process_attester_slashing.py
+++ b/tests/core/pyspec/eth2spec/test/phase_0/block_processing/test_process_attester_slashing.py
@@ -5,10 +5,9 @@ from eth2spec.test.context import (
 from eth2spec.test.helpers.attestations import sign_indexed_attestation
 from eth2spec.test.helpers.attester_slashings import get_valid_attester_slashing, \
     get_indexed_attestation_participants, get_attestation_2_data, get_attestation_1_data
-from eth2spec.test.helpers.block import apply_empty_block
 from eth2spec.test.helpers.state import (
     get_balance,
-    next_epoch,
+    next_epoch_via_block,
 )
 
 
@@ -91,8 +90,7 @@ def test_success_double(spec, state):
 @with_all_phases
 @spec_state_test
 def test_success_surround(spec, state):
-    next_epoch(spec, state)
-    apply_empty_block(spec, state)
+    next_epoch_via_block(spec, state)
 
     state.current_justified_checkpoint.epoch += 1
     attester_slashing = get_valid_attester_slashing(spec, state, signed_1=False, signed_2=True)

--- a/tests/core/pyspec/eth2spec/test/phase_0/epoch_processing/run_epoch_process_base.py
+++ b/tests/core/pyspec/eth2spec/test/phase_0/epoch_processing/run_epoch_process_base.py
@@ -18,7 +18,8 @@ def run_epoch_processing_to(spec, state, process_name: str):
     slot = state.slot + (spec.SLOTS_PER_EPOCH - state.slot % spec.SLOTS_PER_EPOCH)
 
     # transition state to slot before epoch state transition
-    spec.process_slots(state, slot - 1)
+    if state.slot < slot - 1:
+        spec.process_slots(state, slot - 1)
 
     # start transitioning, do one slot update before the epoch itself.
     spec.process_slot(state)

--- a/tests/core/pyspec/eth2spec/test/phase_1/block_processing/test_process_early_derived_secret_reveal.py
+++ b/tests/core/pyspec/eth2spec/test/phase_1/block_processing/test_process_early_derived_secret_reveal.py
@@ -1,6 +1,5 @@
 from eth2spec.test.helpers.custody import get_valid_early_derived_secret_reveal
-from eth2spec.test.helpers.block import apply_empty_block
-from eth2spec.test.helpers.state import next_epoch, get_balance
+from eth2spec.test.helpers.state import next_epoch_via_block, get_balance
 from eth2spec.test.context import (
     PHASE0,
     with_all_phases_except,
@@ -64,8 +63,7 @@ def test_reveal_from_current_epoch(spec, state):
 @spec_state_test
 @never_bls
 def test_reveal_from_past_epoch(spec, state):
-    next_epoch(spec, state)
-    apply_empty_block(spec, state)
+    next_epoch_via_block(spec, state)
     randao_key_reveal = get_valid_early_derived_secret_reveal(spec, state, spec.get_current_epoch(state) - 1)
 
     yield from run_early_derived_secret_reveal_processing(spec, state, randao_key_reveal, False)

--- a/tests/core/pyspec/eth2spec/test/sanity/test_slots.py
+++ b/tests/core/pyspec/eth2spec/test/sanity/test_slots.py
@@ -51,7 +51,8 @@ def test_double_empty_epoch(spec, state):
 @with_all_phases
 @spec_state_test
 def test_over_epoch_boundary(spec, state):
-    spec.process_slots(state, state.slot + (spec.SLOTS_PER_EPOCH // 2))
+    if spec.SLOTS_PER_EPOCH > 1:
+        spec.process_slots(state, state.slot + (spec.SLOTS_PER_EPOCH // 2))
     yield 'pre', state
     slots = spec.SLOTS_PER_EPOCH
     yield 'slots', slots

--- a/tests/core/pyspec/eth2spec/test/test_finality.py
+++ b/tests/core/pyspec/eth2spec/test/test_finality.py
@@ -1,7 +1,6 @@
 from eth2spec.test.context import spec_state_test, never_bls, with_all_phases, with_phases
-from eth2spec.test.helpers.state import next_epoch
+from eth2spec.test.helpers.state import next_epoch_via_block
 from eth2spec.test.helpers.attestations import next_epoch_with_attestations
-from eth2spec.test.helpers.block import apply_empty_block
 
 
 def check_finality(spec,
@@ -58,10 +57,8 @@ def test_finality_no_updates_at_genesis(spec, state):
 @never_bls
 def test_finality_rule_4(spec, state):
     # get past first two epochs that finality does not run on
-    next_epoch(spec, state)
-    apply_empty_block(spec, state)
-    next_epoch(spec, state)
-    apply_empty_block(spec, state)
+    next_epoch_via_block(spec, state)
+    next_epoch_via_block(spec, state)
 
     yield 'pre', state
 
@@ -86,10 +83,8 @@ def test_finality_rule_4(spec, state):
 @never_bls
 def test_finality_rule_1(spec, state):
     # get past first two epochs that finality does not run on
-    next_epoch(spec, state)
-    apply_empty_block(spec, state)
-    next_epoch(spec, state)
-    apply_empty_block(spec, state)
+    next_epoch_via_block(spec, state)
+    next_epoch_via_block(spec, state)
 
     yield 'pre', state
 
@@ -116,10 +111,8 @@ def test_finality_rule_1(spec, state):
 @never_bls
 def test_finality_rule_2(spec, state):
     # get past first two epochs that finality does not run on
-    next_epoch(spec, state)
-    apply_empty_block(spec, state)
-    next_epoch(spec, state)
-    apply_empty_block(spec, state)
+    next_epoch_via_block(spec, state)
+    next_epoch_via_block(spec, state)
 
     yield 'pre', state
 
@@ -152,10 +145,8 @@ def test_finality_rule_3(spec, state):
     https://github.com/ethereum/eth2.0-specs/issues/611#issuecomment-463612892
     """
     # get past first two epochs that finality does not run on
-    next_epoch(spec, state)
-    apply_empty_block(spec, state)
-    next_epoch(spec, state)
-    apply_empty_block(spec, state)
+    next_epoch_via_block(spec, state)
+    next_epoch_via_block(spec, state)
 
     yield 'pre', state
 


### PR DESCRIPTION
Security patch to v0.11 to prevent the application of multiple blocks upon a single slot.

Patch already applied to prysm (topaz/schlesi) and teku (schlesi). Lighthouse unaffected. Other clients not currently validating on testnets

This _critical_ bug was found by @daejunpark while doing formal verification work with @runtimeverification. THANK YOU