### PR TITLE
Rework `Shard transition processing`

### DIFF
--- a/tests/core/pyspec/eth2spec/test/helpers/shard_transitions.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/shard_transitions.py
@@ -1,9 +1,9 @@
 from eth2spec.test.context import expect_assertion_error
 
 
-def run_crosslinks_processing(spec, state, shard_transitions, attestations, valid=True):
+def run_shard_transitions_processing(spec, state, shard_transitions, attestations, valid=True):
     """
-    Run ``process_attestation``, yielding:
+    Run ``process_shard_transitions``, yielding:
       - pre-state ('pre')
       - shard_transitions ('shard_transitions')
       - attestations ('attestations')
@@ -17,12 +17,12 @@ def run_crosslinks_processing(spec, state, shard_transitions, attestations, vali
 
     # If the attestation is invalid, processing is aborted, and there is no post-state.
     if not valid:
-        expect_assertion_error(lambda: spec.process_crosslinks(state, shard_transitions, attestations))
+        expect_assertion_error(lambda: spec.process_shard_transitions(state, shard_transitions, attestations))
         yield 'post', None
         return
 
     # process crosslinks
-    spec.process_crosslinks(state, shard_transitions, attestations)
+    spec.process_shard_transitions(state, shard_transitions, attestations)
 
     # yield post-state
     yield 'post', state

--- a/tests/core/pyspec/eth2spec/test/phase_1/block_processing/test_process_shard_transition.py
+++ b/tests/core/pyspec/eth2spec/test/phase_1/block_processing/test_process_shard_transition.py
@@ -4,7 +4,7 @@ from eth2spec.test.context import (
     spec_state_test,
     always_bls,
 )
-from eth2spec.test.helpers.crosslinks import run_crosslinks_processing
+from eth2spec.test.helpers.shard_transitions import run_shard_transitions_processing
 from eth2spec.test.helpers.shard_block import (
     build_attestation_with_shard_transition,
     build_shard_block,
@@ -46,7 +46,7 @@ def run_basic_crosslink_tests(spec, state, target_len_offset_slot, valid=True):
     transition_to(spec, state, state.slot + target_len_offset_slot)
     pre_shard_state = state.shard_states[shard]
 
-    yield from run_crosslinks_processing(spec, state, shard_transitions, [attestation], valid=valid)
+    yield from run_shard_transitions_processing(spec, state, shard_transitions, [attestation], valid=valid)
 
     if valid:
         # After state transition,

--- a/tests/generators/README.md
+++ b/tests/generators/README.md
@@ -184,7 +184,7 @@ def create_provider(handler_name: str, tests_src, config_name: str) -> gen_typin
 
 if __name__ == "__main__":
     gen_runner.run_generator("epoch_processing", [
-        create_provider('crosslinks', test_process_crosslinks, 'minimal'),
+        create_provider('final_updates', test_process_final_updates, 'minimal'),
         ...
     ])
 


### PR DESCRIPTION
Pending on #1854

1. Separate `New Attestation processin` section and `Shard transition processing` section
2. Combine `process_crosslinks` and `verify_empty_shard_transition` into `process_shard_transitions`
3. Make `verify_empty_shard_transition` return `bool` as other `verify_*` functions

/cc @terencechain 