### PR TITLE
Ensure balances remain unchanged for optimal validators during leak

### DIFF
--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -1368,7 +1368,7 @@ def get_finality_delay(state: BeaconState) -> uint64:
 
 
 ```python
-def in_inactivity_leak(state: BeaconState) -> bool:
+def is_in_inactivity_leak(state: BeaconState) -> bool:
     return get_finality_delay(state) > MIN_EPOCHS_TO_INACTIVITY_PENALTY
 ```
 
@@ -1397,8 +1397,9 @@ def get_attestation_component_deltas(state: BeaconState,
     for index in get_eligible_validator_indices(state):
         if index in unslashed_attesting_indices:
             increment = EFFECTIVE_BALANCE_INCREMENT  # Factored out from balance totals to avoid uint64 overflow
-            if in_inactivity_leak(state):
-                # Full base reward will be cancelled out by inactivity penalty deltas
+            if is_in_inactivity_leak(state):
+                # Since full base reward will be canceled out by inactivity penalty deltas,
+                # optimal participation receives full base reward compensation here.
                 rewards[index] += get_base_reward(state, index)
             else:
                 reward_numerator = get_base_reward(state, index) * (attesting_balance // increment)
@@ -1464,7 +1465,7 @@ def get_inactivity_penalty_deltas(state: BeaconState) -> Tuple[Sequence[Gwei], S
     Return inactivity reward/penalty deltas for each validator.
     """
     penalties = [Gwei(0) for _ in range(len(state.validators))]
-    if in_inactivity_leak(state):
+    if is_in_inactivity_leak(state):
         matching_target_attestations = get_matching_target_attestations(state, get_previous_epoch(state))
         matching_target_attesting_indices = get_unslashed_attesting_indices(state, matching_target_attestations)
         for index in get_eligible_validator_indices(state):

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -1354,6 +1354,19 @@ def get_base_reward(state: BeaconState, index: ValidatorIndex) -> Gwei:
     return Gwei(effective_balance * BASE_REWARD_FACTOR // integer_squareroot(total_balance) // BASE_REWARDS_PER_EPOCH)
 ```
 
+
+```python
+def get_finality_delay(state: BeaconState) -> uint64:
+    return get_previous_epoch(state) - state.finalized_checkpoint.epoch
+```
+
+
+```python
+def in_inactivity_leak(state: BeaconState) -> bool:
+    return get_finality_delay(state) > MIN_EPOCHS_TO_INACTIVITY_PENALTY
+```
+
+
 ```python
 def get_eligible_validator_indices(state: BeaconState) -> Sequence[ValidatorIndex]:
     previous_epoch = get_previous_epoch(state)
@@ -1378,8 +1391,11 @@ def get_attestation_component_deltas(state: BeaconState,
     for index in get_eligible_validator_indices(state):
         if index in unslashed_attesting_indices:
             increment = EFFECTIVE_BALANCE_INCREMENT  # Factored out from balance totals to avoid uint64 overflow
-            reward_numerator = get_base_reward(state, index) * (attesting_balance // increment)
-            rewards[index] += reward_numerator // (total_balance // increment)
+            if in_inactivity_leak(state):
+                rewards[index] += get_base_reward(state, index)
+            else:
+                reward_numerator = get_base_reward(state, index) * (attesting_balance // increment)
+                rewards[index] += reward_numerator // (total_balance // increment)
         else:
             penalties[index] += get_base_reward(state, index)
     return rewards, penalties
@@ -1428,7 +1444,10 @@ def get_inclusion_delay_deltas(state: BeaconState) -> Tuple[Sequence[Gwei], Sequ
         ], key=lambda a: a.inclusion_delay)
         proposer_reward = Gwei(get_base_reward(state, index) // PROPOSER_REWARD_QUOTIENT)
         rewards[attestation.proposer_index] += proposer_reward
-        max_attester_reward = get_base_reward(state, index) - proposer_reward
+        if in_inactivity_leak(state):
+            max_attester_reward = get_base_reward(state, index)
+        else:
+            max_attester_reward = get_base_reward(state, index) - proposer_reward
         rewards[index] += Gwei(max_attester_reward // attestation.inclusion_delay)
 
     # No penalties associated with inclusion delay
@@ -1442,16 +1461,14 @@ def get_inactivity_penalty_deltas(state: BeaconState) -> Tuple[Sequence[Gwei], S
     Return inactivity reward/penalty deltas for each validator.
     """
     penalties = [Gwei(0) for _ in range(len(state.validators))]
-    finality_delay = get_previous_epoch(state) - state.finalized_checkpoint.epoch
-
-    if finality_delay > MIN_EPOCHS_TO_INACTIVITY_PENALTY:
+    if in_inactivity_leak(state):
         matching_target_attestations = get_matching_target_attestations(state, get_previous_epoch(state))
         matching_target_attesting_indices = get_unslashed_attesting_indices(state, matching_target_attestations)
         for index in get_eligible_validator_indices(state):
             penalties[index] += Gwei(BASE_REWARDS_PER_EPOCH * get_base_reward(state, index))
             if index not in matching_target_attesting_indices:
                 effective_balance = state.validators[index].effective_balance
-                penalties[index] += Gwei(effective_balance * finality_delay // INACTIVITY_PENALTY_QUOTIENT)
+                penalties[index] += Gwei(effective_balance * get_finality_delay(state) // INACTIVITY_PENALTY_QUOTIENT)
 
     # No rewards associated with inactivity penalties
     rewards = [Gwei(0) for _ in range(len(state.validators))]

--- a/tests/core/pyspec/eth2spec/test/helpers/rewards.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/rewards.py
@@ -151,7 +151,6 @@ def run_get_inactivity_penalty_deltas(spec, state):
     matching_attestations = spec.get_matching_target_attestations(state, spec.get_previous_epoch(state))
     matching_attesting_indices = spec.get_unslashed_attesting_indices(state, matching_attestations)
 
-    finality_delay = spec.get_previous_epoch(state) - state.finalized_checkpoint.epoch
     eligible_indices = spec.get_eligible_validator_indices(state)
     for index in range(len(state.validators)):
         assert rewards[index] == 0
@@ -159,7 +158,7 @@ def run_get_inactivity_penalty_deltas(spec, state):
             assert penalties[index] == 0
             continue
 
-        if finality_delay > spec.MIN_EPOCHS_TO_INACTIVITY_PENALTY:
+        if spec.is_in_inactivity_leak(state):
             base_reward = spec.get_base_reward(state, index)
             base_penalty = spec.BASE_REWARDS_PER_EPOCH * base_reward - spec.get_proposer_reward(state, index)
             if not has_enough_for_reward(spec, state, index):

--- a/tests/core/pyspec/eth2spec/test/helpers/rewards.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/rewards.py
@@ -160,7 +160,8 @@ def run_get_inactivity_penalty_deltas(spec, state):
             continue
 
         if finality_delay > spec.MIN_EPOCHS_TO_INACTIVITY_PENALTY:
-            base_penalty = spec.BASE_REWARDS_PER_EPOCH * spec.get_base_reward(state, index)
+            base_reward = spec.get_base_reward(state, index)
+            base_penalty = spec.BASE_REWARDS_PER_EPOCH * base_reward - spec.get_proposer_reward(state, index)
             if not has_enough_for_reward(spec, state, index):
                 assert penalties[index] == 0
             elif index in matching_attesting_indices:

--- a/tests/core/pyspec/eth2spec/test/helpers/rewards.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/rewards.py
@@ -1,4 +1,5 @@
 from random import Random
+from lru import LRU
 
 from eth2spec.phase0 import spec as spec_phase0
 from eth2spec.test.helpers.attestations import cached_prepare_state_with_attestations
@@ -168,6 +169,39 @@ def run_get_inactivity_penalty_deltas(spec, state):
                 assert penalties[index] > base_penalty
         else:
             assert penalties[index] == 0
+
+
+def transition_state_to_leak(spec, state, epochs=None):
+    if epochs is None:
+        epochs = spec.MIN_EPOCHS_TO_INACTIVITY_PENALTY
+    assert epochs >= spec.MIN_EPOCHS_TO_INACTIVITY_PENALTY
+
+    for _ in range(epochs):
+        next_epoch(spec, state)
+
+
+_cache_dict = LRU(size=10)
+
+
+def leaking(epochs=None):
+
+    def deco(fn):
+        def entry(*args, spec, state, **kw):
+            # If the pre-state is not already known in the LRU, then take it,
+            # transition it to leak, and put it in the LRU.
+            # The input state is likely already cached, so the hash-tree-root does not affect speed.
+            key = (state.hash_tree_root(), spec.MIN_EPOCHS_TO_INACTIVITY_PENALTY, spec.SLOTS_PER_EPOCH, epochs)
+            global _cache_dict
+            if key not in _cache_dict:
+                transition_state_to_leak(spec, state, epochs=epochs)
+                _cache_dict[key] = state.get_backing()  # cache the tree structure, not the view wrapping it.
+
+            # Take an entry out of the LRU.
+            # No copy is necessary, as we wrap the immutable backing with a new view.
+            state = spec.BeaconState(backing=_cache_dict[key])
+            return fn(*args, spec=spec, state=state, **kw)
+        return entry
+    return deco
 
 
 def set_some_new_deposits(spec, state, rng):

--- a/tests/core/pyspec/eth2spec/test/phase_0/rewards/test_leak.py
+++ b/tests/core/pyspec/eth2spec/test/phase_0/rewards/test_leak.py
@@ -1,40 +1,6 @@
 from eth2spec.test.context import with_all_phases, spec_state_test
-from eth2spec.test.helpers.state import next_epoch
+from eth2spec.test.helpers.rewards import leaking
 import eth2spec.test.helpers.rewards as rewards_helpers
-from lru import LRU
-
-
-def transition_state_to_leak(spec, state, epochs=None):
-    if epochs is None:
-        epochs = spec.MIN_EPOCHS_TO_INACTIVITY_PENALTY
-    assert epochs >= spec.MIN_EPOCHS_TO_INACTIVITY_PENALTY
-
-    for _ in range(epochs):
-        next_epoch(spec, state)
-
-
-_cache_dict = LRU(size=10)
-
-
-def leaking(epochs=None):
-
-    def deco(fn):
-        def entry(*args, spec, state, **kw):
-            # If the pre-state is not already known in the LRU, then take it,
-            # transition it to leak, and put it in the LRU.
-            # The input state is likely already cached, so the hash-tree-root does not affect speed.
-            key = (state.hash_tree_root(), spec.MIN_EPOCHS_TO_INACTIVITY_PENALTY, spec.SLOTS_PER_EPOCH, epochs)
-            global _cache_dict
-            if key not in _cache_dict:
-                transition_state_to_leak(spec, state, epochs=epochs)
-                _cache_dict[key] = state.get_backing()  # cache the tree structure, not the view wrapping it.
-
-            # Take an entry out of the LRU.
-            # No copy is necessary, as we wrap the immutable backing with a new view.
-            state = spec.BeaconState(backing=_cache_dict[key])
-            return fn(*args, spec=spec, state=state, **kw)
-        return entry
-    return deco
 
 
 @with_all_phases


### PR DESCRIPTION
Address #1370 to preserve the design goal of "if attesting perfectly during an inactivity leak, your balance remains unchanged"

Approach: During an inactivity leak, do not scale base rewards by participation so that they perfectly cancel out with the baseline penalties applied for the inactivity leak (not including the actual quadratic leak portion).