### PR TITLE
Add more tests for `shard_state_transition` 

### DIFF
--- a/tests/core/pyspec/eth2spec/test/phase1/sanity/test_shard_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/phase1/sanity/test_shard_blocks.py
@@ -174,6 +174,7 @@ def test_invalid_offset(spec, state):
     # 4 is not in `SHARD_BLOCK_OFFSETS`
     shard = 0
     slot = beacon_state.shard_states[shard].slot + 4
+    assert slot not in spec.SHARD_BLOCK_OFFSETS
     transition_to(spec, beacon_state, slot)
 
     shard_state = beacon_state.shard_states[shard]


### PR DESCRIPTION
#1928 Part 2

Add more test cases:
- Invalid cases:
    - `test_out_of_bound_offset`: the shard block slot is greater than `beacon_state.shard_states[shard].slot + spec.SHARD_BLOCK_OFFSETS[spec.MAX_SHARD_BLOCKS_PER_ATTESTATION - 1]`.
       - TODO: need to handle this case properly in other PRs. (#1768 B.4)
    - `test_invalid_offset`: the shard block slot is not at the acceptable offsets
    - `test_empty_block_body`: the shard block body is `b''`

- Valid cases:
    - `test_max_offset`: the shard block slot is equal to `beacon_state.shard_states[shard].slot + spec.SHARD_BLOCK_OFFSETS[spec.MAX_SHARD_BLOCKS_PER_ATTESTATION - 1]`.
   - `test_pending_shard_parent_block`: the shard block's parent is not included in the beacon state yet.