### PR TITLE
Fix phase1 on-time sign_indexed_attestation

### DIFF
--- a/tests/core/pyspec/eth2spec/test/helpers/attestations.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/attestations.py
@@ -211,7 +211,10 @@ def sign_indexed_attestation(spec, state, indexed_attestation):
             indexed_attestation.attestation.aggregation_bits,
         )
         data = indexed_attestation.attestation.data
-        indexed_attestation.attestation.signature = sign_aggregate_attestation(spec, state, data, participants)
+        if any(indexed_attestation.attestation.custody_bits_blocks):
+            sign_on_time_attestation(spec, state, indexed_attestation.attestation)
+        else:
+            indexed_attestation.attestation.signature = sign_aggregate_attestation(spec, state, data, participants)
 
 
 def sign_on_time_attestation(spec, state, attestation):

--- a/tests/core/pyspec/eth2spec/test/phase_0/block_processing/test_process_attester_slashing.py
+++ b/tests/core/pyspec/eth2spec/test/phase_0/block_processing/test_process_attester_slashing.py
@@ -1,6 +1,6 @@
 from eth2spec.test.context import (
     PHASE0, PHASE1,
-    spec_state_test, expect_assertion_error, always_bls, never_bls, with_all_phases, with_phases
+    spec_state_test, expect_assertion_error, always_bls, with_all_phases, with_phases
 )
 from eth2spec.test.helpers.attestations import sign_indexed_attestation
 from eth2spec.test.helpers.attester_slashings import get_valid_attester_slashing, \
@@ -89,7 +89,6 @@ def test_success_double(spec, state):
 
 @with_all_phases
 @spec_state_test
-@never_bls
 def test_success_surround(spec, state):
     next_epoch_via_block(spec, state)
 


### PR DESCRIPTION
### Issue
Pointed out by @nisdas, the `bls_setting` change is the v012x. (#1841)
Also pointed out by @protolambda, it's actually should be BLS-verifiable (bls_setting=0) since we should have re-signed the mocked attestation in test generator.

### How did I fix it
It turns out the issue is phase-1 only: we didn't handle the phase 1 on-time `sign_on_time_attestation` case.

This PR fixes `sign_indexed_attestation` and reverts the bls_setting.

@nisdas, it's okay to ignore it for now until the next spec release, sorry about it! 🙏