### PR TITLE
Tidying up `shard_state_transition`

### DIFF
--- a/specs/phase1/shard-transition.md
+++ b/specs/phase1/shard-transition.md
@@ -71,21 +71,22 @@ def verify_shard_block_signature(beacon_state: BeaconState,
 def shard_state_transition(beacon_state: BeaconState,
                            shard_state: ShardState,
                            block: ShardBlock) -> None:
-    # Update shard state
+    """
+    Update ``shard_state`` with shard ``block`` and ``beacon_state`.
+    """
+    shard_state.slot = block.slot
     prev_gasprice = shard_state.gasprice
-    if len(block.body) == 0:
-        latest_block_root = shard_state.latest_block_root
-    else:
-        latest_block_root = hash_tree_root(block)
-
+    shard_state.gasprice = compute_updated_gasprice(prev_gasprice, len(block.body))
     shard_state.transition_digest = compute_shard_transition_digest(
         beacon_state,
         shard_state,
         block.beacon_parent_root,
         hash_tree_root(block.body),
     )
-    shard_state.gasprice = compute_updated_gasprice(prev_gasprice, len(block.body))
-    shard_state.slot = block.slot
+    if len(block.body) == 0:
+        latest_block_root = shard_state.latest_block_root
+    else:
+        latest_block_root = hash_tree_root(block)
     shard_state.latest_block_root = latest_block_root
 ```
 

--- a/specs/phase1/shard-transition.md
+++ b/specs/phase1/shard-transition.md
@@ -77,17 +77,17 @@ def shard_state_transition(beacon_state: BeaconState,
     shard_state.slot = block.slot
     prev_gasprice = shard_state.gasprice
     shard_state.gasprice = compute_updated_gasprice(prev_gasprice, len(block.body))
+    if len(block.body) == 0:
+        latest_block_root = shard_state.latest_block_root
+    else:
+        latest_block_root = hash_tree_root(block)
+    shard_state.latest_block_root = latest_block_root
     shard_state.transition_digest = compute_shard_transition_digest(
         beacon_state,
         shard_state,
         block.beacon_parent_root,
         hash_tree_root(block.body),
     )
-    if len(block.body) == 0:
-        latest_block_root = shard_state.latest_block_root
-    else:
-        latest_block_root = hash_tree_root(block)
-    shard_state.latest_block_root = latest_block_root
 ```
 
 We have a pure function `get_post_shard_state` for describing the fraud proof verification and honest validator behavior.


### PR DESCRIPTION
Change list:
 * Replaced `#Update shard state` with triple quotes comment
 * Moved the order of update operations (Slot -> GasPrice -> TransitionDigest -> LatestBlockRoot) Hope it helps with readability 