### PR TITLE
Clarification of SSZ bitlist and bitvector types.

### DIFF
--- a/ssz/simple-serialize.md
+++ b/ssz/simple-serialize.md
@@ -66,6 +66,8 @@
 * **union**: union type containing one of the given subtypes
     * notation `Union[type_0, type_1, ...]`, e.g. `union[null, uint64]`
 
+*Note*: Both `Vector[boolean, N]` and `Bitvector[N]` are valid, yet distinct due to their different serialization requirements. Similarly, both `List[boolean, N]` and `Bitlist[N]` are valid, yet distinct. Generally `Bitvector[N]`/`Bitlist[N]` are preferred because of their serialization efficiencies.
+
 ### Variable-size and fixed-size
 
 We recursively define "variable-size" types to be lists, unions, `Bitlist` and all types that contain a variable-size type. All other types are said to be "fixed-size".
@@ -88,9 +90,9 @@ Assuming a helper function `default(type)` which returns the default value for `
 | `boolean` | `False` |
 | `Container` | `[default(type) for type in container]` |
 | `Vector[type, N]` | `[default(type)] * N` |
-| `Bitvector[boolean, N]` | `[False] * N` |
+| `Bitvector[N]` | `[False] * N` |
 | `List[type, N]` | `[]` |
-| `Bitlist[boolean, N]` | `[]` |
+| `Bitlist[N]` | `[]` |
 | `Union[type_0, type_1, ...]` | `default(type_0)` |
 
 #### `is_zero`


### PR DESCRIPTION
## What was wrong?

More a clarification, this PR has been created on the basis of #1892 and discussions with @protolambda (thank you).

## How was it fixed?

I have added a note to the end of the Composite types section. I wasn't sure if the comment regarding the preference for bitvectors/bitlists is necessary (?) but it can always be edited :)

I also modified the table of default values so as to keep the notation consistent with that used earlier.

## Cute animal picture
![1920px-Short-beaked_echidna_in_ANBG](https://user-images.githubusercontent.com/43776922/84985537-47fe4d80-b180-11ea-8430-a56ee9ed542c.jpg)

