### PR TITLE
Fix deprecated utility code, avoid wrong helper function name, add tests

### DIFF
--- a/tests/core/pyspec/eth2spec/utils/test_merkle_proof_util.py
+++ b/tests/core/pyspec/eth2spec/utils/test_merkle_proof_util.py
@@ -1,0 +1,47 @@
+import pytest
+
+
+# Note: these functions are extract from merkle-proofs.md (deprecated),
+# the tests are temporary to show correctness while the document is still there.
+
+def get_power_of_two_ceil(x: int) -> int:
+    if x <= 1:
+        return 1
+    elif x == 2:
+        return 2
+    else:
+        return 2 * get_power_of_two_ceil((x + 1) // 2)
+
+
+def get_power_of_two_floor(x: int) -> int:
+    if x <= 1:
+        return 1
+    if x == 2:
+        return x
+    else:
+        return 2 * get_power_of_two_floor(x // 2)
+
+
+power_of_two_ceil_cases = [
+    (0, 1), (1, 1), (2, 2), (3, 4), (4, 4), (5, 8), (6, 8), (7, 8), (8, 8), (9, 16),
+]
+
+power_of_two_floor_cases = [
+    (0, 1), (1, 1), (2, 2), (3, 2), (4, 4), (5, 4), (6, 4), (7, 4), (8, 8), (9, 8),
+]
+
+
+@pytest.mark.parametrize(
+    'value,expected',
+    power_of_two_ceil_cases,
+)
+def test_get_power_of_two_ceil(value, expected):
+    assert get_power_of_two_ceil(value) == expected
+
+
+@pytest.mark.parametrize(
+    'value,expected',
+    power_of_two_floor_cases,
+)
+def test_get_power_of_two_floor(value, expected):
+    assert get_power_of_two_floor(value) == expected


### PR DESCRIPTION
The next/previous-power-of-two naming was wrong, the 0 case was wrong, and the functions were prone to off-by-one errors, lacking comments and tests.
@franck44 raised [an issue describing the bug in detail and proposed a fix](https://github.com/ethereum/eth2.0-specs/issues/1695), thank you! This was long ago, but it was never included because no part of the spec used the code.

Now that SSZ is getting some attention again, I decided to implement their fix, with name changes and comments in the merkle functions, to show what it was supposed to be (Or at least what I think it does, I think the original was quick experimental code of Vitalik).

Note that since the code has not been used for so long, it can be regarded as deprecated in this repository. And I have the intention to include these more experimental/extra merkleization things in a "draft" stage document in the new SSZ spec. See #1901 

Marking this as do-not-merge, and prioritizing the removal of the unused code. Let's leave this issue open while we make a plan in #1901 
