### PR TITLE
Update `CompactCommittee` List size

### DIFF
--- a/specs/phase1/beacon-chain.md
+++ b/specs/phase1/beacon-chain.md
@@ -404,8 +404,8 @@ class ShardTransition(Container):
 
 ```python
 class CompactCommittee(Container):
-    pubkeys: List[BLSPubkey, MAX_VALIDATORS_PER_COMMITTEE]
-    compact_validators: List[uint64, MAX_VALIDATORS_PER_COMMITTEE]
+    pubkeys: List[BLSPubkey, LIGHT_CLIENT_COMMITTEE_SIZE]
+    compact_validators: List[uint64, LIGHT_CLIENT_COMMITTEE_SIZE]
 ```
 
 ### `AttestationCustodyBitWrapper`
@@ -559,7 +559,7 @@ def get_shard_committee(beacon_state: BeaconState, epoch: Epoch, shard: Shard) -
 ```python
 def get_light_client_committee(beacon_state: BeaconState, epoch: Epoch) -> Sequence[ValidatorIndex]:
     """
-    Return the light client committee of no more than ``TARGET_COMMITTEE_SIZE`` validators.
+    Return the light client committee of no more than ``LIGHT_CLIENT_COMMITTEE_SIZE`` validators.
     """
     source_epoch = compute_committee_source_epoch(epoch, LIGHT_CLIENT_COMMITTEE_PERIOD)
     active_validator_indices = get_active_validator_indices(beacon_state, source_epoch)


### PR DESCRIPTION
Is there's a reason `CompactCommittee` is using `MAX_VALIDATORS_PER_COMMITTEE` for the list size and not `LIGHT_CLIENT_COMMITTEE_SIZE`?  

`get_light_client_committee` will always cap it at `LIGHT_CLIENT_COMMITTEE_SIZE`

I also think Vector makes sense here. Opening this PR for suggestions