### PR TITLE
Remove shard check in `verify_shard_block_message`

### DIFF
--- a/specs/phase1/shard-transition.md
+++ b/specs/phase1/shard-transition.md
@@ -42,8 +42,6 @@ def verify_shard_block_message(beacon_parent_state: BeaconState,
     next_slot = Slot(block.slot + 1)
     offset_slots = compute_offset_slots(get_latest_slot_for_shard(beacon_parent_state, shard), next_slot)
     assert block.slot in offset_slots
-    # Check `shard` field
-    assert block.shard == shard
     # Check `proposer_index` field
     assert block.proposer_index == get_shard_proposer_index(beacon_parent_state, block.slot, shard)
     # Check `body` field


### PR DESCRIPTION
The shard field consistency check in `verify_shard_block_message` is redundant
```python
shard = block.shard
assert block.shard == shard
```
Given the input argument, I'm not able to find a proper consistency check the for block's shard field. 
One can argue we don't need to check for the shard field because `shard_parent_root` indirectly validates `shard`.  The shard field is most useful to looking up shard blocks are coming in from the correct p2p subnet (`shard_{shard}_block`)

Opening this PR for suggestion