### PR TITLE
Reword fork choice comment

### DIFF
--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -285,7 +285,7 @@ def validate_on_attestation(store: Store, attestation: Attestation) -> None:
     # Attestations must not be for blocks in the future. If not, the attestation should not be considered
     assert store.blocks[attestation.data.beacon_block_root].slot <= attestation.data.slot
 
-    # FFG and LMD vote must be consistent with each other
+    # LMD vote must be consistent with FFG target
     target_slot = compute_start_slot_at_epoch(target.epoch)
     assert target.root == get_ancestor(store, attestation.data.beacon_block_root, target_slot)
 

--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -285,7 +285,7 @@ def validate_on_attestation(store: Store, attestation: Attestation) -> None:
     # Attestations must not be for blocks in the future. If not, the attestation should not be considered
     assert store.blocks[attestation.data.beacon_block_root].slot <= attestation.data.slot
 
-    # LMD vote must be consistent with FFG target
+    # LMD vote must be consistent with FFG vote target
     target_slot = compute_start_slot_at_epoch(target.epoch)
     assert target.root == get_ancestor(store, attestation.data.beacon_block_root, target_slot)
 


### PR DESCRIPTION
Ensuring _true_ consistency between the LMD & FFG votes would also involve checking the source.

This is a bit of a nitpick, but it can be useful to flag when comments don't exactly match the code.
