### PR TITLE
Avoid negative values and minor refactoring

### DIFF
--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -307,7 +307,7 @@ def get_eth1_vote(state: BeaconState, eth1_chain: Sequence[Eth1Block]) -> Eth1Da
     valid_votes = [vote for vote in state.eth1_data_votes if vote in votes_to_consider]
 
     # Default vote on latest eth1 block data in the period range unless eth1 chain is not live
-    default_vote = votes_to_consider[-1] if any(votes_to_consider) else state.eth1_data
+    default_vote = votes_to_consider[len(votes_to_consider) - 1] if any(votes_to_consider) else state.eth1_data
 
     return max(
         valid_votes,

--- a/specs/phase1/beacon-chain.md
+++ b/specs/phase1/beacon-chain.md
@@ -532,7 +532,7 @@ def get_active_shard_count(state: BeaconState) -> uint64:
 ```python
 def get_online_validator_indices(state: BeaconState) -> Set[ValidatorIndex]:
     active_validators = get_active_validator_indices(state, get_current_epoch(state))
-    return set([i for i in active_validators if state.online_countdown[i] != 0])
+    return set(i for i in active_validators if state.online_countdown[i] != 0)  # non-duplicate
 ```
 
 #### `get_shard_committee`

--- a/specs/phase1/custody-game.md
+++ b/specs/phase1/custody-game.md
@@ -554,7 +554,6 @@ def process_custody_slashing(state: BeaconState, signed_custody_slashing: Signed
         slash_validator(state, custody_slashing.whistleblower_index)
 ```
 
-
 ## Per-epoch processing
 
 ### Handling of reveal deadlines
@@ -586,7 +585,7 @@ def process_custody_final_updates(state: BeaconState) -> None:
 
     # Reset withdrawable epochs if challenge records are empty
     records = state.custody_chunk_challenge_records
-    validator_indices_in_records = set([record.responder_index for record in records])
+    validator_indices_in_records = set(record.responder_index for record in records)  # non-duplicate
     for index, validator in enumerate(state.validators):
         if validator.exit_epoch != FAR_FUTURE_EPOCH:
             not_all_secrets_are_revealed = validator.all_custody_secrets_revealed_epoch == FAR_FUTURE_EPOCH

--- a/specs/phase1/custody-game.md
+++ b/specs/phase1/custody-game.md
@@ -229,9 +229,11 @@ Given one set of data, return the custody atoms: each atom will be combined with
 
 ```python
 def get_custody_atoms(bytez: bytes) -> Sequence[bytes]:
-    bytez += b'\x00' * (-len(bytez) % BYTES_PER_CUSTODY_ATOM)  # right-padding
-    return [bytez[i:i + BYTES_PER_CUSTODY_ATOM]
-            for i in range(0, len(bytez), BYTES_PER_CUSTODY_ATOM)]
+    bytez += b'\x00' * ((BYTES_PER_CUSTODY_ATOM - len(bytez)) % BYTES_PER_CUSTODY_ATOM)  # right-padding
+    return [
+        bytez[i:i + BYTES_PER_CUSTODY_ATOM]
+        for i in range(0, len(bytez), BYTES_PER_CUSTODY_ATOM)
+    ]
 ```
 
 ### `get_custody_secrets`

--- a/specs/phase1/custody-game.md
+++ b/specs/phase1/custody-game.md
@@ -229,7 +229,8 @@ Given one set of data, return the custody atoms: each atom will be combined with
 
 ```python
 def get_custody_atoms(bytez: bytes) -> Sequence[bytes]:
-    bytez += b'\x00' * ((BYTES_PER_CUSTODY_ATOM - len(bytez)) % BYTES_PER_CUSTODY_ATOM)  # right-padding
+    length_remainder = len(bytez) % BYTES_PER_CUSTODY_ATOM
+    bytez += b'\x00' * ((BYTES_PER_CUSTODY_ATOM - length_remainder) % BYTES_PER_CUSTODY_ATOM)  # right-padding
     return [
         bytez[i:i + BYTES_PER_CUSTODY_ATOM]
         for i in range(0, len(bytez), BYTES_PER_CUSTODY_ATOM)

--- a/specs/phase1/validator.md
+++ b/specs/phase1/validator.md
@@ -162,7 +162,7 @@ def get_shard_winning_roots(state: BeaconState,
         committee = get_beacon_committee(state, on_time_attestation_slot, committee_index)
 
         # Loop over all shard transition roots, looking for a winning root
-        shard_transition_roots = set([a.data.shard_transition_root for a in shard_attestations])
+        shard_transition_roots = set(a.data.shard_transition_root for a in shard_attestations)  # non-duplicate
         for shard_transition_root in sorted(shard_transition_roots):
             transition_attestations = [
                 a for a in shard_attestations


### PR DESCRIPTION
### Issue
Fix #1923

### How did I fix it
- Change `(-len(bytez) % BYTES_PER_CUSTODY_ATOM)` to `((BYTES_PER_CUSTODY_ATOM - (len(bytez) % BYTES_PER_CUSTODY_ATOM)) % BYTES_PER_CUSTODY_ATOM)`
- Avoid negative index
- Some other minor refactoring

p.s. [`state.justification_bits[:-1]`](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase0/beacon-chain.md#justification-and-finalization) will be resolved in #1746 

/cc @ericsson49 