### PR TITLE
Fix usages of shard in `process_crosslink_for_shard`

### DIFF
--- a/specs/phase1/beacon-chain.md
+++ b/specs/phase1/beacon-chain.md
@@ -901,7 +901,7 @@ def process_crosslink_for_shard(state: BeaconState,
         assert shard_transition_root == hash_tree_root(shard_transition)
 
         # Apply transition
-        apply_shard_transition(state, attestation.data.shard, shard_transition)
+        apply_shard_transition(state, attestations[0].data.shard, shard_transition)
         # Apply proposer reward and cost
         beacon_proposer_index = get_beacon_proposer_index(state)
         estimated_attester_reward = sum([get_base_reward(state, attester) for attester in transition_participants])
@@ -909,11 +909,11 @@ def process_crosslink_for_shard(state: BeaconState,
         increase_balance(state, beacon_proposer_index, proposer_reward)
         states_slots_lengths = zip(
             shard_transition.shard_states,
-            get_offset_slots(state, attestation.data.shard),
+            get_offset_slots(state, attestations[0].data.shard),
             shard_transition.shard_block_lengths
         )
         for shard_state, slot, length in states_slots_lengths:
-            proposer_index = get_shard_proposer_index(state, slot, attestation.data.shard)
+            proposer_index = get_shard_proposer_index(state, slot, attestations[0].data.shard)
             decrease_balance(state, proposer_index, shard_state.gasprice * length)
 
         # Return winning transition root

--- a/specs/phase1/beacon-chain.md
+++ b/specs/phase1/beacon-chain.md
@@ -876,6 +876,7 @@ def process_crosslink_for_shard(state: BeaconState,
     on_time_attestation_slot = compute_previous_slot(state.slot)
     committee = get_beacon_committee(state, on_time_attestation_slot, committee_index)
     online_indices = get_online_validator_indices(state)
+    shard = compute_shard_from_committee_index(state, committee_index, on_time_attestation_slot)
 
     # Loop over all shard transition roots
     shard_transition_roots = set([a.data.shard_transition_root for a in attestations])
@@ -901,7 +902,7 @@ def process_crosslink_for_shard(state: BeaconState,
         assert shard_transition_root == hash_tree_root(shard_transition)
 
         # Apply transition
-        apply_shard_transition(state, attestations[0].data.shard, shard_transition)
+        apply_shard_transition(state, shard, shard_transition)
         # Apply proposer reward and cost
         beacon_proposer_index = get_beacon_proposer_index(state)
         estimated_attester_reward = sum([get_base_reward(state, attester) for attester in transition_participants])
@@ -909,11 +910,11 @@ def process_crosslink_for_shard(state: BeaconState,
         increase_balance(state, beacon_proposer_index, proposer_reward)
         states_slots_lengths = zip(
             shard_transition.shard_states,
-            get_offset_slots(state, attestations[0].data.shard),
+            get_offset_slots(state, shard),
             shard_transition.shard_block_lengths
         )
         for shard_state, slot, length in states_slots_lengths:
-            proposer_index = get_shard_proposer_index(state, slot, attestations[0].data.shard)
+            proposer_index = get_shard_proposer_index(state, slot, shard)
             decrease_balance(state, proposer_index, shard_state.gasprice * length)
 
         # Return winning transition root


### PR DESCRIPTION
To apply shard transition in `process_crosslink_for_shard`, we can't use `attestation` because it's outside of the `transition_attestations` for loop. One naive solution is to use `attestations[0]`. It's not the prettiest, and it assumes input `attestations` are all from the same `shard`, which is what caller `process_crosslinks` does. If anyone has a better solution, feel free to supersede this. I mainly wanted to open this to point out misuses.