### PR TITLE
Fix `ShardTransition.shard_data_roots` and add custody game block-level tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -226,7 +226,7 @@ get_attesting_indices = cache_this(
 PHASE1_SUNDRY_FUNCTIONS = '''
 
 def get_block_data_merkle_root(data: ByteList) -> Root:
-    # To get the Merkle root of the block data, we need the Merkle root without the length Mixing
+    # To get the Merkle root of the block data, we need the Merkle root without the length mix-in
     # The below implements this in the Remerkleable framework
     return data.get_backing().get_left().merkle_root()
 

--- a/setup.py
+++ b/setup.py
@@ -216,7 +216,10 @@ get_matching_head_attestations = cache_this(
 
 _get_attesting_indices = get_attesting_indices
 get_attesting_indices = cache_this(
-    lambda state, data, bits: (state.validators.hash_tree_root(), data.hash_tree_root(), bits.hash_tree_root()),
+    lambda state, data, bits: (
+        state.randao_mixes.hash_tree_root(),
+        state.validators.hash_tree_root(), data.hash_tree_root(), bits.hash_tree_root()
+    ),
     _get_attesting_indices, lru_size=SLOTS_PER_EPOCH * MAX_COMMITTEES_PER_SLOT * 3)'''
 
 

--- a/setup.py
+++ b/setup.py
@@ -221,6 +221,13 @@ get_attesting_indices = cache_this(
 
 
 PHASE1_SUNDRY_FUNCTIONS = '''
+
+def get_block_data_merkle_root(data: ByteList) -> Root:
+    # To get the Merkle root of the block data, we need the Merkle root without the length Mixing
+    # The below implements this in the Remerkleable framework
+    return data.get_backing().get_left().merkle_root()
+
+
 _get_start_shard = get_start_shard
 get_start_shard = cache_this(
     lambda state, slot: (state.validators.hash_tree_root(), slot),

--- a/specs/phase1/custody-game.md
+++ b/specs/phase1/custody-game.md
@@ -25,6 +25,7 @@
     - [`CustodyKeyReveal`](#custodykeyreveal)
     - [`EarlyDerivedSecretReveal`](#earlyderivedsecretreveal)
 - [Helpers](#helpers)
+  - [`get_block_data_merkle_root`](#get_block_data_merkle_root)
   - [`replace_empty_or_append`](#replace_empty_or_append)
   - [`legendre_bit`](#legendre_bit)
   - [`get_custody_atoms`](#get_custody_atoms)
@@ -181,6 +182,10 @@ class EarlyDerivedSecretReveal(Container):
 
 
 ## Helpers
+
+### `get_block_data_merkle_root`
+
+`get_block_data_merkle_root(data: ByteList) -> Root` is the function that returns the Merkle root of the block data without the length mix-in.
 
 ### `replace_empty_or_append`
 
@@ -515,7 +520,7 @@ def process_custody_slashing(state: BeaconState, signed_custody_slashing: Signed
     assert hash_tree_root(shard_transition) == attestation.data.shard_transition_root
     # Verify that the provided data matches the shard-transition
     assert (
-        custody_slashing.data.get_backing().get_left().merkle_root()
+        get_block_data_merkle_root(custody_slashing.data)
         == shard_transition.shard_data_roots[custody_slashing.data_index]
     )
     assert len(custody_slashing.data) == shard_transition.shard_block_lengths[custody_slashing.data_index]

--- a/specs/phase1/validator.md
+++ b/specs/phase1/validator.md
@@ -275,8 +275,6 @@ Set `attestation_data.shard_head_root = hash_tree_root(shard_head_block)`.
 
 Set `shard_transition` to the value returned by `get_shard_transition(head_state, shard, shard_blocks)`.
 
-`get_block_data_merkle_root(data: ByteList) -> Root` is the function that returns the Merkle root of the block data without the length mixing.
-
 ```python
 def get_shard_transition_fields(
     beacon_state: BeaconState,

--- a/specs/phase1/validator.md
+++ b/specs/phase1/validator.md
@@ -275,6 +275,8 @@ Set `attestation_data.shard_head_root = hash_tree_root(shard_head_block)`.
 
 Set `shard_transition` to the value returned by `get_shard_transition(head_state, shard, shard_blocks)`.
 
+`get_block_data_merkle_root(data: ByteList) -> Root` is the function that returns the Merkle root of the block data without the length mixing.
+
 ```python
 def get_shard_transition_fields(
     beacon_state: BeaconState,
@@ -294,7 +296,7 @@ def get_shard_transition_fields(
     for slot in offset_slots:
         if slot in shard_block_slots:
             shard_block = shard_blocks[shard_block_slots.index(slot)]
-            shard_data_roots.append(hash_tree_root(shard_block.message.body))
+            shard_data_roots.append(get_block_data_merkle_root(shard_block.message.body))
         else:
             shard_block = SignedShardBlock(message=ShardBlock(slot=slot, shard=shard))
             shard_data_roots.append(Root())

--- a/tests/core/pyspec/eth2spec/test/helpers/custody.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/custody.py
@@ -191,7 +191,7 @@ def get_custody_slashable_test_vector(spec, custody_secret, length, slashable=Tr
     offset = 0
     while spec.compute_custody_bit(custody_secret, test_vector) != slashable:
         offset += 1
-        test_vector = test_vector = get_custody_test_vector(length, offset)
+        test_vector = get_custody_test_vector(length, offset)
     return test_vector
 
 

--- a/tests/core/pyspec/eth2spec/test/helpers/custody.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/custody.py
@@ -136,17 +136,16 @@ def build_proof(anchor, leaf_index):
     return list(reversed(proof))
 
 
-def get_block_data_merkle_root(data_as_bytelist):
-    # To get the Merkle root of the block data, we need the Merkle root without the length Mixing
-    # The below implements this in the Remerkleable framework
-    return data_as_bytelist.get_backing().get_left().merkle_root()
-
-
-def get_valid_custody_chunk_response(spec, state, chunk_challenge, block_length, challenge_index,
+def get_valid_custody_chunk_response(spec, state, chunk_challenge, challenge_index,
+                                     block_length_or_custody_data,
                                      invalid_chunk_data=False):
-    custody_data = get_custody_test_vector(block_length)
+    if isinstance(block_length_or_custody_data, int):
+        custody_data = get_custody_test_vector(block_length_or_custody_data)
+    else:
+        custody_data = block_length_or_custody_data
+
     custody_data_block = ByteList[spec.MAX_SHARD_BLOCK_SIZE](custody_data)
-    chunks = custody_chunkify(spec, custody_data)
+    chunks = custody_chunkify(spec, custody_data_block)
 
     chunk_index = chunk_challenge.chunk_index
 
@@ -166,7 +165,7 @@ def get_custody_test_vector(bytelength, offset=0):
 
 
 def get_sample_shard_transition(spec, start_slot, block_lengths):
-    b = [get_block_data_merkle_root(ByteList[spec.MAX_SHARD_BLOCK_SIZE](get_custody_test_vector(x)))
+    b = [spec.get_block_data_merkle_root(ByteList[spec.MAX_SHARD_BLOCK_SIZE](get_custody_test_vector(x)))
          for x in block_lengths]
     shard_transition = spec.ShardTransition(
         start_slot=start_slot,
@@ -201,5 +200,5 @@ def get_custody_slashable_shard_transition(spec, start_slot, block_lengths, cust
     slashable_test_vector = get_custody_slashable_test_vector(spec, custody_secret,
                                                               block_lengths[0], slashable=slashable)
     block_data = ByteList[spec.MAX_SHARD_BLOCK_SIZE](slashable_test_vector)
-    shard_transition.shard_data_roots[0] = get_block_data_merkle_root(block_data)
+    shard_transition.shard_data_roots[0] = spec.get_block_data_merkle_root(block_data)
     return shard_transition, slashable_test_vector

--- a/tests/core/pyspec/eth2spec/test/phase1/block_processing/test_process_chunk_challenge.py
+++ b/tests/core/pyspec/eth2spec/test/phase1/block_processing/test_process_chunk_challenge.py
@@ -242,7 +242,8 @@ def test_custody_response(spec, state):
 
     chunk_challenge_index = state.custody_chunk_challenge_index - 1
 
-    custody_response = get_valid_custody_chunk_response(spec, state, challenge, 2**15 // 3, chunk_challenge_index)
+    custody_response = get_valid_custody_chunk_response(
+        spec, state, challenge, chunk_challenge_index, block_length_or_custody_data=2**15 // 3)
 
     yield from run_custody_chunk_response_processing(spec, state, custody_response)
 
@@ -270,7 +271,8 @@ def test_custody_response_multiple_epochs(spec, state):
 
     chunk_challenge_index = state.custody_chunk_challenge_index - 1
 
-    custody_response = get_valid_custody_chunk_response(spec, state, challenge, 2**15 // 3, chunk_challenge_index)
+    custody_response = get_valid_custody_chunk_response(
+        spec, state, challenge, chunk_challenge_index, block_length_or_custody_data=2**15 // 3)
 
     yield from run_custody_chunk_response_processing(spec, state, custody_response)
 
@@ -298,6 +300,7 @@ def test_custody_response_many_epochs(spec, state):
 
     chunk_challenge_index = state.custody_chunk_challenge_index - 1
 
-    custody_response = get_valid_custody_chunk_response(spec, state, challenge, 2**15 // 3, chunk_challenge_index)
+    custody_response = get_valid_custody_chunk_response(
+        spec, state, challenge, chunk_challenge_index, block_length_or_custody_data=2**15 // 3)
 
     yield from run_custody_chunk_response_processing(spec, state, custody_response)

--- a/tests/core/pyspec/eth2spec/test/phase1/epoch_processing/test_process_custody_final_updates.py
+++ b/tests/core/pyspec/eth2spec/test/phase1/epoch_processing/test_process_custody_final_updates.py
@@ -159,7 +159,8 @@ def test_validator_withdrawal_resume_after_chunk_challenge_response(spec, state)
     assert state.validators[validator_index].withdrawable_epoch == spec.FAR_FUTURE_EPOCH
 
     chunk_challenge_index = state.custody_chunk_challenge_index - 1
-    custody_response = get_valid_custody_chunk_response(spec, state, challenge, 2**15 // 3, chunk_challenge_index)
+    custody_response = get_valid_custody_chunk_response(
+        spec, state, challenge, chunk_challenge_index, block_length_or_custody_data=2**15 // 3)
 
     _, _, _ = run_custody_chunk_response_processing(spec, state, custody_response)
 

--- a/tests/core/pyspec/eth2spec/test/phase1/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/phase1/sanity/test_blocks.py
@@ -25,13 +25,13 @@ def run_beacon_block(spec, state, block, valid=True):
     yield 'pre', state.copy()
 
     if not valid:
-        state_transition_and_sign_block(spec, state, block, expect_fail=True)
-        yield 'block', block
+        signed_beacon_block = state_transition_and_sign_block(spec, state, block, expect_fail=True)
+        yield 'block', signed_beacon_block
         yield 'post', None
         return
 
-    state_transition_and_sign_block(spec, state, block)
-    yield 'block', block
+    signed_beacon_block = state_transition_and_sign_block(spec, state, block)
+    yield 'block', signed_beacon_block
     yield 'post', state
 
 
@@ -73,8 +73,8 @@ def run_beacon_block_with_shard_blocks(spec, state, target_len_offset_slot, comm
         yield 'post', None
         return
 
-    state_transition_and_sign_block(spec, state, beacon_block)
-    yield 'block', beacon_block
+    signed_beacon_block = state_transition_and_sign_block(spec, state, beacon_block)
+    yield 'block', signed_beacon_block
     yield 'post', state
 
     for shard in range(spec.get_active_shard_count(state)):
@@ -159,7 +159,7 @@ def test_with_custody_challenge_and_response(spec, state):
     block.body.attestations = [attestation]
     block.body.shard_transitions = shard_transitions
 
-    # Custody operations
+    # CustodyChunkChallenge and CustodyChunkResponse operations
     challenge = get_valid_chunk_challenge(spec, state, attestation, shard_transitions[shard])
     block.body.chunk_challenges = [challenge]
     chunk_challenge_index = state.custody_chunk_challenge_index


### PR DESCRIPTION
(pending on #1928 refactoring)

### Issues
1. https://github.com/ethereum/eth2.0-specs/issues/1768 B.7: Should use non-length mixins root for `shard_data_roots`
2. Lack of block-level custody operations tests

### How did I fix it
1. **[validator spec]** Fix `ShardTransition.shard_data_roots`: use `get_block_data_merkle_root` helper to calculate the root.
2. Testing
    - Rework `get_valid_custody_chunk_response` testing helper: accept `block_length_or_custody_data`
    - Add `test_with_shard_transition_with_custody_challenge_and_response`, `test_custody_key_reveal`, `test_early_derived_secret_reveal`, `test_custody_slashing` test cases for increasing testing coverage.
    - Fix `run_beacon_block`: should yield the `signed_beacon_block`
3. pyspec cache
    - Fix `get_attesting_indices` cache: add `randao_mixes` to the cache keys