### PR TITLE
Fix exception in `get_best_light_client_aggregate`

### DIFF
--- a/specs/phase1/validator.md
+++ b/specs/phase1/validator.md
@@ -195,7 +195,7 @@ def get_best_light_client_aggregate(block: BeaconBlock,
                                     aggregates: Sequence[LightClientVote]) -> LightClientVote:
     viable_aggregates = [
         aggregate for aggregate in aggregates
-        if aggregate.slot == compute_previous_slot(block.slot) and aggregate.beacon_block_root == block.parent_root
+        if aggregate.data.slot == compute_previous_slot(block.slot) and aggregate.data.beacon_block_root == block.parent_root
     ]
 
     return max(

--- a/specs/phase1/validator.md
+++ b/specs/phase1/validator.md
@@ -195,7 +195,10 @@ def get_best_light_client_aggregate(block: BeaconBlock,
                                     aggregates: Sequence[LightClientVote]) -> LightClientVote:
     viable_aggregates = [
         aggregate for aggregate in aggregates
-        if aggregate.data.slot == compute_previous_slot(block.slot) and aggregate.data.beacon_block_root == block.parent_root
+        if (
+            aggregate.data.slot == compute_previous_slot(block.slot)
+            and aggregate.data.beacon_block_root == block.parent_root
+        )
     ]
 
     return max(


### PR DESCRIPTION
[get_best_light_client_aggregate](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase1/validator.md#light-client-fields) tries to get `slot` and `beacon_block_root` of `LightClientVote`, however, they are defined in `LightClientVoteData`.

Here is an illustration of the problem
```python
>>> from eth2spec.phase1 import spec
>>> spec.get_best_light_client_aggregate(spec.BeaconBlock(), [spec.LightClientVote()])
Traceback (most recent call last):
  File "/mnt/c/Users/ericsson/IdeaProjects/eth2.0-specs/venv/lib/python3.8/site-packages/remerkleable/complex.py", line 781, in __getattr__
    i = self.__class__._field_indices[item]
KeyError: 'slot'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/mnt/c/Users/ericsson/IdeaProjects/eth2.0-specs/venv/lib/python3.8/site-packages/eth2spec/phase1/spec.py", line 3194, in get_best_light_client_aggregate
    viable_aggregates = [
  File "/mnt/c/Users/ericsson/IdeaProjects/eth2.0-specs/venv/lib/python3.8/site-packages/eth2spec/phase1/spec.py", line 3196, in <listcomp>
    if aggregate.slot == compute_previous_slot(block.slot) and aggregate.beacon_block_root == block.parent_root
  File "/mnt/c/Users/ericsson/IdeaProjects/eth2.0-specs/venv/lib/python3.8/site-packages/remerkleable/complex.py", line 783, in __getattr__
    raise AttributeError(f"unknown attribute {item}")
AttributeError: unknown attribute slot
```