### PR TITLE
require blocks to be ordered consecutively in block range request

### DIFF
--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -587,11 +587,13 @@ The response MUST consist of zero or more `response_chunk`. Each _successful_ `r
 
 Clients MUST keep a record of signed blocks seen since the since the start of the weak subjectivity period and MUST support serving requests of blocks up to their own `head_block_root`.
 
-Clients MUST respond with at least one block, if they have it and it exists in the range. Clients MAY limit the number of blocks in the response.
+Clients MUST respond with at least the first block that exists in the range, if they have it.
+
+The following blocks MUST be ordered consecutively, with each `parent_root` matching the `hash_tree_root` of the previous block.
+
+Clients MAY limit the number of blocks in the response.
 
 The response MUST contain no more than `count` blocks.
-
-Clients MUST order blocks by increasing slot number.
 
 Clients MUST respond with blocks from their view of the current fork choice. In particular, blocks from slots before the finalization MUST lead to the finalized block reported in the `Status` handshake.
 

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -589,7 +589,7 @@ Clients MUST keep a record of signed blocks seen since the since the start of th
 
 Clients MUST respond with at least the first block that exists in the range, if they have it.
 
-The following blocks MUST be ordered consecutively, with each `parent_root` matching the `hash_tree_root` of the previous block.
+The following blocks, where they exist, MUST be send in consecutive order without gaps, as selected by `step`. In particular, when `step == 1`, each `parent_root` MUST match the `hash_tree_root` of the preceding block.
 
 Clients MAY limit the number of blocks in the response.
 


### PR DESCRIPTION
Per the spec, if I request range 5-10, it is permissible for a client to
answer with block 7, 9 - even if the blocks 5, 6 and 8 exist.

Because blocks 7 and 9 cannot be validated as they arrive in such a
request, it seems better to close this gap - this update adds the spec
language that forbids well-behaving clients from answering this way.
