### PR TITLE
Update phase1 beacon-chain config table

### DIFF
--- a/specs/phase1/beacon-chain.md
+++ b/specs/phase1/beacon-chain.md
@@ -102,23 +102,47 @@ Configuration is not namespaced. Instead it is strictly an extension;
 
 ### Misc
 
-| Name | Value | Unit | Duration |
-| - | - | - | - | 
+| Name | Value |
+| - | - | 
 | `MAX_SHARDS` | `2**10` (= 1024) |
-| `ONLINE_PERIOD` | `OnlineEpochs(2**3)` (= 8) | online epochs | ~51 min |
 | `LIGHT_CLIENT_COMMITTEE_SIZE` | `2**7` (= 128) |
+| `GASPRICE_ADJUSTMENT_COEFFICIENT` | `2**3` (= 8) | 
+
+### Shard block configs
+| Name | Value |
+| - | - |
+| `MAX_SHARD_BLOCK_SIZE` | `2**20` (= 1,048,576) | 
+| `TARGET_SHARD_BLOCK_SIZE` | `2**18` (= 262,144) | 
+| `SHARD_BLOCK_OFFSETS` | `[1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233]` | 
+| `MAX_SHARD_BLOCKS_PER_ATTESTATION` | `len(SHARD_BLOCK_OFFSETS)` | 
+
+### Gwei values
+
+| Name | Value |
+| - | - |
+| `MAX_GASPRICE` | `Gwei(2**14)` (= 16,384) | Gwei | 
+| `MIN_GASPRICE` | `Gwei(2**3)` (= 8) | Gwei | 
+
+### Initial values
+
+| Name | Value |
+| - | - |
+| `NO_SIGNATURE` | `BLSSignature(b'\x00' * 96)` | 
+
+### Time parameters
+
+| Name | Value | Unit | Duration |
+| - | - | :-: | :-: |
+| `ONLINE_PERIOD` | `OnlineEpochs(2**3)` (= 8) | online epochs | ~51 mins |
 | `LIGHT_CLIENT_COMMITTEE_PERIOD` | `Epoch(2**8)` (= 256) | epochs | ~27 hours |
-| `MAX_SHARD_BLOCK_SIZE` | `2**20` (= 1,048,576) | |
-| `TARGET_SHARD_BLOCK_SIZE` | `2**18` (= 262,144) | |
-| `SHARD_BLOCK_OFFSETS` | `[1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233]` | |
-| `MAX_SHARD_BLOCKS_PER_ATTESTATION` | `len(SHARD_BLOCK_OFFSETS)` | |
-| `MAX_GASPRICE` | `Gwei(2**14)` (= 16,384) | Gwei | |
-| `MIN_GASPRICE` | `Gwei(2**3)` (= 8) | Gwei | |
-| `GASPRICE_ADJUSTMENT_COEFFICIENT` | `2**3` (= 8) | |
-| `DOMAIN_SHARD_PROPOSAL` | `DomainType('0x80000000')` | |
-| `DOMAIN_SHARD_COMMITTEE` | `DomainType('0x81000000')` | |
-| `DOMAIN_LIGHT_CLIENT` | `DomainType('0x82000000')` | |
-| `NO_SIGNATURE` | `BLSSignature(b'\x00' * 96)` | |
+
+### Domain types
+
+| Name | Value |
+| - | - |
+| `DOMAIN_SHARD_PROPOSAL` | `DomainType('0x80000000')` | 
+| `DOMAIN_SHARD_COMMITTEE` | `DomainType('0x81000000')` | 
+| `DOMAIN_LIGHT_CLIENT` | `DomainType('0x82000000')` | 
 
 ## Updated containers
 


### PR DESCRIPTION
This PR updates the phase 1 beacon chain config table to read more like the [phase 0 table](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase0/beacon-chain.md#misc)