### PR TITLE
Some phase1 refactoring

### DIFF
--- a/specs/phase1/beacon-chain.md
+++ b/specs/phase1/beacon-chain.md
@@ -130,7 +130,7 @@ class AttestationData(Container):
     source: Checkpoint
     target: Checkpoint
     # Current-slot shard block root
-    head_shard_root: Root
+    shard_head_root: Root
     # Shard transition root
     shard_transition_root: Root
 ```
@@ -823,7 +823,7 @@ def process_crosslink_for_shard(state: BeaconState,
         for attestation in transition_attestations:
             participants = get_attesting_indices(state, attestation.data, attestation.aggregation_bits)
             transition_participants = transition_participants.union(participants)
-            assert attestation.data.head_shard_root == shard_transition.shard_data_roots[
+            assert attestation.data.shard_head_root == shard_transition.shard_data_roots[
                 len(shard_transition.shard_data_roots) - 1
             ]
 

--- a/specs/phase1/beacon-chain.md
+++ b/specs/phase1/beacon-chain.md
@@ -66,7 +66,7 @@
         - [`process_crosslinks`](#process_crosslinks)
         - [`process_attestation`](#process_attestation)
       - [New Attester slashing processing](#new-attester-slashing-processing)
-    - [Shard transition false positives](#shard-transition-false-positives)
+    - [Verify empty shard transition](#verify-empty-shard-transition)
     - [Light client processing](#light-client-processing)
   - [Epoch transition](#epoch-transition)
     - [Custody game updates](#custody-game-updates)
@@ -671,7 +671,7 @@ def process_block(state: BeaconState, block: BeaconBlock) -> None:
     process_eth1_data(state, block.body)
     process_light_client_signatures(state, block.body)
     process_operations(state, block.body)
-    verify_shard_transition_false_positives(state, block.body)
+    verify_empty_shard_transition(state, block.body)
 ```
 
 #### Operations
@@ -943,11 +943,13 @@ def process_attester_slashing(state: BeaconState, attester_slashing: AttesterSla
     assert slashed_any
 ```
 
-#### Shard transition false positives
+#### Verify empty shard transition
 
 ```python
-def verify_shard_transition_false_positives(state: BeaconState, block_body: BeaconBlockBody) -> None:
-    # Verify that a `shard_transition` in a block is empty if an attestation was not processed for it
+def verify_empty_shard_transition(state: BeaconState, block_body: BeaconBlockBody) -> None:
+    """
+    Verify that a `shard_transition` in a block is empty if an attestation was not processed for it.
+    """
     for shard in range(get_active_shard_count(state)):
         if state.shard_states[shard].slot != compute_previous_slot(state.slot):
             assert block_body.shard_transitions[shard] == ShardTransition()

--- a/specs/phase1/beacon-chain.md
+++ b/specs/phase1/beacon-chain.md
@@ -948,7 +948,7 @@ def process_attester_slashing(state: BeaconState, attester_slashing: AttesterSla
 ```python
 def verify_empty_shard_transition(state: BeaconState, block_body: BeaconBlockBody) -> None:
     """
-    Verify that a `shard_transition` in a block is empty if an attestation was not processed for it.
+    Verify that ``shard_transitions`` are empty if a crosslink was not formed for the associated shard in this slot.
     """
     for shard in range(get_active_shard_count(state)):
         if state.shard_states[shard].slot != compute_previous_slot(state.slot):

--- a/tests/core/pyspec/eth2spec/test/helpers/attestations.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/attestations.py
@@ -78,7 +78,7 @@ def build_attestation_data(spec, state, slot, index, shard_transition=None, on_t
     if spec.fork == PHASE1:
         if shard_transition is not None:
             lastest_shard_data_root_index = len(shard_transition.shard_data_roots) - 1
-            attestation_data.head_shard_root = shard_transition.shard_data_roots[lastest_shard_data_root_index]
+            attestation_data.shard_head_root = shard_transition.shard_data_roots[lastest_shard_data_root_index]
             attestation_data.shard_transition_root = shard_transition.hash_tree_root()
         else:
             # No shard transition
@@ -88,10 +88,10 @@ def build_attestation_data(spec, state, slot, index, shard_transition=None, on_t
                 next_slot(spec, temp_state)
                 shard_transition = spec.get_shard_transition(temp_state, shard, [])
                 lastest_shard_data_root_index = len(shard_transition.shard_data_roots) - 1
-                attestation_data.head_shard_root = shard_transition.shard_data_roots[lastest_shard_data_root_index]
+                attestation_data.shard_head_root = shard_transition.shard_data_roots[lastest_shard_data_root_index]
                 attestation_data.shard_transition_root = shard_transition.hash_tree_root()
             else:
-                attestation_data.head_shard_root = state.shard_states[shard].transition_digest
+                attestation_data.shard_head_root = state.shard_states[shard].transition_digest
                 attestation_data.shard_transition_root = spec.Root()
     return attestation_data
 


### PR DESCRIPTION
Per #1850 request
1. Rename `head_shard_root` to `shard_head_root`
2. Rework `is_shard_attestation`
    * Different from #1850 suggested, I changed it to `is_on_time_attestation` so that it could be reused in `validate_attestation`
3. Rename `verify_shard_transition_false_positives` to `verify_empty_shard_transition`

/cc @terencechain 
