### PR TITLE
revert local config settings from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,13 +28,3 @@ tests/core/pyspec/test-reports
 tests/core/pyspec/eth2spec/test_results.xml
 
 *.egg-info
-
-# flake8 config
-tox.ini
-
-# VS code files
-.vscode
-*.code-workspace
-
-# npm (for doctoc)
-package-lock.json


### PR DESCRIPTION
Some local setup files (rather than specific to general operation of the repo) were added in #1705.

I would argue that these should go into the local system's [global gitignore](https://stackoverflow.com/questions/7335420/global-git-ignore/22885996) rather than the repo here