### PR TITLE
Fix `is_valid_fraud_proof` which tries to access `message` field of a `ShardBlock` instance

### DIFF
--- a/specs/phase1/shard-transition.md
+++ b/specs/phase1/shard-transition.md
@@ -133,7 +133,7 @@ def is_valid_fraud_proof(beacon_state: BeaconState,
     else:
         shard_state = transition.shard_states[offset_index - 1]  # Not doing the actual state updates here.
 
-    process_shard_block(shard_state, block.message)
+    process_shard_block(shard_state, block)
     if shard_state != transition.shard_states[offset_index]:
         return True
 


### PR DESCRIPTION
Though, the `message` field belongs to `SignedShardBlock`.
Found during py-specs transpilation.