### PR TITLE
Use parent_root for finalized chain check

### DIFF
--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -44,9 +44,11 @@ This document is the beacon chain fork choice spec, part of Ethereum 2.0 Phase 0
 
 The head block root associated with a `store` is defined as `get_head(store)`. At genesis, let `store = get_forkchoice_store(genesis_state)` and update `store` by running:
 
-- `on_tick(time)` whenever `time > store.time` where `time` is the current Unix time
-- `on_block(block)` whenever a block `block: SignedBeaconBlock` is received
-- `on_attestation(attestation)` whenever an attestation `attestation` is received
+- `on_tick(store, time)` whenever `time > store.time` where `time` is the current Unix time
+- `on_block(store, block)` whenever a block `block: SignedBeaconBlock` is received
+- `on_attestation(store, attestation)` whenever an attestation `attestation` is received
+
+Any of the above handlers that trigger an unhandled exception (e.g. a failed assert or an out-of-range list access) are considered invalid. Invalid calls to handlers must not modify `store`.
 
 *Notes*:
 

--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -347,17 +347,17 @@ def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
     pre_state = store.block_states[block.parent_root].copy()
     # Blocks cannot be in the future. If they are, their consideration must be delayed until the are in the past.
     assert get_current_slot(store) >= block.slot
-    # Add new block to the store
-    store.blocks[hash_tree_root(block)] = block
 
     # Check that block is later than the finalized epoch slot (optimization to reduce calls to get_ancestor)
     finalized_slot = compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)
     assert block.slot > finalized_slot
     # Check block is a descendant of the finalized block at the checkpoint finalized slot
-    assert get_ancestor(store, hash_tree_root(block), finalized_slot) == store.finalized_checkpoint.root
+    assert get_ancestor(store, block.parent_root, finalized_slot) == store.finalized_checkpoint.root
 
     # Check the block is valid and compute the post-state
     state = state_transition(pre_state, signed_block, True)
+    # Add new block to the store
+    store.blocks[hash_tree_root(block)] = block
     # Add new state for this block to the store
     store.block_states[hash_tree_root(block)] = state
 


### PR DESCRIPTION
## Summary

Use `block.parent_root` instead of `hash_tree_root(block)` to determine if the block descends from the finalized root.

This has two outcomes:

1. Removes a single iteration from the check (probably trivial).
1. Allows for storing the `block` in `store.blocks` *only if it is valid*.

## Reasoning

I will make an argument that the following two checks are equal:

### Check 1 (existing)

```python
assert get_ancestor(store, hash_tree_root(block), finalized_slot) == store.finalized_checkpoint.root
```

### Check 2 (proposed)

```python
assert get_ancestor(store, block.parent_root, finalized_slot) == store.finalized_checkpoint.root
```

### Argument

In `get_ancestor`, there are effectively two paths:

1. `if block.slot > slot`, recurse using `block.parent_root`.
2. Return `root`.

Considering we've established that prior to both checks we have `assert block.slot > finalized_slot`, the only possible path in `get_ancestor` is (1). This recursion in path 1 is equivalent to check 2.

## Why am I raising this?

### Optimization

Firstly, this removes a redundant block lookup. However, it's not significant and shouldn't be a driving factor, IMO.

### Ergonomics

My motivation is that it allows for calling `store.blocks[hash_tree_root(block)] = block` *only once the block is valid*. This is important for implementations (like Lighthouse) because it means we don't need to roll back on an invalid block.

I'd like to implement this for Lighthouse and similar to #1880 it would nice to get feedback from spec authors and link to this PR in our code.

### Spec bug

Seeing as the spec doesn't implement a rollback, I also believe that this PR fixes a bug that we can call: *"Fork choice store is corrupted if an invalid block is suppplied to `on_block`"*.

Consider we have some `signed_block` with an invalid signature and it is the first block to be added to `Store` after genesis. In `on_block` that block will be added to `store.blocks`. Then, the invalid signature will cause `on_block` to terminate prior to adding the respective state to `store.block_states`.

Consider that there are now two objects in `store.blocks`:
 - The genesis block (`genesis_block`)
 - The invalid block (`invalid_block`)

But only one object in `store.block_states`:

- The genesis block state

Now consider the call stack the next time `get_head` is called:

1. `get_head(store)`
1. `get_filtered_block_store(store)`
1. `filter_block_tree(store, tree_hash_root(genesis_block_root), {})`
1. `filter_block_tree(store, tree_hash_root(invalid_block), {})`

During (4) we will run:

```python
head_state = store.block_states[tree_hash_root(invalid_block)]
```

This will raise an exception.
