### PR TITLE
Remove `ShardState.transition_digest`

### DIFF
--- a/specs/phase1/beacon-chain.md
+++ b/specs/phase1/beacon-chain.md
@@ -349,7 +349,6 @@ class ShardBlockHeader(Container):
 class ShardState(Container):
     slot: Slot
     gasprice: Gwei
-    transition_digest: Bytes32
     latest_block_root: Root
 ```
 

--- a/specs/phase1/phase1-fork.md
+++ b/specs/phase1/phase1-fork.md
@@ -104,7 +104,6 @@ def upgrade_to_phase1(pre: phase0.BeaconState) -> BeaconState:
             ShardState(
                 slot=pre.slot,
                 gasprice=MIN_GASPRICE,
-                transition_digest=Root(),
                 latest_block_root=Root(),
             ) for i in range(INITIAL_ACTIVE_SHARDS)
         ),

--- a/specs/phase1/shard-fork-choice.md
+++ b/specs/phase1/shard-fork-choice.md
@@ -172,7 +172,7 @@ def on_shard_block(store: Store, shard_store: ShardStore, signed_shard_block: Si
     assert verify_shard_block_message(beacon_parent_state, shard_parent_state, shard_block)
     assert verify_shard_block_signature(beacon_parent_state, signed_shard_block)
 
-    post_state = get_post_shard_state(beacon_parent_state, shard_parent_state, shard_block)
+    post_state = get_post_shard_state(shard_parent_state, shard_block)
 
     # Add new block to the store
     shard_store.blocks[hash_tree_root(shard_block)] = shard_block

--- a/specs/phase1/validator.md
+++ b/specs/phase1/validator.md
@@ -289,7 +289,7 @@ def get_shard_transition_fields(
         else:
             shard_block = SignedShardBlock(message=ShardBlock(slot=slot, shard=shard))
             shard_data_roots.append(Root())
-        shard_state = get_post_shard_state(beacon_state, shard_state, shard_block.message)
+        shard_state = get_post_shard_state(shard_state, shard_block.message)
         shard_states.append(shard_state)
         shard_block_lengths.append(len(shard_block.message.body))
 

--- a/tests/core/pyspec/eth2spec/test/helpers/attestations.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/attestations.py
@@ -90,7 +90,7 @@ def build_attestation_data(spec, state, slot, index, shard_transition=None, on_t
                 attestation_data.shard_head_root = shard_transition.shard_data_roots[lastest_shard_data_root_index]
                 attestation_data.shard_transition_root = shard_transition.hash_tree_root()
             else:
-                attestation_data.shard_head_root = state.shard_states[shard].transition_digest
+                attestation_data.shard_head_root = state.shard_states[shard].latest_block_root
                 attestation_data.shard_transition_root = spec.Root()
     return attestation_data
 

--- a/tests/core/pyspec/eth2spec/test/helpers/shard_block.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/shard_block.py
@@ -62,8 +62,6 @@ def get_shard_transitions(spec, parent_beacon_state, shard_blocks):
             on_time_slot,
         )
         len_offset_slots = len(offset_slots)
-        # TODO this is actually unsafe for long offset_slots
-        assert len_offset_slots == on_time_slot - parent_beacon_state.shard_states[shard].slot - 1
         shard_transition = spec.get_shard_transition(parent_beacon_state, shard, blocks)
 
         if len(blocks) > 0:


### PR DESCRIPTION
### Issue
This field can be used to:
1. Indicate if the given shard state is at a skipped slot.
2. As a digest of shard state.

For (1), `ShardState.latest_block_root` can also provide it.
For (2), `hash_tree_root(shard_state)` could cover it.

This value looks like a stub at the early draft. Is there any other reason we need it?

### How did I fix it
Remove this field.