### PR TITLE
Fix typing error in `process_custody_game_operations`

### DIFF
--- a/specs/phase1/beacon-chain.md
+++ b/specs/phase1/beacon-chain.md
@@ -252,8 +252,8 @@ class BeaconBlockBody(Container):
     deposits: List[Deposit, MAX_DEPOSITS]
     voluntary_exits: List[SignedVoluntaryExit, MAX_VOLUNTARY_EXITS]
     # Custody game
-    chunk_challenges: List[CustodyChunkResponse, MAX_CUSTODY_CHUNK_CHALLENGES]
-    chunk_challenge_responses: List[CustodyChunkResponse, MAX_CUSTODY_CHUNK_CHALLENGE_RESPONSES]
+    chunk_challenges: List[CustodyChunkChallenge, MAX_CUSTODY_CHUNK_CHALLENGES]
+    chunk_challenge_responses: List[CustodyChunkChallenge, MAX_CUSTODY_CHUNK_CHALLENGE_RESPONSES]
     custody_key_reveals: List[CustodyKeyReveal, MAX_CUSTODY_KEY_REVEALS]
     early_derived_secret_reveals: List[EarlyDerivedSecretReveal, MAX_EARLY_DERIVED_SECRET_REVEALS]
     custody_slashings: List[SignedCustodySlashing, MAX_CUSTODY_SLASHINGS]

--- a/specs/phase1/beacon-chain.md
+++ b/specs/phase1/beacon-chain.md
@@ -253,7 +253,7 @@ class BeaconBlockBody(Container):
     voluntary_exits: List[SignedVoluntaryExit, MAX_VOLUNTARY_EXITS]
     # Custody game
     chunk_challenges: List[CustodyChunkChallenge, MAX_CUSTODY_CHUNK_CHALLENGES]
-    chunk_challenge_responses: List[CustodyChunkChallenge, MAX_CUSTODY_CHUNK_CHALLENGE_RESPONSES]
+    chunk_challenge_responses: List[CustodyChunkResponse, MAX_CUSTODY_CHUNK_CHALLENGE_RESPONSES]
     custody_key_reveals: List[CustodyKeyReveal, MAX_CUSTODY_KEY_REVEALS]
     early_derived_secret_reveals: List[EarlyDerivedSecretReveal, MAX_EARLY_DERIVED_SECRET_REVEALS]
     custody_slashings: List[SignedCustodySlashing, MAX_CUSTODY_SLASHINGS]

--- a/specs/phase1/custody-game.md
+++ b/specs/phase1/custody-game.md
@@ -302,7 +302,7 @@ def process_custody_game_operations(state: BeaconState, body: BeaconBlockBody) -
             fn(state, operation)
 
     for_ops(body.chunk_challenges, process_chunk_challenge)
-    for_ops(body.chunk_challenge_responses, process_chunk_challenge)
+    for_ops(body.chunk_challenge_responses, process_chunk_challenge_response)
     for_ops(body.custody_key_reveals, process_custody_key_reveal)
     for_ops(body.early_derived_secret_reveals, process_early_derived_secret_reveal)
     for_ops(body.custody_slashings, process_custody_slashing)


### PR DESCRIPTION
Change types of `BeaconBlockBody.chunk_challenges` and `BeaconBlockBody.chunk_challenge_responses` to be `List[CustodyChunkChallenge, ...]`.
It's a suggested fix for #1908 