### PR TITLE
Rework `shard_state_transition` interface + fix #1922

### DIFF
--- a/specs/phase1/shard-fork-choice.md
+++ b/specs/phase1/shard-fork-choice.md
@@ -169,14 +169,12 @@ def on_shard_block(store: Store, shard_store: ShardStore, signed_shard_block: Si
     )
 
     # Check the block is valid and compute the post-state
-    assert verify_shard_block_message(beacon_parent_state, shard_parent_state, shard_block)
-    assert verify_shard_block_signature(beacon_parent_state, signed_shard_block)
-
-    post_state = get_post_shard_state(shard_parent_state, shard_block)
+    shard_state = shard_parent_state.copy()
+    shard_state_transition(beacon_parent_state, shard_state, shard_block)
 
     # Add new block to the store
     shard_store.blocks[hash_tree_root(shard_block)] = shard_block
 
     # Add new state for this block to the store
-    shard_store.block_states[hash_tree_root(shard_block)] = post_state
+    shard_store.block_states[hash_tree_root(shard_block)] = shard_state
 ```

--- a/specs/phase1/shard-fork-choice.md
+++ b/specs/phase1/shard-fork-choice.md
@@ -170,7 +170,9 @@ def on_shard_block(store: Store, shard_store: ShardStore, signed_shard_block: Si
 
     # Check the block is valid and compute the post-state
     shard_state = shard_parent_state.copy()
-    shard_state_transition(shard_state, shard_block, validate_message=True, beacon_parent_state=beacon_parent_state)
+    shard_state_transition(
+        shard_state, signed_shard_block,
+        validate=True, beacon_parent_state=beacon_parent_state)
 
     # Add new block to the store
     shard_store.blocks[hash_tree_root(shard_block)] = shard_block

--- a/specs/phase1/shard-fork-choice.md
+++ b/specs/phase1/shard-fork-choice.md
@@ -170,7 +170,7 @@ def on_shard_block(store: Store, shard_store: ShardStore, signed_shard_block: Si
 
     # Check the block is valid and compute the post-state
     shard_state = shard_parent_state.copy()
-    shard_state_transition(beacon_parent_state, shard_state, shard_block)
+    shard_state_transition(shard_state, shard_block, validate_message=True, beacon_parent_state=beacon_parent_state)
 
     # Add new block to the store
     shard_store.blocks[hash_tree_root(shard_block)] = shard_block

--- a/specs/phase1/shard-transition.md
+++ b/specs/phase1/shard-transition.md
@@ -61,11 +61,12 @@ def verify_shard_block_signature(beacon_state: BeaconState,
 ## Shard state transition
 
 ```python
-def shard_state_transition(beacon_parent_state: BeaconState,
-                           shard_state: ShardState,
+def shard_state_transition(shard_state: ShardState,
                            block: ShardBlock,
-                           validate_message: bool = True) -> bool:
+                           validate_message: bool = True,
+                           beacon_parent_state: Optional[BeaconState] = None) -> bool:
     if validate_message:
+        assert beacon_parent_state is not None
         assert verify_shard_block_message(beacon_parent_state, shard_state, block)
 
     process_shard_block(shard_state, block)
