### PR TITLE
remerkleable 0.1.16

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -503,7 +503,7 @@ setup(
         "pycryptodome==3.9.4",
         "py_ecc==4.0.0",
         "dataclasses==0.6",
-        "remerkleable==0.1.15",
+        "remerkleable==0.1.16",
         "ruamel.yaml==0.16.5",
         "lru-dict==1.1.6"
     ]


### PR DESCRIPTION
See changelog: https://github.com/protolambda/remerkleable/blob/master/CHANGELOG.rst

It now has functions to convert from and to regular python dict/list/etc structures. To use with `json.dumps/loads`, or a yaml package.

All test cases in remerkleable now also cover the different intended object type transforms.


Example usage, loading a beacon state (with root separately) API response from lighthouse:
```python
with open('some_test_data.json', 'tr') as f:
    dat = json.load(f)
    state = spec.BeaconState.from_obj(dat['beacon_state'])

    print(state)
    print('expected: ' + dat['root'])
    print('got: ' + state.hash_tree_root().hex()) # They match!
```

Edit: we could also retire the old value->yaml structure function in the debug package. Right now it's not the best timing right before a release, but it may be worth it in the future.