### PR TITLE
Bump gossipsub protocol id to /meshsub/1.1.0

### DIFF
--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -218,8 +218,6 @@ where `base64` is the [URL-safe base64 alphabet](https://tools.ietf.org/html/rfc
 
 The payload is carried in the `data` field of a gossipsub message, and varies depending on the topic:
 
-| Name                                           | Message Type            |
-|------------------------------------------------|-------------------------|
 | Name                             | Message Type              |
 |----------------------------------|---------------------------|
 | `beacon_block`                   | `SignedBeaconBlock`       |
@@ -552,7 +550,7 @@ Clients MUST order blocks by increasing slot number.
 
 Clients MUST respond with blocks from their view of the current fork choice -- that is, blocks from the single chain defined by the current head. Of note, blocks from slots before the finalization MUST lead to the finalized block reported in the `Status` handshake.
 
-Clients MUST respond with blocks that are consistent from a single chain within the context of the request. After the initial block clients MAY stop in the process of responding, if their fork choice changes the view of the chain in the context of the request.
+Clients MUST respond with blocks that are consistent from a single chain within the context of the request. After the initial block, clients MAY stop in the process of responding if their fork choice changes the view of the chain in the context of the request.
 
 #### BeaconBlocksByRoot
 

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -178,7 +178,7 @@ Where
 
 Clients MUST support the [gossipsub v1](https://github.com/libp2p/specs/tree/master/pubsub/gossipsub) libp2p protocol including the [gossipsub v1.1](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md) extension.
 
-**Protocol ID:** `/meshsub/1.0.0`
+**Protocol ID:** `/meshsub/1.1.0`
 
 **Gossipsub Parameters**
 


### PR DESCRIPTION
As per [gossipsub v1.1 spec](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md)

(and fix broken table formatting)