### PR TITLE
`compute_shard_transition_digest` expects `Root` as a fourth parameter

### DIFF
--- a/specs/phase1/shard-transition.md
+++ b/specs/phase1/shard-transition.md
@@ -81,7 +81,7 @@ def shard_state_transition(beacon_state: BeaconState,
         beacon_state,
         shard_state,
         block.beacon_parent_root,
-        block.body,
+        hash_tree_root(block.body),
     )
     shard_state.gasprice = compute_updated_gasprice(prev_gasprice, len(block.body))
     shard_state.slot = block.slot


### PR DESCRIPTION
`compute_shard_transition_digest` expects `Root` as a fourth parameter, however, `shard_state_transition` passes `block.body` as the fourth parameter, which has type `ByteList[MAX_SHARD_BLOCK_SIZE]`:
```python
shard_state.transition_digest = compute_shard_transition_digest(
    beacon_state,
    shard_state,
    block.beacon_parent_root,
    block.body,
)
```
Looks like `hash_tree_root` around `block.body` is missed.