### PR TITLE
Use `LIGHT_CLIENT_COMMITTEE_SIZE` in `get_light_client_committee`

### DIFF
--- a/specs/phase1/beacon-chain.md
+++ b/specs/phase1/beacon-chain.md
@@ -569,7 +569,7 @@ def get_light_client_committee(beacon_state: BeaconState, epoch: Epoch) -> Seque
         seed=seed,
         index=0,
         count=get_active_shard_count(beacon_state),
-    )[:TARGET_COMMITTEE_SIZE]
+    )[:LIGHT_CLIENT_COMMITTEE_SIZE]
 ```
 
 #### `get_shard_proposer_index`


### PR DESCRIPTION
Is there a reason `TARGET_COMMITTEE_SIZE` is used over `LIGHT_CLIENT_COMMITTEE_SIZE`? 
I think it should align to the vector size naming as `BeaconBlockBody`


```python
class BeaconBlockBody(Container):
    ...
    # Light clients
    light_client_bits: Bitvector[LIGHT_CLIENT_COMMITTEE_SIZE]
    ...
```