### PR TITLE
`get_start_shard` proposal

### DIFF
--- a/configs/minimal.yaml
+++ b/configs/minimal.yaml
@@ -165,7 +165,7 @@ PHASE_1_FORK_VERSION: 0x01000001
 # [customized] for testing
 PHASE_1_GENESIS_SLOT: 8
 # [customized] reduced for testing
-INITIAL_ACTIVE_SHARDS: 4
+INITIAL_ACTIVE_SHARDS: 2
 
 
 # Phase 1: General

--- a/setup.py
+++ b/setup.py
@@ -140,7 +140,7 @@ SUNDRY_CONSTANTS_FUNCTIONS = '''
 def ceillog2(x: uint64) -> int:
     return (x - 1).bit_length()
 '''
-SUNDRY_FUNCTIONS = '''
+PHASE0_SUNDRY_FUNCTIONS = '''
 # Monkey patch hash cache
 _hash = hash
 hash_cache: Dict[bytes, Bytes32] = {}
@@ -220,6 +220,13 @@ get_attesting_indices = cache_this(
     _get_attesting_indices, lru_size=SLOTS_PER_EPOCH * MAX_COMMITTEES_PER_SLOT * 3)'''
 
 
+PHASE1_SUNDRY_FUNCTIONS = '''
+_get_start_shard = get_start_shard
+get_start_shard = cache_this(
+    lambda state, slot: (state.validators.hash_tree_root(), slot),
+    _get_start_shard, lru_size=SLOTS_PER_EPOCH * 3)'''
+
+
 def objects_to_spec(spec_object: SpecObject, imports: str, fork: str) -> str:
     """
     Given all the objects that constitute a spec, combine them into a single pyfile.
@@ -250,9 +257,11 @@ def objects_to_spec(spec_object: SpecObject, imports: str, fork: str) -> str:
             + '\n\n' + CONFIG_LOADER
             + '\n\n' + ssz_objects_instantiation_spec
             + '\n\n' + functions_spec
-            + '\n' + SUNDRY_FUNCTIONS
-            + '\n'
+            + '\n' + PHASE0_SUNDRY_FUNCTIONS
     )
+    if fork == 'phase1':
+        spec += '\n' + PHASE1_SUNDRY_FUNCTIONS
+    spec += '\n'
     return spec
 
 

--- a/specs/phase1/beacon-chain.md
+++ b/specs/phase1/beacon-chain.md
@@ -558,13 +558,9 @@ def get_indexed_attestation(beacon_state: BeaconState, attestation: Attestation)
 ```python
 def get_committee_count_delta(state: BeaconState, start_slot: Slot, stop_slot: Slot) -> uint64:
     """
-    Return the sum of committee counts between ``[start_slot, stop_slot)``.
+    Return the sum of committee counts in range ``[start_slot, stop_slot)``.
     """
-    committee_sum = 0
-    for slot in range(start_slot, stop_slot):
-        count = get_committee_count_at_slot(state, Slot(slot))
-        committee_sum += count
-    return committee_sum
+    return sum(get_committee_count_at_slot(state, Slot(slot)) for slot in range(start_slot, stop_slot))
 ```
 
 #### `get_start_shard`

--- a/specs/phase1/beacon-chain.md
+++ b/specs/phase1/beacon-chain.md
@@ -578,7 +578,7 @@ def get_start_shard(state: BeaconState, slot: Slot) -> Shard:
 ```python
 def get_shard(state: BeaconState, attestation: Attestation) -> Shard:
     """
-    Return the shard that the given attestation is attesting.
+    Return the shard that the given ``attestation`` is attesting.
     """
     return compute_shard_from_committee_index(state, attestation.data.index, attestation.data.slot)
 ```
@@ -588,7 +588,7 @@ def get_shard(state: BeaconState, attestation: Attestation) -> Shard:
 ```python
 def get_latest_slot_for_shard(state: BeaconState, shard: Shard) -> Slot:
     """
-    Return the latest slot number of the given shard.
+    Return the latest slot number of the given ``shard``.
     """
     return state.shard_states[shard].slot
 ```
@@ -598,7 +598,7 @@ def get_latest_slot_for_shard(state: BeaconState, shard: Shard) -> Slot:
 ```python
 def get_offset_slots(state: BeaconState, shard: Shard) -> Sequence[Slot]:
     """
-    Return the offset slots of the given shard.
+    Return the offset slots of the given ``shard``.
     The offset slot are after the latest slot and before current slot. 
     """
     return compute_offset_slots(get_latest_slot_for_shard(state, shard), state.slot)

--- a/specs/phase1/phase1-fork.md
+++ b/specs/phase1/phase1-fork.md
@@ -99,6 +99,7 @@ def upgrade_to_phase1(pre: phase0.BeaconState) -> BeaconState:
         current_justified_checkpoint=pre.current_justified_checkpoint,
         finalized_checkpoint=pre.finalized_checkpoint,
         # Phase 1
+        current_epoch_start_shard=Shard(0),
         shard_states=List[ShardState, MAX_SHARDS](
             ShardState(
                 slot=pre.slot,

--- a/tests/core/pyspec/eth2spec/test/helpers/attestations.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/attestations.py
@@ -1,8 +1,9 @@
 from typing import List
 
 from eth2spec.test.context import expect_assertion_error, PHASE0, PHASE1
-from eth2spec.test.helpers.state import state_transition_and_sign_block, next_epoch, next_slot, transition_to
+from eth2spec.test.helpers.state import state_transition_and_sign_block, next_epoch, next_slot
 from eth2spec.test.helpers.block import build_empty_block_for_next_slot
+from eth2spec.test.helpers.shard_transitions import get_shard_transition_of_committee
 from eth2spec.test.helpers.keys import privkeys
 from eth2spec.utils import bls
 from eth2spec.utils.ssz.ssz_typing import Bitlist
@@ -81,12 +82,12 @@ def build_attestation_data(spec, state, slot, index, shard_transition=None, on_t
             attestation_data.shard_head_root = shard_transition.shard_data_roots[lastest_shard_data_root_index]
             attestation_data.shard_transition_root = shard_transition.hash_tree_root()
         else:
-            # No shard transition
+            # No shard transition -> no shard block
             shard = spec.get_shard(state, spec.Attestation(data=attestation_data))
             if on_time:
                 temp_state = state.copy()
                 next_slot(spec, temp_state)
-                shard_transition = spec.get_shard_transition(temp_state, shard, [])
+                shard_transition = spec.get_shard_transition(temp_state, shard, shard_blocks=[])
                 lastest_shard_data_root_index = len(shard_transition.shard_data_roots) - 1
                 attestation_data.shard_head_root = shard_transition.shard_data_roots[lastest_shard_data_root_index]
                 attestation_data.shard_transition_root = shard_transition.hash_tree_root()
@@ -180,7 +181,7 @@ def get_valid_attestation(spec,
     fill_aggregate_attestation(spec, state, attestation, signed=signed, filter_participant_set=filter_participant_set)
 
     if spec.fork == PHASE1 and on_time:
-        attestation = convert_to_valid_on_time_attestation(spec, state, attestation, signed)
+        attestation = convert_to_valid_on_time_attestation(spec, state, attestation, signed=signed)
 
     return attestation
 
@@ -317,7 +318,19 @@ def next_epoch_with_attestations(spec,
             committees_per_slot = spec.get_committee_count_at_slot(state, slot_to_attest)
             if slot_to_attest >= spec.compute_start_slot_at_epoch(spec.get_current_epoch(post_state)):
                 for index in range(committees_per_slot):
-                    cur_attestation = get_valid_attestation(spec, post_state, slot_to_attest, index=index, signed=True)
+                    if spec.fork == PHASE1:
+                        shard = spec.compute_shard_from_committee_index(post_state, index, slot_to_attest)
+                        shard_transition = get_shard_transition_of_committee(
+                            spec, post_state, index, slot=slot_to_attest
+                        )
+                        block.body.shard_transitions[shard] = shard_transition
+                    else:
+                        shard_transition = None
+
+                    cur_attestation = get_valid_attestation(
+                        spec, post_state, slot_to_attest,
+                        shard_transition=shard_transition, index=index, signed=True, on_time=True
+                    )
                     block.body.attestations.append(cur_attestation)
 
         if fill_prev_epoch:
@@ -327,9 +340,6 @@ def next_epoch_with_attestations(spec,
                 prev_attestation = get_valid_attestation(
                     spec, post_state, slot_to_attest, index=index, signed=True, on_time=False)
                 block.body.attestations.append(prev_attestation)
-
-        if spec.fork == PHASE1:
-            fill_block_shard_transitions_by_attestations(spec, post_state, block)
 
         signed_block = state_transition_and_sign_block(spec, post_state, block)
         signed_blocks.append(signed_block)
@@ -396,14 +406,3 @@ def cached_prepare_state_with_attestations(spec, state):
 
     # Put the LRU cache result into the state view, as if we transitioned the original view
     state.set_backing(_prep_state_cache_dict[key])
-
-
-def fill_block_shard_transitions_by_attestations(spec, state, block):
-    block.body.shard_transitions = [spec.ShardTransition()] * spec.MAX_SHARDS
-    for attestation in block.body.attestations:
-        shard = spec.get_shard(state, attestation)
-        if attestation.data.slot == state.slot:
-            temp_state = state.copy()
-            transition_to(spec, temp_state, slot=block.slot)
-            shard_transition = spec.get_shard_transition(temp_state, shard, [])
-            block.body.shard_transitions[shard] = shard_transition

--- a/tests/core/pyspec/eth2spec/test/helpers/shard_block.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/shard_block.py
@@ -70,7 +70,7 @@ def build_shard_transitions_till_slot(spec, state, shard_blocks, on_time_slot):
     return shard_transitions
 
 
-def build_attestation_with_shard_transition(spec, state, index, on_time_slot, shard_transition=None):
+def build_attestation_with_shard_transition(spec, state, index, on_time_slot, shard_transition):
     temp_state = state.copy()
     transition_to(spec, temp_state, on_time_slot - 1)
     attestation = get_valid_on_time_attestation(

--- a/tests/core/pyspec/eth2spec/test/helpers/shard_transitions.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/shard_transitions.py
@@ -1,4 +1,5 @@
 from eth2spec.test.context import expect_assertion_error
+from eth2spec.test.helpers.state import transition_to
 
 
 def run_shard_transitions_processing(spec, state, shard_transitions, attestations, valid=True):
@@ -26,3 +27,17 @@ def run_shard_transitions_processing(spec, state, shard_transitions, attestation
 
     # yield post-state
     yield 'post', state
+
+
+def get_shard_transition_of_committee(spec, state, committee_index, slot=None, shard_blocks=None):
+    if shard_blocks is None:
+        shard_blocks = []
+
+    if slot is None:
+        slot = state.slot
+
+    shard = spec.compute_shard_from_committee_index(state, committee_index, state.slot)
+    temp_state = state.copy()
+    transition_to(spec, temp_state, slot + 1)
+    shard_transition = spec.get_shard_transition(temp_state, shard, shard_blocks=shard_blocks)
+    return shard_transition

--- a/tests/core/pyspec/eth2spec/test/phase_1/block_processing/test_process_crosslink.py
+++ b/tests/core/pyspec/eth2spec/test/phase_1/block_processing/test_process_crosslink.py
@@ -18,7 +18,7 @@ def run_basic_crosslink_tests(spec, state, target_len_offset_slot, valid=True):
     # At the beginning, let `x = state.slot`, `state.shard_states[shard].slot == x - 1`
     slot_x = state.slot
     committee_index = spec.CommitteeIndex(0)
-    shard = spec.compute_shard_from_committee_index(state, committee_index, state.slot)
+    shard = spec.compute_shard_from_committee_index(state, committee_index, state.slot + target_len_offset_slot)
     assert state.shard_states[shard].slot == slot_x - 1
 
     # Create SignedShardBlock

--- a/tests/core/pyspec/eth2spec/test/phase_1/block_processing/test_process_shard_transition.py
+++ b/tests/core/pyspec/eth2spec/test/phase_1/block_processing/test_process_shard_transition.py
@@ -15,11 +15,10 @@ from eth2spec.test.helpers.state import transition_to, transition_to_valid_shard
 
 def run_basic_crosslink_tests(spec, state, target_len_offset_slot, valid=True):
     state = transition_to_valid_shard_slot(spec, state)
-    # At the beginning, let `x = state.slot`, `state.shard_states[shard].slot == x - 1`
-    slot_x = state.slot
+    init_slot = state.slot
     committee_index = spec.CommitteeIndex(0)
-    shard = spec.compute_shard_from_committee_index(state, committee_index, state.slot + target_len_offset_slot)
-    assert state.shard_states[shard].slot == slot_x - 1
+    shard = spec.compute_shard_from_committee_index(state, committee_index, state.slot + target_len_offset_slot - 1)
+    assert state.shard_states[shard].slot == state.slot - 1
 
     # Create SignedShardBlock
     body = b'\x56' * spec.MAX_SHARD_BLOCK_SIZE
@@ -50,7 +49,7 @@ def run_basic_crosslink_tests(spec, state, target_len_offset_slot, valid=True):
 
     if valid:
         # After state transition,
-        assert state.slot == slot_x + target_len_offset_slot
+        assert state.slot == init_slot + target_len_offset_slot
         shard_state = state.shard_states[shard]
         assert shard_state != pre_shard_state
         assert shard_state == shard_transition.shard_states[len(shard_transition.shard_states) - 1]

--- a/tests/core/pyspec/eth2spec/test/phase_1/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/phase_1/sanity/test_blocks.py
@@ -67,7 +67,7 @@ def test_process_beacon_block_with_normal_shard_transition(spec, state):
 
     target_len_offset_slot = 1
     committee_index = spec.CommitteeIndex(0)
-    shard = spec.compute_shard_from_committee_index(state, committee_index, state.slot)
+    shard = spec.compute_shard_from_committee_index(state, committee_index, state.slot + target_len_offset_slot)
     assert state.shard_states[shard].slot == state.slot - 1
 
     pre_gasprice = state.shard_states[shard].gasprice
@@ -93,7 +93,7 @@ def test_process_beacon_block_with_empty_proposal_transition(spec, state):
 
     target_len_offset_slot = 1
     committee_index = spec.CommitteeIndex(0)
-    shard = spec.compute_shard_from_committee_index(state, committee_index, state.slot)
+    shard = spec.compute_shard_from_committee_index(state, committee_index, state.slot + target_len_offset_slot)
     assert state.shard_states[shard].slot == state.slot - 1
 
     # No new shard block

--- a/tests/core/pyspec/eth2spec/test/phase_1/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/phase_1/sanity/test_blocks.py
@@ -67,7 +67,7 @@ def test_process_beacon_block_with_normal_shard_transition(spec, state):
 
     target_len_offset_slot = 1
     committee_index = spec.CommitteeIndex(0)
-    shard = spec.compute_shard_from_committee_index(state, committee_index, state.slot + target_len_offset_slot)
+    shard = spec.compute_shard_from_committee_index(state, committee_index, state.slot + target_len_offset_slot - 1)
     assert state.shard_states[shard].slot == state.slot - 1
 
     pre_gasprice = state.shard_states[shard].gasprice
@@ -93,7 +93,7 @@ def test_process_beacon_block_with_empty_proposal_transition(spec, state):
 
     target_len_offset_slot = 1
     committee_index = spec.CommitteeIndex(0)
-    shard = spec.compute_shard_from_committee_index(state, committee_index, state.slot + target_len_offset_slot)
+    shard = spec.compute_shard_from_committee_index(state, committee_index, state.slot + target_len_offset_slot - 1)
     assert state.shard_states[shard].slot == state.slot - 1
 
     # No new shard block

--- a/tests/core/pyspec/eth2spec/test/phase_1/unittests/test_get_start_shard.py
+++ b/tests/core/pyspec/eth2spec/test/phase_1/unittests/test_get_start_shard.py
@@ -1,0 +1,71 @@
+from eth2spec.test.context import (
+    PHASE0,
+    with_all_phases_except,
+    spec_state_test,
+)
+from eth2spec.test.helpers.state import next_epoch
+
+
+@with_all_phases_except([PHASE0])
+@spec_state_test
+def test_get_committee_count_delta(spec, state):
+    assert spec.get_committee_count_delta(state, 0, 0) == 0
+    assert spec.get_committee_count_at_slot(state, 0) != 0
+    assert spec.get_committee_count_delta(state, 0, 1) == spec.get_committee_count_at_slot(state, 0)
+    assert spec.get_committee_count_delta(state, 1, 2) == spec.get_committee_count_at_slot(state, 1)
+    assert spec.get_committee_count_delta(state, 0, 2) == (
+        spec.get_committee_count_at_slot(state, 0) + spec.get_committee_count_at_slot(state, 1)
+    )
+
+
+@with_all_phases_except([PHASE0])
+@spec_state_test
+def test_get_start_shard_current_epoch_start(spec, state):
+    assert state.current_epoch_start_shard == 0
+    next_epoch(spec, state)
+    active_shard_count = spec.get_active_shard_count(state)
+    assert state.current_epoch_start_shard == (
+        spec.get_committee_count_delta(state, 0, spec.SLOTS_PER_EPOCH) % active_shard_count
+    )
+    current_epoch_start_slot = spec.compute_start_slot_at_epoch(spec.get_current_epoch(state))
+
+    slot = current_epoch_start_slot
+    start_shard = spec.get_start_shard(state, slot)
+    assert start_shard == state.current_epoch_start_shard
+
+
+@with_all_phases_except([PHASE0])
+@spec_state_test
+def test_get_start_shard_next_slot(spec, state):
+    next_epoch(spec, state)
+    active_shard_count = spec.get_active_shard_count(state)
+    current_epoch_start_slot = spec.compute_start_slot_at_epoch(spec.get_current_epoch(state))
+
+    slot = current_epoch_start_slot + 1
+    start_shard = spec.get_start_shard(state, slot)
+
+    current_epoch_start_slot = spec.compute_start_slot_at_epoch(spec.get_current_epoch(state))
+    expected_start_shard = (
+        state.current_epoch_start_shard +
+        spec.get_committee_count_delta(state, start_slot=current_epoch_start_slot, stop_slot=slot)
+    ) % active_shard_count
+    assert start_shard == expected_start_shard
+
+
+@with_all_phases_except([PHASE0])
+@spec_state_test
+def test_get_start_shard_previous_slot(spec, state):
+    next_epoch(spec, state)
+    active_shard_count = spec.get_active_shard_count(state)
+    current_epoch_start_slot = spec.compute_start_slot_at_epoch(spec.get_current_epoch(state))
+
+    slot = current_epoch_start_slot - 1
+    start_shard = spec.get_start_shard(state, slot)
+
+    current_epoch_start_slot = spec.compute_start_slot_at_epoch(spec.get_current_epoch(state))
+    expected_start_shard = (
+        state.current_epoch_start_shard
+        + spec.MAX_COMMITTEES_PER_SLOT * spec.SLOTS_PER_EPOCH * active_shard_count
+        - spec.get_committee_count_delta(state, start_slot=slot, stop_slot=current_epoch_start_slot)
+    ) % active_shard_count
+    assert start_shard == expected_start_shard

--- a/tests/core/pyspec/eth2spec/test/phase_1/unittests/test_get_start_shard.py
+++ b/tests/core/pyspec/eth2spec/test/phase_1/unittests/test_get_start_shard.py
@@ -46,8 +46,8 @@ def test_get_start_shard_next_slot(spec, state):
 
     current_epoch_start_slot = spec.compute_start_slot_at_epoch(spec.get_current_epoch(state))
     expected_start_shard = (
-        state.current_epoch_start_shard +
-        spec.get_committee_count_delta(state, start_slot=current_epoch_start_slot, stop_slot=slot)
+        state.current_epoch_start_shard
+        + spec.get_committee_count_delta(state, start_slot=current_epoch_start_slot, stop_slot=slot)
     ) % active_shard_count
     assert start_shard == expected_start_shard
 


### PR DESCRIPTION
### Issue
Implement `get_start_shard`

### How did I fix it
1. Add `current_epoch_start_shard` to `BeaconState`.
2. Implement `get_start_shard`
    1. Use `state.current_epoch_start_shard` as the current view, to plus or substract the committee count delta.
    2. `get_start_shard` and `get_committee_count_at_slot` results should be cached.
3. [**minimal config**] Change `INITIAL_ACTIVE_SHARDS` from `4` to `2` for more frequent crosslinks


TODO
- [x] add tests