### PR TITLE
Update light committee for next slot

### DIFF
--- a/specs/phase1/beacon-chain.md
+++ b/specs/phase1/beacon-chain.md
@@ -1084,7 +1084,7 @@ def process_light_client_committee_updates(state: BeaconState) -> None:
     """
     Update light client committees.
     """
-    next_epoch = compute_epoch_at_slot(state.slot + 1)
+    next_epoch = compute_epoch_at_slot(Slot(state.slot + 1))
     if next_epoch % LIGHT_CLIENT_COMMITTEE_PERIOD == 0:
         state.current_light_committee = state.next_light_committee
         new_committee = get_light_client_committee(state, next_epoch + LIGHT_CLIENT_COMMITTEE_PERIOD)

--- a/specs/phase1/beacon-chain.md
+++ b/specs/phase1/beacon-chain.md
@@ -1084,8 +1084,9 @@ def process_light_client_committee_updates(state: BeaconState) -> None:
     """
     Update light client committees.
     """
-    if compute_epoch_at_slot(state.slot + 1) % LIGHT_CLIENT_COMMITTEE_PERIOD == 0:
+    next_epoch = compute_epoch_at_slot(state.slot + 1)
+    if next_epoch % LIGHT_CLIENT_COMMITTEE_PERIOD == 0:
         state.current_light_committee = state.next_light_committee
-        new_committee = get_light_client_committee(state, get_current_epoch(state) + LIGHT_CLIENT_COMMITTEE_PERIOD)
+        new_committee = get_light_client_committee(state, next_epoch + LIGHT_CLIENT_COMMITTEE_PERIOD)
         state.next_light_committee = committee_to_compact_committee(state, new_committee)
 ```

--- a/specs/phase1/beacon-chain.md
+++ b/specs/phase1/beacon-chain.md
@@ -1084,7 +1084,7 @@ def process_light_client_committee_updates(state: BeaconState) -> None:
     """
     Update light client committees.
     """
-    if get_current_epoch(state) % LIGHT_CLIENT_COMMITTEE_PERIOD == 0:
+    if compute_epoch_at_slot(state.slot + 1) % LIGHT_CLIENT_COMMITTEE_PERIOD == 0:
         state.current_light_committee = state.next_light_committee
         new_committee = get_light_client_committee(state, get_current_epoch(state) + LIGHT_CLIENT_COMMITTEE_PERIOD)
         state.next_light_committee = committee_to_compact_committee(state, new_committee)


### PR DESCRIPTION
I think this should update light client for the next slot since `state.slot = Slot(state.slot + 1)` happens after process epoch. This is similar to how we calculate current epoch start shard `get_start_shard(state, Slot(state.slot + 1))`

Another suggestion is to move `state.slot = Slot(state.slot + 1)` before `process_epoch(state)` so we can avoid these `+1`s