@@ -126,7 +127,7 @@ def is_valid_fraud_proof(beacon_state: BeaconState,
     else:
         shard_state = transition.shard_states[offset_index - 1]  # Not doing the actual state updates here.
 
-    shard_state_transition(beacon_state, shard_state, block, validate_message=False)
+    shard_state_transition(shard_state, block, validate_message=False)
     if shard_state != transition.shard_states[offset_index]:
         return True
 

--- a/specs/phase1/shard-transition.md
+++ b/specs/phase1/shard-transition.md
@@ -64,7 +64,7 @@ def verify_shard_block_signature(beacon_state: BeaconState,
 def shard_state_transition(shard_state: ShardState,
                            block: ShardBlock,
                            validate_message: bool = True,
-                           beacon_parent_state: Optional[BeaconState] = None) -> bool:
+                           beacon_parent_state: Optional[BeaconState] = None) -> ShardState:
     if validate_message:
         assert beacon_parent_state is not None
         assert verify_shard_block_message(beacon_parent_state, shard_state, block)

--- a/specs/phase1/shard-transition.md
+++ b/specs/phase1/shard-transition.md
@@ -50,10 +50,10 @@ def verify_shard_block_message(beacon_parent_state: BeaconState,
 ```
 
 ```python
-def verify_shard_block_signature(beacon_state: BeaconState,
+def verify_shard_block_signature(beacon_parent_state: BeaconState,
                                  signed_block: SignedShardBlock) -> bool:
-    proposer = beacon_state.validators[signed_block.message.proposer_index]
-    domain = get_domain(beacon_state, DOMAIN_SHARD_PROPOSAL, compute_epoch_at_slot(signed_block.message.slot))
+    proposer = beacon_parent_state.validators[signed_block.message.proposer_index]
+    domain = get_domain(beacon_parent_state, DOMAIN_SHARD_PROPOSAL, compute_epoch_at_slot(signed_block.message.slot))
     signing_root = compute_signing_root(signed_block.message, domain)
     return bls.Verify(proposer.pubkey, signing_root, signed_block.signature)
 ```
@@ -62,14 +62,15 @@ def verify_shard_block_signature(beacon_state: BeaconState,
 
 ```python
 def shard_state_transition(shard_state: ShardState,
-                           block: ShardBlock,
-                           validate_message: bool = True,
+                           signed_block: SignedShardBlock,
+                           validate: bool = True,
                            beacon_parent_state: Optional[BeaconState] = None) -> ShardState:
-    if validate_message:
+    if validate:
         assert beacon_parent_state is not None
-        assert verify_shard_block_message(beacon_parent_state, shard_state, block)
+        assert verify_shard_block_message(beacon_parent_state, shard_state, signed_block.message)
+        assert verify_shard_block_signature(beacon_parent_state, signed_block)
 
-    process_shard_block(shard_state, block)
+    process_shard_block(shard_state, signed_block.message)
     return shard_state
 ```
 
@@ -127,7 +128,7 @@ def is_valid_fraud_proof(beacon_state: BeaconState,
     else:
         shard_state = transition.shard_states[offset_index - 1]  # Not doing the actual state updates here.
 
-    shard_state_transition(shard_state, block, validate_message=False)
+    shard_state_transition(shard_state, block, validate=False)
     if shard_state != transition.shard_states[offset_index]:
         return True
 

--- a/specs/phase1/validator.md
+++ b/specs/phase1/validator.md
@@ -286,7 +286,7 @@ def get_shard_transition_fields(
     shard_data_roots = []
     shard_block_lengths = []
 
-    shard_state = beacon_state.shard_states[shard]
+    shard_state = beacon_state.shard_states[shard].copy()
     shard_block_slots = [shard_block.message.slot for shard_block in shard_blocks]
     offset_slots = compute_offset_slots(
         get_latest_slot_for_shard(beacon_state, shard),
@@ -299,7 +299,7 @@ def get_shard_transition_fields(
         else:
             shard_block = SignedShardBlock(message=ShardBlock(slot=slot, shard=shard))
             shard_data_roots.append(Root())
-        shard_state = get_post_shard_state(shard_state, shard_block.message)
+        shard_state_transition(beacon_state, shard_state, shard_block.message, validate_message=False)
         shard_states.append(shard_state)
         shard_block_lengths.append(len(shard_block.message.body))
 

--- a/specs/phase1/validator.md
+++ b/specs/phase1/validator.md
@@ -299,7 +299,7 @@ def get_shard_transition_fields(
             shard_block = SignedShardBlock(message=ShardBlock(slot=slot, shard=shard))
             shard_data_roots.append(Root())
         shard_state = shard_state.copy()
-        shard_state_transition(shard_state, shard_block.message, validate_message=False)
+        shard_state_transition(shard_state, shard_block, validate=False)
         shard_states.append(shard_state)
         shard_block_lengths.append(len(shard_block.message.body))
 

--- a/specs/phase1/validator.md
+++ b/specs/phase1/validator.md
@@ -280,13 +280,12 @@ def get_shard_transition_fields(
     beacon_state: BeaconState,
     shard: Shard,
     shard_blocks: Sequence[SignedShardBlock],
-    validate_signature: bool=True,
 ) -> Tuple[Sequence[uint64], Sequence[Root], Sequence[ShardState]]:
     shard_states = []
     shard_data_roots = []
     shard_block_lengths = []
 
-    shard_state = beacon_state.shard_states[shard].copy()
+    shard_state = beacon_state.shard_states[shard]
     shard_block_slots = [shard_block.message.slot for shard_block in shard_blocks]
     offset_slots = compute_offset_slots(
         get_latest_slot_for_shard(beacon_state, shard),
@@ -299,7 +298,8 @@ def get_shard_transition_fields(
         else:
             shard_block = SignedShardBlock(message=ShardBlock(slot=slot, shard=shard))
             shard_data_roots.append(Root())
-        shard_state_transition(beacon_state, shard_state, shard_block.message, validate_message=False)
+        shard_state = shard_state.copy()
+        shard_state_transition(shard_state, shard_block.message, validate_message=False)
         shard_states.append(shard_state)
         shard_block_lengths.append(len(shard_block.message.body))
 


### PR DESCRIPTION
### Issue
Per #1922, it reminded me that it's not very clear when should we call `verify_shard_block_message`.

I think we can rework the current phase 1 `shard_state_transition` to a similar structure as the phase 0 `state_transition` function now. 

### Proposal

Make `shard_state_transition` function:
1. be similar with phase 0 `state_transition` function
2. be the main shard state transition function for (almost?) all the specs.

Changelog

1. Rename old `shard_state_transition` to `process_shard_block`
2. Add `shard_state_transition` with `validate_message` flag, we only
validate it in shard fork choice
3. Assume that the given block's `shard` field has been validated by p2p layer or shard fork choice rule. Remove `block.shard` verification from `verify_shard_block_message` as #1922 suggested