### PR TITLE
AttesterSlashing with 0 indices and out of bounds indices

### DIFF
--- a/tests/core/pyspec/eth2spec/test/phase0/block_processing/test_process_attester_slashing.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/block_processing/test_process_attester_slashing.py
@@ -200,6 +200,74 @@ def test_participants_already_slashed(spec, state):
 @with_phases([PHASE0])
 @spec_state_test
 @always_bls
+def test_att1_high_index(spec, state):
+    attester_slashing = get_valid_attester_slashing(spec, state, signed_1=True, signed_2=True)
+
+    indices = get_indexed_attestation_participants(spec, attester_slashing.attestation_1)
+    indices.append(spec.ValidatorIndex(len(state.validators)))  # off by 1
+    attester_slashing.attestation_1.attesting_indices = indices
+
+    yield from run_attester_slashing_processing(spec, state, attester_slashing, False)
+
+
+@with_phases([PHASE0])
+@spec_state_test
+@always_bls
+def test_att2_high_index(spec, state):
+    attester_slashing = get_valid_attester_slashing(spec, state, signed_1=True, signed_2=True)
+
+    indices = get_indexed_attestation_participants(spec, attester_slashing.attestation_2)
+    indices.append(spec.ValidatorIndex(len(state.validators)))  # off by 1
+    attester_slashing.attestation_2.attesting_indices = indices
+
+    yield from run_attester_slashing_processing(spec, state, attester_slashing, False)
+
+
+EMPTY_SIGNATURE = b'\xc0' + (b'\x00' * 95)
+
+
+@with_phases([PHASE0])
+@spec_state_test
+@always_bls
+def test_att1_empty_indices(spec, state):
+    attester_slashing = get_valid_attester_slashing(spec, state, signed_1=False, signed_2=True)
+
+    attester_slashing.attestation_1.attesting_indices = []
+    attester_slashing.attestation_1.signature = EMPTY_SIGNATURE
+
+    yield from run_attester_slashing_processing(spec, state, attester_slashing, False)
+
+
+@with_phases([PHASE0])
+@spec_state_test
+@always_bls
+def test_att2_empty_indices(spec, state):
+    attester_slashing = get_valid_attester_slashing(spec, state, signed_1=True, signed_2=False)
+
+    attester_slashing.attestation_2.attesting_indices = []
+    attester_slashing.attestation_2.signature = EMPTY_SIGNATURE
+
+    yield from run_attester_slashing_processing(spec, state, attester_slashing, False)
+
+
+@with_phases([PHASE0])
+@spec_state_test
+@always_bls
+def test_all_empty_indices(spec, state):
+    attester_slashing = get_valid_attester_slashing(spec, state, signed_1=False, signed_2=False)
+
+    attester_slashing.attestation_1.attesting_indices = []
+    attester_slashing.attestation_1.signature = EMPTY_SIGNATURE
+
+    attester_slashing.attestation_2.attesting_indices = []
+    attester_slashing.attestation_2.signature = EMPTY_SIGNATURE
+
+    yield from run_attester_slashing_processing(spec, state, attester_slashing, False)
+
+
+@with_phases([PHASE0])
+@spec_state_test
+@always_bls
 def test_att1_bad_extra_index(spec, state):
     attester_slashing = get_valid_attester_slashing(spec, state, signed_1=True, signed_2=True)
 

--- a/tests/core/pyspec/eth2spec/test/phase0/block_processing/test_process_attester_slashing.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/block_processing/test_process_attester_slashing.py
@@ -223,9 +223,6 @@ def test_att2_high_index(spec, state):
     yield from run_attester_slashing_processing(spec, state, attester_slashing, False)
 
 
-EMPTY_SIGNATURE = b'\xc0' + (b'\x00' * 95)
-
-
 @with_phases([PHASE0])
 @spec_state_test
 @always_bls
@@ -233,7 +230,7 @@ def test_att1_empty_indices(spec, state):
     attester_slashing = get_valid_attester_slashing(spec, state, signed_1=False, signed_2=True)
 
     attester_slashing.attestation_1.attesting_indices = []
-    attester_slashing.attestation_1.signature = EMPTY_SIGNATURE
+    attester_slashing.attestation_1.signature = spec.bls.Z2_SIGNATURE
 
     yield from run_attester_slashing_processing(spec, state, attester_slashing, False)
 
@@ -245,7 +242,7 @@ def test_att2_empty_indices(spec, state):
     attester_slashing = get_valid_attester_slashing(spec, state, signed_1=True, signed_2=False)
 
     attester_slashing.attestation_2.attesting_indices = []
-    attester_slashing.attestation_2.signature = EMPTY_SIGNATURE
+    attester_slashing.attestation_2.signature = spec.bls.Z2_SIGNATURE
 
     yield from run_attester_slashing_processing(spec, state, attester_slashing, False)
 
@@ -257,10 +254,10 @@ def test_all_empty_indices(spec, state):
     attester_slashing = get_valid_attester_slashing(spec, state, signed_1=False, signed_2=False)
 
     attester_slashing.attestation_1.attesting_indices = []
-    attester_slashing.attestation_1.signature = EMPTY_SIGNATURE
+    attester_slashing.attestation_1.signature = spec.bls.Z2_SIGNATURE
 
     attester_slashing.attestation_2.attesting_indices = []
-    attester_slashing.attestation_2.signature = EMPTY_SIGNATURE
+    attester_slashing.attestation_2.signature = spec.bls.Z2_SIGNATURE
 
     yield from run_attester_slashing_processing(spec, state, attester_slashing, False)
 


### PR DESCRIPTION
Based on [this bug find in Nimbus](https://github.com/status-im/nim-beacon-chain/pull/1214/), which was found thanks to the work by the fuzzing team (@zedt3ster and others), it showed how the attester slashing tests missed the high-index case. And cases for 0 attesting indices were missing as well.

We may want the spec to be more explicit about these cases, as the current approach is too implicit (in my opinion). For now, these tests help catch the case in other clients that may not have been given this input through fuzzing yet.

BLS is forced to be enabled in these tests, as that should catch it if not with anything else. But the high index may still cause a panic before that in a client. And the 0 indices case with BLS is important too, since the move away from empty aggregation was based on client BLS issues with empty aggregation there.
