### PR TITLE
BeaconState.exposed_derived_secrets (of Vector type) initialized to an empty list

### DIFF
--- a/specs/phase1/phase1-fork.md
+++ b/specs/phase1/phase1-fork.md
@@ -111,7 +111,7 @@ def upgrade_to_phase1(pre: phase0.BeaconState) -> BeaconState:
         current_light_committee=CompactCommittee(),  # computed after state creation
         next_light_committee=CompactCommittee(),
         # Custody game
-        exposed_derived_secrets=[[]] * EARLY_DERIVED_SECRET_PENALTY_MAX_FUTURE_EPOCHS,
+        exposed_derived_secrets=[()] * EARLY_DERIVED_SECRET_PENALTY_MAX_FUTURE_EPOCHS,
         # exposed_derived_secrets will fully default to zeroes
     )
     next_epoch = Epoch(epoch + 1)

--- a/specs/phase1/phase1-fork.md
+++ b/specs/phase1/phase1-fork.md
@@ -111,7 +111,7 @@ def upgrade_to_phase1(pre: phase0.BeaconState) -> BeaconState:
         current_light_committee=CompactCommittee(),  # computed after state creation
         next_light_committee=CompactCommittee(),
         # Custody game
-        exposed_derived_secrets=[] * EARLY_DERIVED_SECRET_PENALTY_MAX_FUTURE_EPOCHS,
+        exposed_derived_secrets=[[]] * EARLY_DERIVED_SECRET_PENALTY_MAX_FUTURE_EPOCHS,
         # exposed_derived_secrets will fully default to zeroes
     )
     next_epoch = Epoch(epoch + 1)


### PR DESCRIPTION
[upgrade_to_phase1](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase1/phase1-fork.md#upgrading-the-state) creates `BeaconState` with its field `exposed_derived_secrets` initialized to `[] * EARLY_DERIVED_SECRET_PENALTY_MAX_FUTURE_EPOCHS`.
However, `exposed_derived_secrets` has a type of `Vector[List[ValidatorIndex, ...], ...]` and the initialization expression evaluates to an empty list, not to a list of length `EARLY_DERIVED_SECRET_PENALTY_MAX_FUTURE_EPOCHS`.

As a Vector field is initialized with an empty list in result, it's behavior is not evident.
@protolambda clarified that an error should be raised (if the vector has a non-zero length).

I suspect that the problem is a result of a typo, i.e. `[[]] * <num>` should be used instead of `[] * <num>`.