### PR TITLE
Add `shard` field to `ShardBlock`

### DIFF
--- a/specs/phase1/beacon-chain.md
+++ b/specs/phase1/beacon-chain.md
@@ -302,6 +302,7 @@ class ShardBlock(Container):
     shard_parent_root: Root
     beacon_parent_root: Root
     slot: Slot
+    shard: Shard
     proposer_index: ValidatorIndex
     body: ByteList[MAX_SHARD_BLOCK_SIZE]
 ```
@@ -321,6 +322,7 @@ class ShardBlockHeader(Container):
     shard_parent_root: Root
     beacon_parent_root: Root
     slot: Slot
+    shard: Shard
     proposer_index: ValidatorIndex
     body_root: Root
 ```
@@ -781,8 +783,9 @@ def apply_shard_transition(state: BeaconState, shard: Shard, transition: ShardTr
             header = ShardBlockHeader(
                 shard_parent_root=shard_parent_root,
                 beacon_parent_root=get_block_root_at_slot(state, offset_slots[i]),
-                proposer_index=proposal_index,
                 slot=offset_slots[i],
+                shard=shard,
+                proposer_index=proposal_index,
                 body_root=transition.shard_data_roots[i]
             )
             shard_parent_root = hash_tree_root(header)

--- a/specs/phase1/shard-transition.md
+++ b/specs/phase1/shard-transition.md
@@ -50,6 +50,7 @@ def verify_shard_block_message(beacon_state: BeaconState,
                                shard: Shard) -> bool:
     assert block.shard_parent_root == shard_state.latest_block_root
     assert block.slot == slot
+    assert block.shard == shard
     assert block.proposer_index == get_shard_proposer_index(beacon_state, slot, shard)
     assert 0 < len(block.body) <= MAX_SHARD_BLOCK_SIZE
     return True

--- a/tests/core/pyspec/eth2spec/test/helpers/shard_block.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/shard_block.py
@@ -38,6 +38,7 @@ def build_shard_block(spec,
         shard_parent_root=shard_state.latest_block_root,
         beacon_parent_root=beacon_parent_root,
         slot=slot,
+        shard=shard,
         proposer_index=proposer_index,
         body=body,
     )


### PR DESCRIPTION
### Issue
Per #1850 point 2, add `shard` to `ShardBlock`.

### How did I solve it
1. Add add `shard` to `ShardBlock` and `ShardBlockHeader`.
2. Add verification in `verify_shard_block_message`.

/cc @terencechain 