### PR TITLE
Update fork choice spec comment for clarity

### DIFF
--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -150,7 +150,7 @@ def get_ancestor(store: Store, root: Root, slot: Slot) -> Root:
     elif block.slot == slot:
         return root
     else:
-        # root is older than queried slot, thus a skip slot. Return earliest root prior to slot
+        # root is older than queried slot, thus a skip slot. Return most recent root prior to slot
         return root
 ```
 


### PR DESCRIPTION
I think this change more clearly specifies the intended behavior. Given the terseness of the spec's code representation, I think we should aim for as much clarity as possible.

Rationale:

"earliest" implies the root with the lowest timestamp.

"most recent" more precisely implies the highest root in the chain before the (skipped) slot in question.