### PR TITLE
Proposal: generic `uint_to_bytes`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,9 +94,9 @@ from dataclasses import (
 
 from lru import LRU
 
-from eth2spec.utils.ssz.ssz_impl import hash_tree_root
+from eth2spec.utils.ssz.ssz_impl import hash_tree_root, uint_to_bytes
 from eth2spec.utils.ssz.ssz_typing import (
-    View, boolean, Container, List, Vector, uint64,
+    View, boolean, Container, List, Vector, uint8, uint32, uint64,
     Bytes1, Bytes4, Bytes32, Bytes48, Bytes96, Bitlist, Bitvector,
 )
 from eth2spec.utils import bls
@@ -118,9 +118,9 @@ from dataclasses import (
 
 from lru import LRU
 
-from eth2spec.utils.ssz.ssz_impl import hash_tree_root
+from eth2spec.utils.ssz.ssz_impl import hash_tree_root, uint_to_bytes
 from eth2spec.utils.ssz.ssz_typing import (
-    View, boolean, Container, List, Vector, uint64, uint8, bit,
+    View, boolean, Container, List, Vector, uint8, uint32, uint64, bit,
     ByteList, ByteVector, Bytes1, Bytes4, Bytes32, Bytes48, Bytes96, Bitlist, Bitvector,
 )
 from eth2spec.utils import bls

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -578,7 +578,7 @@ def xor(bytes_1: Bytes32, bytes_2: Bytes32) -> Bytes32:
 
 #### `uint_to_bytes`
 
-`def uint_to_bytes(n: uint8) -> bytes` is a function for serializing the `uint` type object to bytes in ``ENDIANNESS``-endian. The expected length of the output is the byte-length of the `uint` type.
+`def uint_to_bytes(n: uint) -> bytes` is a function for serializing the `uint` type object to bytes in ``ENDIANNESS``-endian. The expected length of the output is the byte-length of the `uint` type.
 
 #### `bytes_to_uint64`
 

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -55,8 +55,8 @@
   - [Math](#math)
     - [`integer_squareroot`](#integer_squareroot)
     - [`xor`](#xor)
-    - [`int_to_bytes`](#int_to_bytes)
-    - [`bytes_to_int`](#bytes_to_int)
+    - [`uint_to_bytes`](#uint_to_bytes)
+    - [`bytes_to_uint64`](#bytes_to_uint64)
   - [Crypto](#crypto)
     - [`hash`](#hash)
     - [`hash_tree_root`](#hash_tree_root)
@@ -576,20 +576,14 @@ def xor(bytes_1: Bytes32, bytes_2: Bytes32) -> Bytes32:
     return Bytes32(a ^ b for a, b in zip(bytes_1, bytes_2))
 ```
 
-#### `int_to_bytes`
+#### `uint_to_bytes`
+
+`def uint_to_bytes(n: uint8) -> bytes` is a function for serializing the `uint` type object to bytes in ``ENDIANNESS``-endian. The expected length of the output is the byte-length of the `uint` type.
+
+#### `bytes_to_uint64`
 
 ```python
-def int_to_bytes(n: uint64, length: uint64) -> bytes:
-    """
-    Return the ``length``-byte serialization of ``n`` in ``ENDIANNESS``-endian.
-    """
-    return n.to_bytes(length, ENDIANNESS)
-```
-
-#### `bytes_to_int`
-
-```python
-def bytes_to_int(data: bytes) -> uint64:
+def bytes_to_uint64(data: bytes) -> uint64:
     """
     Return the integer deserialization of ``data`` interpreted as ``ENDIANNESS``-endian.
     """
@@ -732,11 +726,15 @@ def compute_shuffled_index(index: uint64, index_count: uint64, seed: Bytes32) ->
 
     # Swap or not (https://link.springer.com/content/pdf/10.1007%2F978-3-642-32009-5_1.pdf)
     # See the 'generalized domain' algorithm on page 3
-    for current_round in range(SHUFFLE_ROUND_COUNT):
-        pivot = bytes_to_int(hash(seed + int_to_bytes(current_round, length=1))[0:8]) % index_count
-        flip = (pivot + index_count - index) % index_count
+    for current_round in map(uint8, range(SHUFFLE_ROUND_COUNT)):
+        pivot = bytes_to_uint64(hash(seed + uint_to_bytes(current_round))[0:8]) % index_count
+        flip = uint64((pivot + index_count - index) % index_count)
         position = max(index, flip)
-        source = hash(seed + int_to_bytes(current_round, length=1) + int_to_bytes(position // 256, length=4))
+        source = hash(
+            seed
+            + uint_to_bytes(current_round)
+            + uint_to_bytes(uint32(position // 256))
+        )
         byte = source[(position % 256) // 8]
         bit = (byte >> (position % 8)) % 2
         index = flip if bit else index
@@ -756,7 +754,7 @@ def compute_proposer_index(state: BeaconState, indices: Sequence[ValidatorIndex]
     i = 0
     while True:
         candidate_index = indices[compute_shuffled_index(i % len(indices), len(indices), seed)]
-        random_byte = hash(seed + int_to_bytes(i // 32, length=8))[i % 32]
+        random_byte = hash(seed + uint_to_bytes(uint64(i // 32)))[i % 32]
         effective_balance = state.validators[candidate_index].effective_balance
         if effective_balance * MAX_RANDOM_BYTE >= MAX_EFFECTIVE_BALANCE * random_byte:
             return candidate_index
@@ -945,7 +943,7 @@ def get_seed(state: BeaconState, epoch: Epoch, domain_type: DomainType) -> Bytes
     Return the seed at ``epoch``.
     """
     mix = get_randao_mix(state, Epoch(epoch + EPOCHS_PER_HISTORICAL_VECTOR - MIN_SEED_LOOKAHEAD - 1))  # Avoid underflow
-    return hash(domain_type + int_to_bytes(epoch, length=8) + mix)
+    return hash(domain_type + uint_to_bytes(epoch) + mix)
 ```
 
 #### `get_committee_count_per_slot`
@@ -986,7 +984,7 @@ def get_beacon_proposer_index(state: BeaconState) -> ValidatorIndex:
     Return the beacon proposer index at the current slot.
     """
     epoch = get_current_epoch(state)
-    seed = hash(get_seed(state, epoch, DOMAIN_BEACON_PROPOSER) + int_to_bytes(state.slot, length=8))
+    seed = hash(get_seed(state, epoch, DOMAIN_BEACON_PROPOSER) + uint_to_bytes(state.slot))
     indices = get_active_validator_indices(state, epoch)
     return compute_proposer_index(state, indices, seed)
 ```

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -726,13 +726,13 @@ def compute_shuffled_index(index: uint64, index_count: uint64, seed: Bytes32) ->
 
     # Swap or not (https://link.springer.com/content/pdf/10.1007%2F978-3-642-32009-5_1.pdf)
     # See the 'generalized domain' algorithm on page 3
-    for current_round in map(uint8, range(SHUFFLE_ROUND_COUNT)):
-        pivot = bytes_to_uint64(hash(seed + uint_to_bytes(current_round))[0:8]) % index_count
-        flip = uint64((pivot + index_count - index) % index_count)
+    for current_round in range(SHUFFLE_ROUND_COUNT):
+        pivot = bytes_to_uint64(hash(seed + uint_to_bytes(uint8(current_round)))[0:8]) % index_count
+        flip = (pivot + index_count - index) % index_count
         position = max(index, flip)
         source = hash(
             seed
-            + uint_to_bytes(current_round)
+            + uint_to_bytes(uint8(current_round))
             + uint_to_bytes(uint32(position // 256))
         )
         byte = source[(position % 256) // 8]

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -465,7 +465,7 @@ def get_slot_signature(state: BeaconState, slot: Slot, privkey: int) -> BLSSigna
 def is_aggregator(state: BeaconState, slot: Slot, index: CommitteeIndex, slot_signature: BLSSignature) -> bool:
     committee = get_beacon_committee(state, slot, index)
     modulo = max(1, len(committee) // TARGET_AGGREGATORS_PER_COMMITTEE)
-    return bytes_to_int(hash(slot_signature)[0:8]) % modulo == 0
+    return bytes_to_uint64(hash(slot_signature)[0:8]) % modulo == 0
 ```
 
 #### Construct aggregate

--- a/specs/phase1/beacon-chain.md
+++ b/specs/phase1/beacon-chain.md
@@ -581,8 +581,8 @@ def get_shard_proposer_index(beacon_state: BeaconState, slot: Slot, shard: Shard
     """
     epoch = compute_epoch_at_slot(slot)
     committee = get_shard_committee(beacon_state, epoch, shard)
-    seed = hash(get_seed(beacon_state, epoch, DOMAIN_SHARD_COMMITTEE) + int_to_bytes(slot, length=8))
-    r = bytes_to_int(seed[:8])
+    seed = hash(get_seed(beacon_state, epoch, DOMAIN_SHARD_COMMITTEE) + uint_to_bytes(slot))
+    r = bytes_to_uint64(seed[:8])
     return committee[r % len(committee)]
 ```
 

--- a/specs/phase1/validator.md
+++ b/specs/phase1/validator.md
@@ -463,7 +463,7 @@ def get_light_client_slot_signature(state: BeaconState, slot: Slot, privkey: int
 def is_light_client_aggregator(state: BeaconState, slot: Slot, slot_signature: BLSSignature) -> bool:
     committee = get_light_client_committee(state, compute_epoch_at_slot(slot))
     modulo = max(1, len(committee) // TARGET_LIGHT_CLIENT_AGGREGATORS_PER_SLOT)
-    return bytes_to_int(hash(slot_signature)[0:8]) % modulo == 0
+    return bytes_to_uint64(hash(slot_signature)[0:8]) % modulo == 0
 ```
 
 #### Construct aggregate

--- a/tests/core/pyspec/eth2spec/utils/ssz/ssz_impl.py
+++ b/tests/core/pyspec/eth2spec/utils/ssz/ssz_impl.py
@@ -1,3 +1,4 @@
+from remerkleable.basic import uint
 from remerkleable.core import View
 from remerkleable.byte_arrays import Bytes32
 
@@ -8,3 +9,7 @@ def serialize(obj: View) -> bytes:
 
 def hash_tree_root(obj: View) -> Bytes32:
     return Bytes32(obj.get_backing().merkle_root())
+
+
+def uint_to_bytes(n: uint) -> bytes:
+    return serialize(n)


### PR DESCRIPTION
### Issue

An alternative to #1746 `int_to_bytes` and `compute_shuffled_index` part.

1. **[Typing presentation bug]** Status-quo `int_to_bytes` expects `uint64` as the input. But actually we were passing Python `int` to it [in some cases](https://github.com/ethereum/eth2.0-specs/blob/ce0371a66b408c86af5305527a9bd2bd253899e0/specs/phase0/beacon-chain.md#compute_shuffled_index).
2. Part of https://github.com/ethereum/eth2.0-specs/pull/1746. Open a new PR to discuss this phase 0 change proposal for decreasing ambiguity. IMHO this PR is neater than #1746's casting.

### Proposed solution
1. To make it more explicit, rename `int_to_bytes` to `uint_to_bytes` and enforce the input of `uint_to_bytes` to be SSZ `uint` type.
3. Encode the `uint` object by its length in bytes. i.e., encode `uint8` to 1-byte output and `uint64` to 8-byte output.
4. To avoid exposing SSZ APIs, describe `uint_to_bytes` in prose instead of in code. Similar to `hash_tree_root`.
5. To make it more explicit, rename `bytes_to_int` to `bytes_to_uint64`. 


**Note**: It's a refactoring change of the current spec and it should not change the consensus logic.