### PR TITLE
Use shard_block.slot to get seed for proposer selection

### DIFF
--- a/specs/phase1/beacon-chain.md
+++ b/specs/phase1/beacon-chain.md
@@ -537,9 +537,13 @@ def get_light_client_committee(beacon_state: BeaconState, epoch: Epoch) -> Seque
 
 ```python
 def get_shard_proposer_index(beacon_state: BeaconState, slot: Slot, shard: Shard) -> ValidatorIndex:
-    committee = get_shard_committee(beacon_state, compute_epoch_at_slot(slot), shard)
+    """
+    Return the proposer's index of shard block at ``slot``.
+    """
     epoch = compute_epoch_at_slot(slot)
-    r = bytes_to_int(get_seed(beacon_state, epoch, DOMAIN_SHARD_COMMITTEE)[:8])
+    committee = get_shard_committee(beacon_state, epoch, shard)
+    seed = hash(get_seed(beacon_state, epoch, DOMAIN_SHARD_COMMITTEE) + int_to_bytes(slot, length=8))
+    r = bytes_to_int(seed[:8])
     return committee[r % len(committee)]
 ```
 

--- a/specs/phase1/beacon-chain.md
+++ b/specs/phase1/beacon-chain.md
@@ -538,7 +538,8 @@ def get_light_client_committee(beacon_state: BeaconState, epoch: Epoch) -> Seque
 ```python
 def get_shard_proposer_index(beacon_state: BeaconState, slot: Slot, shard: Shard) -> ValidatorIndex:
     committee = get_shard_committee(beacon_state, compute_epoch_at_slot(slot), shard)
-    r = bytes_to_int(get_seed(beacon_state, get_current_epoch(beacon_state), DOMAIN_SHARD_COMMITTEE)[:8])
+    epoch = compute_epoch_at_slot(slot)
+    r = bytes_to_int(get_seed(beacon_state, epoch, DOMAIN_SHARD_COMMITTEE)[:8])
     return committee[r % len(committee)]
 ```
 


### PR DESCRIPTION
For shard proposer selection, we should use the epoch of `shard_block.slot` to get seed in case cross-epoch operation. e.g., the shard block at slot 43 is part of the shard transition at slot 74.