### PR TITLE
Handle `beacon_parent_root` checks

### DIFF
--- a/specs/phase1/shard-fork-choice.md
+++ b/specs/phase1/shard-fork-choice.md
@@ -169,7 +169,7 @@ def on_shard_block(store: Store, shard_store: ShardStore, signed_shard_block: Si
     )
 
     # Check the block is valid and compute the post-state
-    assert verify_shard_block_message(beacon_parent_state, shard_parent_state, shard_block, shard_block.slot, shard)
+    assert verify_shard_block_message(beacon_parent_state, shard_parent_state, shard_block)
     assert verify_shard_block_signature(beacon_parent_state, signed_shard_block)
 
     post_state = get_post_shard_state(beacon_parent_state, shard_parent_state, shard_block)

--- a/specs/phase1/shard-fork-choice.md
+++ b/specs/phase1/shard-fork-choice.md
@@ -151,10 +151,11 @@ def on_shard_block(store: Store, shard_store: ShardStore, signed_shard_block: Si
 
     # Check shard parent exists
     assert shard_block.shard_parent_root in shard_store.block_states
-    pre_shard_state = shard_store.block_states[shard_block.shard_parent_root]
+    shard_parent_state = shard_store.block_states[shard_block.shard_parent_root]
 
     # Check beacon parent exists
     assert shard_block.beacon_parent_root in store.block_states
+    beacon_parent_state = store.block_states[shard_block.beacon_parent_root]
 
     # Check that block is later than the finalized shard state slot (optimization to reduce calls to get_ancestor)
     finalized_beacon_state = store.block_states[store.finalized_checkpoint.root]
@@ -171,11 +172,9 @@ def on_shard_block(store: Store, shard_store: ShardStore, signed_shard_block: Si
     shard_store.blocks[hash_tree_root(shard_block)] = shard_block
 
     # Check the block is valid and compute the post-state
-    beacon_head_root = get_head(store)
-    beacon_head_state = store.block_states[beacon_head_root]
-    assert verify_shard_block_message(beacon_head_state, pre_shard_state, shard_block, shard_block.slot, shard)
-    assert verify_shard_block_signature(beacon_head_state, signed_shard_block)
-    post_state = get_post_shard_state(beacon_head_state, pre_shard_state, shard_block)
+    assert verify_shard_block_message(beacon_parent_state, shard_parent_state, shard_block, shard_block.slot, shard)
+    assert verify_shard_block_signature(beacon_parent_state, signed_shard_block)
+    post_state = get_post_shard_state(beacon_parent_state, shard_parent_state, shard_block)
     # Add new state for this block to the store
     shard_store.block_states[hash_tree_root(shard_block)] = post_state
 ```

--- a/specs/phase1/shard-transition.md
+++ b/specs/phase1/shard-transition.md
@@ -280,8 +280,8 @@ Suppose you are a committee member on shard `shard` at slot `current_slot` and y
 ```python
 def get_shard_transition(beacon_state: BeaconState,
                          shard: Shard,
-                         shard_blocks: Sequence[SignedShardBlock],
-                         on_time_slot: Slot) -> ShardTransition:
+                         shard_blocks: Sequence[SignedShardBlock]) -> ShardTransition:
+    on_time_slot = Slot(beacon_state.slot + 1)
     offset_slots = compute_offset_slots(get_latest_slot_for_shard(beacon_state, shard), on_time_slot)
     proposals, shard_states, shard_data_roots = get_shard_state_transition_result(
         beacon_state, shard, shard_blocks, on_time_slot

--- a/specs/phase1/shard-transition.md
+++ b/specs/phase1/shard-transition.md
@@ -43,27 +43,26 @@ def compute_shard_transition_digest(beacon_parent_state: BeaconState,
 ### Shard block verification functions
 
 ```python
-def verify_shard_block_message(beacon_state: BeaconState,
+def verify_shard_block_message(beacon_parent_state: BeaconState,
                                shard_parent_state: ShardState,
-                               block: ShardBlock,
-                               slot: Slot,
-                               shard: Shard) -> bool:
+                               block: ShardBlock) -> bool:
     # Check `shard_parent_root` field
     assert block.shard_parent_root == shard_parent_state.latest_block_root
     # Check `beacon_parent_root` field
-    beacon_parent_block_header = beacon_state.latest_block_header.copy()
+    beacon_parent_block_header = beacon_parent_state.latest_block_header.copy()
     if beacon_parent_block_header.state_root == Root():
-        beacon_parent_block_header.state_root = hash_tree_root(beacon_state)
+        beacon_parent_block_header.state_root = hash_tree_root(beacon_parent_state)
     beacon_parent_root = hash_tree_root(beacon_parent_block_header)
     assert block.beacon_parent_root == beacon_parent_root
     # Check `slot` field
-    next_slot = Slot(slot + 1)
-    offset_slots = compute_offset_slots(get_latest_slot_for_shard(beacon_state, shard), next_slot)
-    assert slot in offset_slots
+    shard = block.shard
+    next_slot = Slot(block.slot + 1)
+    offset_slots = compute_offset_slots(get_latest_slot_for_shard(beacon_parent_state, shard), next_slot)
+    assert block.slot in offset_slots
     # Check `shard` field
     assert block.shard == shard
     # Check `proposer_index` field
-    assert block.proposer_index == get_shard_proposer_index(beacon_state, slot, shard)
+    assert block.proposer_index == get_shard_proposer_index(beacon_parent_state, block.slot, shard)
     # Check `body` field
     assert 0 < len(block.body) <= MAX_SHARD_BLOCK_SIZE
     return True

--- a/tests/core/pyspec/eth2spec/test/fork_choice/test_on_shard_head.py
+++ b/tests/core/pyspec/eth2spec/test/fork_choice/test_on_shard_head.py
@@ -4,7 +4,7 @@ from eth2spec.test.context import PHASE0, spec_state_test, with_all_phases_excep
 from eth2spec.test.helpers.attestations import get_valid_on_time_attestation
 from eth2spec.test.helpers.shard_block import (
     build_shard_block,
-    build_shard_transitions_till_slot,
+    get_shard_transitions,
     get_committee_index_of_shard,
 )
 from eth2spec.test.helpers.fork_choice import add_block_to_store, get_anchor_root
@@ -69,7 +69,7 @@ def apply_shard_and_beacon(spec, state, store, shard_store, shard_blocks_buffer)
         # Sanity check `get_pending_shard_blocks` function
         check_pending_shard_blocks(spec, store, shard_store, shard_blocks_buffer)
         # Use temporary next state to get ShardTransition of shard block
-        shard_transitions = build_shard_transitions_till_slot(
+        shard_transitions = get_shard_transitions(
             spec,
             state,
             shard_blocks={shard: shard_blocks_buffer},

--- a/tests/core/pyspec/eth2spec/test/fork_choice/test_on_shard_head.py
+++ b/tests/core/pyspec/eth2spec/test/fork_choice/test_on_shard_head.py
@@ -89,11 +89,11 @@ def apply_shard_and_beacon(spec, state, store, shard_store, shard_blocks_buffer)
         # Clear buffer
         shard_blocks_buffer.clear()
 
-    signed_beacon_block = state_transition_and_sign_block(spec, state, beacon_block)
+    signed_beacon_block = state_transition_and_sign_block(spec, state, beacon_block)  # transition!
     add_block_to_store(spec, store, signed_beacon_block)
     assert spec.get_head(store) == beacon_block.hash_tree_root()
 
-    # On shard block at updated `state.slot`
+    # On shard block at transitioned `state.slot`
     if is_in_offset_sets(spec, state, shard):
         # The created shard block would be appended to `shard_blocks_buffer`
         apply_shard_block(spec, store, shard_store, state, shard_blocks_buffer)

--- a/tests/core/pyspec/eth2spec/test/fork_choice/test_on_shard_head.py
+++ b/tests/core/pyspec/eth2spec/test/fork_choice/test_on_shard_head.py
@@ -1,8 +1,8 @@
 from eth2spec.utils.ssz.ssz_impl import hash_tree_root
 
 from eth2spec.test.context import PHASE0, spec_state_test, with_all_phases_except, never_bls
+from eth2spec.test.helpers.attestations import get_valid_on_time_attestation
 from eth2spec.test.helpers.shard_block import (
-    build_attestation_with_shard_transition,
     build_shard_block,
     build_shard_transitions_till_slot,
     get_committee_index_of_shard,
@@ -25,15 +25,15 @@ def run_on_shard_block(spec, store, shard_store, signed_block, valid=True):
     assert shard_store.blocks[hash_tree_root(signed_block.message)] == signed_block.message
 
 
-def apply_shard_block(spec, store, shard_store, beacon_head_state, shard_blocks_buffer):
+def apply_shard_block(spec, store, shard_store, beacon_parent_state, shard_blocks_buffer):
     shard = shard_store.shard
     body = b'\x56' * 4
     shard_head_root = spec.get_shard_head(store, shard_store)
     shard_parent_state = shard_store.block_states[shard_head_root]
-    assert shard_parent_state.slot != beacon_head_state.slot
+    assert shard_parent_state.slot != beacon_parent_state.slot
     shard_block = build_shard_block(
-        spec, beacon_head_state, shard,
-        shard_parent_state=shard_parent_state, slot=beacon_head_state.slot, body=body, signed=True
+        spec, beacon_parent_state, shard,
+        shard_parent_state=shard_parent_state, slot=beacon_parent_state.slot, body=body, signed=True
     )
     shard_blocks_buffer.append(shard_block)
     run_on_shard_block(spec, store, shard_store, shard_block)
@@ -62,30 +62,26 @@ def apply_shard_and_beacon(spec, state, store, shard_store, shard_blocks_buffer)
     committee_index = get_committee_index_of_shard(spec, state, state.slot, shard)
     has_shard_committee = committee_index is not None  # has committee of `shard` at this slot
 
-    # On beacon blocks at `state.slot + 1`
     beacon_block = build_empty_block(spec, state, slot=state.slot + 1)
 
     # If next slot has committee of `shard`, add `shard_transtion` to the proposing beacon block
     if has_shard_committee and len(shard_blocks_buffer) > 0:
         # Sanity check `get_pending_shard_blocks` function
         check_pending_shard_blocks(spec, store, shard_store, shard_blocks_buffer)
-
         # Use temporary next state to get ShardTransition of shard block
         shard_transitions = build_shard_transitions_till_slot(
             spec,
             state,
             shard_blocks={shard: shard_blocks_buffer},
-            on_time_slot=state.slot + 1,
         )
         shard_transition = shard_transitions[shard]
-        attestation = build_attestation_with_shard_transition(
+        attestation = get_valid_on_time_attestation(
             spec,
             state,
             index=committee_index,
-            on_time_slot=state.slot + 1,
             shard_transition=shard_transition,
+            signed=False,
         )
-        assert attestation.data.slot == state.slot
         assert spec.get_shard(state, attestation) == shard
         beacon_block.body.attestations = [attestation]
         beacon_block.body.shard_transitions = shard_transitions
@@ -129,7 +125,6 @@ def test_basic(spec, state):
     shard_committee_counter = 2
     shard_blocks_buffer = []
     while shard_committee_counter > 0:
-        print(f'state.slot', state.slot)
         has_shard_committee = apply_shard_and_beacon(
             spec, state, store, shard_store, shard_blocks_buffer
         )

--- a/tests/core/pyspec/eth2spec/test/helpers/attestations.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/attestations.py
@@ -87,7 +87,7 @@ def build_attestation_data(spec, state, slot, index, shard_transition=None, on_t
             if on_time:
                 temp_state = state.copy()
                 next_slot(spec, temp_state)
-                shard_transition = spec.get_shard_transition(temp_state, shard, shard_blocks=[])
+                shard_transition = spec.get_shard_transition(temp_state, shard, shard_blocks=[], on_time_slot=slot + 1)
                 lastest_shard_data_root_index = len(shard_transition.shard_data_roots) - 1
                 attestation_data.shard_head_root = shard_transition.shard_data_roots[lastest_shard_data_root_index]
                 attestation_data.shard_transition_root = shard_transition.hash_tree_root()

--- a/tests/core/pyspec/eth2spec/test/helpers/attestations.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/attestations.py
@@ -85,9 +85,7 @@ def build_attestation_data(spec, state, slot, index, shard_transition=None, on_t
             # No shard transition -> no shard block
             shard = spec.get_shard(state, spec.Attestation(data=attestation_data))
             if on_time:
-                temp_state = state.copy()
-                next_slot(spec, temp_state)
-                shard_transition = spec.get_shard_transition(temp_state, shard, shard_blocks=[], on_time_slot=slot + 1)
+                shard_transition = spec.get_shard_transition(state, shard, shard_blocks=[], on_time_slot=slot + 1)
                 lastest_shard_data_root_index = len(shard_transition.shard_data_roots) - 1
                 attestation_data.shard_head_root = shard_transition.shard_data_roots[lastest_shard_data_root_index]
                 attestation_data.shard_transition_root = shard_transition.hash_tree_root()

--- a/tests/core/pyspec/eth2spec/test/helpers/attestations.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/attestations.py
@@ -85,7 +85,7 @@ def build_attestation_data(spec, state, slot, index, shard_transition=None, on_t
             # No shard transition -> no shard block
             shard = spec.get_shard(state, spec.Attestation(data=attestation_data))
             if on_time:
-                shard_transition = spec.get_shard_transition(state, shard, shard_blocks=[], on_time_slot=slot + 1)
+                shard_transition = spec.get_shard_transition(state, shard, shard_blocks=[])
                 lastest_shard_data_root_index = len(shard_transition.shard_data_roots) - 1
                 attestation_data.shard_head_root = shard_transition.shard_data_roots[lastest_shard_data_root_index]
                 attestation_data.shard_transition_root = shard_transition.hash_tree_root()
@@ -318,9 +318,7 @@ def next_epoch_with_attestations(spec,
                 for index in range(committees_per_slot):
                     if spec.fork == PHASE1:
                         shard = spec.compute_shard_from_committee_index(post_state, index, slot_to_attest)
-                        shard_transition = get_shard_transition_of_committee(
-                            spec, post_state, index, slot=slot_to_attest
-                        )
+                        shard_transition = get_shard_transition_of_committee(spec, post_state, index)
                         block.body.shard_transitions[shard] = shard_transition
                     else:
                         shard_transition = None

--- a/tests/core/pyspec/eth2spec/test/helpers/shard_block.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/shard_block.py
@@ -61,7 +61,7 @@ def build_shard_transitions_till_slot(spec, parent_beacon_state, shard_blocks):
             on_time_slot,
         )
         len_offset_slots = len(offset_slots)
-        shard_transition = spec.get_shard_transition(parent_beacon_state, shard, blocks, on_time_slot)
+        shard_transition = spec.get_shard_transition(parent_beacon_state, shard, blocks)
 
         if len(blocks) > 0:
             shard_block_root = blocks[-1].message.hash_tree_root()

--- a/tests/core/pyspec/eth2spec/test/helpers/shard_block.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/shard_block.py
@@ -52,7 +52,7 @@ def build_shard_block(spec,
     return signed_block
 
 
-def build_shard_transitions_till_slot(spec, parent_beacon_state, shard_blocks):
+def get_shard_transitions(spec, parent_beacon_state, shard_blocks):
     shard_transitions = [spec.ShardTransition()] * spec.MAX_SHARDS
     on_time_slot = parent_beacon_state.slot + 1
     for shard, blocks in shard_blocks.items():

--- a/tests/core/pyspec/eth2spec/test/helpers/shard_transitions.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/shard_transitions.py
@@ -28,13 +28,10 @@ def run_shard_transitions_processing(spec, state, shard_transitions, attestation
     yield 'post', state
 
 
-def get_shard_transition_of_committee(spec, state, committee_index, slot=None, shard_blocks=None):
+def get_shard_transition_of_committee(spec, state, committee_index, shard_blocks=None):
     if shard_blocks is None:
         shard_blocks = []
 
-    if slot is None:
-        slot = state.slot
-
     shard = spec.compute_shard_from_committee_index(state, committee_index, state.slot)
-    shard_transition = spec.get_shard_transition(state, shard, shard_blocks=shard_blocks, on_time_slot=slot + 1)
+    shard_transition = spec.get_shard_transition(state, shard, shard_blocks=shard_blocks)
     return shard_transition

--- a/tests/core/pyspec/eth2spec/test/helpers/shard_transitions.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/shard_transitions.py
@@ -1,5 +1,4 @@
 from eth2spec.test.context import expect_assertion_error
-from eth2spec.test.helpers.state import transition_to
 
 
 def run_shard_transitions_processing(spec, state, shard_transitions, attestations, valid=True):
@@ -37,7 +36,5 @@ def get_shard_transition_of_committee(spec, state, committee_index, slot=None, s
         slot = state.slot
 
     shard = spec.compute_shard_from_committee_index(state, committee_index, state.slot)
-    temp_state = state.copy()
-    transition_to(spec, temp_state, slot + 1)
-    shard_transition = spec.get_shard_transition(temp_state, shard, shard_blocks=shard_blocks)
+    shard_transition = spec.get_shard_transition(state, shard, shard_blocks=shard_blocks, on_time_slot=slot + 1)
     return shard_transition

--- a/tests/core/pyspec/eth2spec/test/phase_1/block_processing/test_process_shard_transition.py
+++ b/tests/core/pyspec/eth2spec/test/phase_1/block_processing/test_process_shard_transition.py
@@ -2,71 +2,64 @@ from eth2spec.test.context import (
     PHASE0,
     with_all_phases_except,
     spec_state_test,
-    always_bls,
 )
+from eth2spec.test.helpers.attestations import get_valid_on_time_attestation
 from eth2spec.test.helpers.shard_transitions import run_shard_transitions_processing
 from eth2spec.test.helpers.shard_block import (
-    build_attestation_with_shard_transition,
     build_shard_block,
     build_shard_transitions_till_slot,
 )
-from eth2spec.test.helpers.state import transition_to, transition_to_valid_shard_slot
+from eth2spec.test.helpers.state import transition_to, transition_to_valid_shard_slot, next_slot
 
 
 def run_basic_crosslink_tests(spec, state, target_len_offset_slot, valid=True):
     state = transition_to_valid_shard_slot(spec, state)
-    init_slot = state.slot
     committee_index = spec.CommitteeIndex(0)
     shard = spec.compute_shard_from_committee_index(state, committee_index, state.slot + target_len_offset_slot - 1)
     assert state.shard_states[shard].slot == state.slot - 1
+    transition_to(spec, state, state.slot + target_len_offset_slot)
+    assert state.shard_states[shard].slot == state.slot - target_len_offset_slot - 1
 
     # Create SignedShardBlock
     body = b'\x56' * spec.MAX_SHARD_BLOCK_SIZE
-    shard_block = build_shard_block(spec, state, shard, body=body, signed=True)
+    shard_block = build_shard_block(spec, state, shard, body=body, slot=state.slot, signed=True)
     shard_blocks = [shard_block]
-    # Create a shard_transitions that would be included at beacon block `state.slot + target_len_offset_slot`
     shard_transitions = build_shard_transitions_till_slot(
         spec,
         state,
         shard_blocks={shard: shard_blocks},
-        on_time_slot=state.slot + target_len_offset_slot,
     )
     shard_transition = shard_transitions[shard]
-    # Create an attestation that would be included at beacon block `state.slot + target_len_offset_slot`
-    attestation = build_attestation_with_shard_transition(
+    attestation = get_valid_on_time_attestation(
         spec,
         state,
         index=committee_index,
-        on_time_slot=state.slot + target_len_offset_slot,
         shard_transition=shard_transition,
+        signed=False,
     )
+    next_slot(spec, state)
     pre_gasprice = state.shard_states[shard].gasprice
-
-    transition_to(spec, state, state.slot + target_len_offset_slot)
     pre_shard_state = state.shard_states[shard]
-
     yield from run_shard_transitions_processing(spec, state, shard_transitions, [attestation], valid=valid)
 
     if valid:
-        # After state transition,
-        assert state.slot == init_slot + target_len_offset_slot
         shard_state = state.shard_states[shard]
         assert shard_state != pre_shard_state
         assert shard_state == shard_transition.shard_states[len(shard_transition.shard_states) - 1]
-
+        assert shard_state.latest_block_root == shard_block.message.hash_tree_root()
         if target_len_offset_slot == 1:
             assert shard_state.gasprice > pre_gasprice
 
 
 @with_all_phases_except([PHASE0])
 @spec_state_test
-@always_bls
 def test_basic_crosslinks(spec, state):
+    # NOTE: this test is only for full crosslink (minimal config), not for mainnet
     yield from run_basic_crosslink_tests(spec, state, target_len_offset_slot=1, valid=True)
 
 
 @with_all_phases_except([PHASE0])
 @spec_state_test
-@always_bls
 def test_multiple_offset_slots(spec, state):
-    yield from run_basic_crosslink_tests(spec, state, target_len_offset_slot=3, valid=True)
+    # NOTE: this test is only for full crosslink (minimal config), not for mainnet
+    yield from run_basic_crosslink_tests(spec, state, target_len_offset_slot=2, valid=True)

--- a/tests/core/pyspec/eth2spec/test/phase_1/block_processing/test_process_shard_transition.py
+++ b/tests/core/pyspec/eth2spec/test/phase_1/block_processing/test_process_shard_transition.py
@@ -7,7 +7,7 @@ from eth2spec.test.helpers.attestations import get_valid_on_time_attestation
 from eth2spec.test.helpers.shard_transitions import run_shard_transitions_processing
 from eth2spec.test.helpers.shard_block import (
     build_shard_block,
-    build_shard_transitions_till_slot,
+    get_shard_transitions,
 )
 from eth2spec.test.helpers.state import transition_to, transition_to_valid_shard_slot, next_slot
 
@@ -24,7 +24,7 @@ def run_basic_crosslink_tests(spec, state, target_len_offset_slot, valid=True):
     body = b'\x56' * spec.MAX_SHARD_BLOCK_SIZE
     shard_block = build_shard_block(spec, state, shard, body=body, slot=state.slot, signed=True)
     shard_blocks = [shard_block]
-    shard_transitions = build_shard_transitions_till_slot(
+    shard_transitions = get_shard_transitions(
         spec,
         state,
         shard_blocks={shard: shard_blocks},

--- a/tests/core/pyspec/eth2spec/test/phase_1/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/phase_1/sanity/test_blocks.py
@@ -4,37 +4,40 @@ from eth2spec.test.context import (
     PHASE0,
     with_all_phases_except,
     spec_state_test,
-    always_bls,
 )
+from eth2spec.test.helpers.attestations import get_valid_on_time_attestation
 from eth2spec.test.helpers.block import build_empty_block
 from eth2spec.test.helpers.shard_block import (
-    build_attestation_with_shard_transition,
     build_shard_block,
     build_shard_transitions_till_slot,
 )
-from eth2spec.test.helpers.state import state_transition_and_sign_block, transition_to_valid_shard_slot
+from eth2spec.test.helpers.state import state_transition_and_sign_block, transition_to_valid_shard_slot, transition_to
 
 
-def run_beacon_block_with_shard_blocks(spec, state, shard_blocks, target_len_offset_slot, committee_index, valid=True):
-    shard_transitions = build_shard_transitions_till_slot(
-        spec, state, shard_blocks, on_time_slot=state.slot + target_len_offset_slot
-    )
+def run_beacon_block_with_shard_blocks(spec, state, target_len_offset_slot, committee_index, shard, valid=True):
+    transition_to(spec, state, state.slot + target_len_offset_slot)
+
+    body = b'\x56' * spec.MAX_SHARD_BLOCK_SIZE
+    shard_block = build_shard_block(spec, state, shard, body=body, slot=state.slot, signed=True)
+    shard_blocks: Dict[spec.Shard, Sequence[spec.SignedShardBlock]] = {shard: [shard_block]}
+
+    shard_transitions = build_shard_transitions_till_slot(spec, state, shard_blocks)
     attestations = [
-        build_attestation_with_shard_transition(
+        get_valid_on_time_attestation(
             spec,
             state,
-            on_time_slot=state.slot + target_len_offset_slot,
             index=committee_index,
             shard_transition=shard_transitions[shard],
+            signed=True,
         )
         for shard in shard_blocks.keys()
     ]
 
-    # Propose beacon block at slot `x + 1`
-    beacon_block = build_empty_block(spec, state, slot=state.slot + target_len_offset_slot)
+    beacon_block = build_empty_block(spec, state, slot=state.slot + 1)
     beacon_block.body.attestations = attestations
     beacon_block.body.shard_transitions = shard_transitions
 
+    pre_gasprice = state.shard_states[shard].gasprice
     pre_shard_states = state.shard_states.copy()
     yield 'pre', state.copy()
     yield 'block', beacon_block
@@ -52,17 +55,18 @@ def run_beacon_block_with_shard_blocks(spec, state, shard_blocks, target_len_off
             assert post_shard_state == shard_transitions[shard].shard_states[
                 len(shard_transitions[shard].shard_states) - 1
             ]
-            assert beacon_block.slot == shard_transitions[shard].shard_states[0].slot + target_len_offset_slot
             assert post_shard_state.slot == state.slot - 1
             if len(shard_blocks[shard]) == 0:
                 # `latest_block_root` is the same
                 assert post_shard_state.latest_block_root == pre_shard_states[shard].latest_block_root
+            if target_len_offset_slot == 1 and len(shard_blocks) > 0:
+                assert post_shard_state.gasprice > pre_gasprice
 
 
 @with_all_phases_except([PHASE0])
 @spec_state_test
-@always_bls
 def test_process_beacon_block_with_normal_shard_transition(spec, state):
+    # NOTE: this test is only for full crosslink (minimal config), not for mainnet
     state = transition_to_valid_shard_slot(spec, state)
 
     target_len_offset_slot = 1
@@ -70,25 +74,13 @@ def test_process_beacon_block_with_normal_shard_transition(spec, state):
     shard = spec.compute_shard_from_committee_index(state, committee_index, state.slot + target_len_offset_slot - 1)
     assert state.shard_states[shard].slot == state.slot - 1
 
-    pre_gasprice = state.shard_states[shard].gasprice
-
-    # Create SignedShardBlock at slot `shard_state.slot + 1`
-    body = b'\x56' * spec.MAX_SHARD_BLOCK_SIZE
-    shard_block = build_shard_block(spec, state, shard, body=body, signed=True)
-    shard_blocks: Dict[spec.Shard, Sequence[spec.SignedShardBlock]] = {shard: [shard_block]}
-
-    yield from run_beacon_block_with_shard_blocks(spec, state, shard_blocks, target_len_offset_slot, committee_index)
-
-    shard_state = state.shard_states[shard]
-
-    if target_len_offset_slot == 1 and len(shard_blocks) > 0:
-        assert shard_state.gasprice > pre_gasprice
+    yield from run_beacon_block_with_shard_blocks(spec, state, target_len_offset_slot, committee_index, shard)
 
 
 @with_all_phases_except([PHASE0])
 @spec_state_test
-@always_bls
 def test_process_beacon_block_with_empty_proposal_transition(spec, state):
+    # NOTE: this test is only for full crosslink (minimal config), not for mainnet
     state = transition_to_valid_shard_slot(spec, state)
 
     target_len_offset_slot = 1
@@ -96,12 +88,4 @@ def test_process_beacon_block_with_empty_proposal_transition(spec, state):
     shard = spec.compute_shard_from_committee_index(state, committee_index, state.slot + target_len_offset_slot - 1)
     assert state.shard_states[shard].slot == state.slot - 1
 
-    # No new shard block
-    shard_blocks = {}
-
-    pre_gasprice = state.shard_states[shard].gasprice
-
-    yield from run_beacon_block_with_shard_blocks(spec, state, shard_blocks, target_len_offset_slot, committee_index)
-
-    if target_len_offset_slot == 1 and len(shard_blocks) > 0:
-        assert state.shard_states[shard].gasprice > pre_gasprice
+    yield from run_beacon_block_with_shard_blocks(spec, state, target_len_offset_slot, committee_index, shard)

--- a/tests/core/pyspec/eth2spec/test/phase_1/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/phase_1/sanity/test_blocks.py
@@ -9,7 +9,7 @@ from eth2spec.test.helpers.attestations import get_valid_on_time_attestation
 from eth2spec.test.helpers.block import build_empty_block
 from eth2spec.test.helpers.shard_block import (
     build_shard_block,
-    build_shard_transitions_till_slot,
+    get_shard_transitions,
 )
 from eth2spec.test.helpers.state import state_transition_and_sign_block, transition_to_valid_shard_slot, transition_to
 
@@ -21,7 +21,7 @@ def run_beacon_block_with_shard_blocks(spec, state, target_len_offset_slot, comm
     shard_block = build_shard_block(spec, state, shard, body=body, slot=state.slot, signed=True)
     shard_blocks: Dict[spec.Shard, Sequence[spec.SignedShardBlock]] = {shard: [shard_block]}
 
-    shard_transitions = build_shard_transitions_till_slot(spec, state, shard_blocks)
+    shard_transitions = get_shard_transitions(spec, state, shard_blocks)
     attestations = [
         get_valid_on_time_attestation(
             spec,


### PR DESCRIPTION
Pending on #1773

### Issue
Pointed by @terencechain, we should verify `shard_block.beacon_parent_root`. Therefore, we'd make sure that we can query the correct `beacon_parent_root` in `verify_shard_block_message`.
^^^^ **updated**

### How did I fix it
1. [shard-transition]
    - Pass `on_time_slot` to `get_shard_transition`. This is the slot of the next slot of attestation. It is for computing `offset_slots` correctly
    - Update `verify_shard_block_message`: check `beacon_parent_root`
    - Since when `offset_slots` > 1, we don't have previous beacon state to run `verify_shard_block_message`.  I disabled verification in `get_proposal_choices_at_slot`. It's okay because it will be removed in #1704 anyway.
2. [shard fork choice] Update `on_shard_block`: Should have pass `previous_beacon_state` to `verify_shard_block_message`
3. Clean up the tests: less annoying `temp_state` for computing `offset_slots`. 🎉 
