### PR TITLE
Fix shard_block_length type in `compute_updated_gasprice`

### DIFF
--- a/specs/phase1/beacon-chain.md
+++ b/specs/phase1/beacon-chain.md
@@ -493,7 +493,7 @@ def compute_offset_slots(start_slot: Slot, end_slot: Slot) -> Sequence[Slot]:
 #### `compute_updated_gasprice`
 
 ```python
-def compute_updated_gasprice(prev_gasprice: Gwei, shard_block_length: uint8) -> Gwei:
+def compute_updated_gasprice(prev_gasprice: Gwei, shard_block_length: uint64) -> Gwei:
     if shard_block_length > TARGET_SHARD_BLOCK_SIZE:
         delta = (prev_gasprice * (shard_block_length - TARGET_SHARD_BLOCK_SIZE)
                  // TARGET_SHARD_BLOCK_SIZE // GASPRICE_ADJUSTMENT_COEFFICIENT)

--- a/specs/phase1/shard-transition.md
+++ b/specs/phase1/shard-transition.md
@@ -70,8 +70,9 @@ def shard_state_transition(shard_state: ShardState,
     """
     shard_state.slot = block.slot
     prev_gasprice = shard_state.gasprice
-    shard_state.gasprice = compute_updated_gasprice(prev_gasprice, len(block.body))
-    if len(block.body) == 0:
+    shard_block_length = len(block.body)
+    shard_state.gasprice = compute_updated_gasprice(prev_gasprice, uint64(shard_block_length))
+    if shard_block_length == 0:
         latest_block_root = shard_state.latest_block_root
     else:
         latest_block_root = hash_tree_root(block)


### PR DESCRIPTION
### Issue
The type of `shard_block_length` in `compute_updated_gasprice` should have been `uint64`.

### How did I fix it
1. Change it to `def compute_updated_gasprice(prev_gasprice: Gwei, shard_block_length: uint64) -> Gwei`
2. Add `uint64` casting when calling it.