### PR TITLE
revert e128 and c901 in lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ codespell:
 
 lint: pyspec
 	. venv/bin/activate; cd $(PY_SPEC_DIR); \
-	flake8  --ignore=E252,W504,W503,E128,C901 --max-line-length=120 ./eth2spec \
+	flake8  --ignore=E252,W504,W503 --max-line-length=120 ./eth2spec \
 	&& cd ./eth2spec && mypy --follow-imports=silent --warn-unused-ignores --ignore-missing-imports --check-untyped-defs --disallow-incomplete-defs --disallow-untyped-defs -p phase0 \
 	&& mypy --follow-imports=silent --warn-unused-ignores --ignore-missing-imports --check-untyped-defs --disallow-incomplete-defs --disallow-untyped-defs -p phase1;
 


### PR DESCRIPTION
Revert removal of E128 and C901. The offending lines had already been resolved so I'd rather keep the restrictions in unless we run into a specific issue we cant' elegantly resolve