### PR TITLE
Proposal for #1947: fix Vyper dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,13 +48,13 @@ commands:
     description: "Restore the venv from cache for the deposit contract compiler"
     steps:
       - restore_cached_venv:
-          venv_name: v20-deposit-contract-compiler
+          venv_name: v21-deposit-contract-compiler
           reqs_checksum: cache-{{ checksum "deposit_contract/compiler/requirements.txt" }}
   save_deposit_contract_compiler_cached_venv:
     description: "Save the venv to cache for later use of the deposit contract compiler"
     steps:
       - save_cached_venv:
-          venv_name: v20-deposit-contract-compiler
+          venv_name: v21-deposit-contract-compiler
           reqs_checksum: cache-{{ checksum "deposit_contract/compiler/requirements.txt" }}
           venv_path: ./deposit_contract/compiler/venv
   restore_deposit_contract_tester_cached_venv:
@@ -154,9 +154,6 @@ jobs:
       - restore_cache:
           key: v3-specs-repo-{{ .Branch }}-{{ .Revision }}
       - restore_deposit_contract_compiler_cached_venv
-      - run:
-          name: pip upgrade
-          command: python3.7 -m venv venv && . venv/bin/activate && pip3.7 install --upgrade pip setuptools wheel virtualenv
       - run:
           name: Install deposit contract compiler requirements
           command: make install_deposit_contract_compiler

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,26 +48,26 @@ commands:
     description: "Restore the venv from cache for the deposit contract compiler"
     steps:
       - restore_cached_venv:
-          venv_name: v19-deposit-contract-compiler
+          venv_name: v20-deposit-contract-compiler
           reqs_checksum: cache-{{ checksum "deposit_contract/compiler/requirements.txt" }}
   save_deposit_contract_compiler_cached_venv:
     description: "Save the venv to cache for later use of the deposit contract compiler"
     steps:
       - save_cached_venv:
-          venv_name: v19-deposit-contract-compiler
+          venv_name: v20-deposit-contract-compiler
           reqs_checksum: cache-{{ checksum "deposit_contract/compiler/requirements.txt" }}
           venv_path: ./deposit_contract/compiler/venv
   restore_deposit_contract_tester_cached_venv:
     description: "Restore the venv from cache for the deposit contract tester"
     steps:
       - restore_cached_venv:
-          venv_name: v19-deposit-contract-tester
+          venv_name: v20-deposit-contract-tester
           reqs_checksum: cache-{{ checksum "setup.py" }}-{{ checksum "deposit_contract/tester/requirements.txt" }}
   save_deposit_contract_tester_cached_venv:
     description: "Save the venv to cache for later use of the deposit contract tester"
     steps:
       - save_cached_venv:
-          venv_name: v19-deposit-contract-tester
+          venv_name: v20-deposit-contract-tester
           reqs_checksum: cache-{{ checksum "setup.py" }}-{{ checksum "deposit_contract/tester/requirements.txt" }}
           venv_path: ./deposit_contract/tester/venv
 jobs:
@@ -156,7 +156,7 @@ jobs:
       - restore_deposit_contract_compiler_cached_venv
       - run:
           name: pip upgrade
-          command: python3.7 -m venv venv && . venv/bin/activate && pip3.7 install setuptools==41.6.0
+          command: python3.7 -m venv venv && . venv/bin/activate && pip3.7 install --upgrade pip setuptools wheel virtualenv
       - run:
           name: Install deposit contract compiler requirements
           command: make install_deposit_contract_compiler

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,6 +155,9 @@ jobs:
           key: v3-specs-repo-{{ .Branch }}-{{ .Revision }}
       - restore_deposit_contract_compiler_cached_venv
       - run:
+          name: pip upgrade
+          command: python3.7 -m venv venv && . venv/bin/activate && pip3.7 install setuptools==41.6.0
+      - run:
           name: Install deposit contract compiler requirements
           command: make install_deposit_contract_compiler
       - save_deposit_contract_compiler_cached_venv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,39 +35,39 @@ commands:
     description: "Restore the cache with pyspec keys"
     steps:
       - restore_cached_venv:
-          venv_name: v20-pyspec
+          venv_name: v21-pyspec
           reqs_checksum: cache-{{ checksum "setup.py" }}
   save_pyspec_cached_venv:
     description: Save a venv into a cache with pyspec keys"
     steps:
       - save_cached_venv:
-          venv_name: v20-pyspec
+          venv_name: v21-pyspec
           reqs_checksum: cache-{{ checksum "setup.py" }}
           venv_path: ./venv
   restore_deposit_contract_compiler_cached_venv:
     description: "Restore the venv from cache for the deposit contract compiler"
     steps:
       - restore_cached_venv:
-          venv_name: v21-deposit-contract-compiler
+          venv_name: v22-deposit-contract-compiler
           reqs_checksum: cache-{{ checksum "deposit_contract/compiler/requirements.txt" }}
   save_deposit_contract_compiler_cached_venv:
     description: "Save the venv to cache for later use of the deposit contract compiler"
     steps:
       - save_cached_venv:
-          venv_name: v21-deposit-contract-compiler
+          venv_name: v22-deposit-contract-compiler
           reqs_checksum: cache-{{ checksum "deposit_contract/compiler/requirements.txt" }}
           venv_path: ./deposit_contract/compiler/venv
   restore_deposit_contract_tester_cached_venv:
     description: "Restore the venv from cache for the deposit contract tester"
     steps:
       - restore_cached_venv:
-          venv_name: v20-deposit-contract-tester
+          venv_name: v21-deposit-contract-tester
           reqs_checksum: cache-{{ checksum "setup.py" }}-{{ checksum "deposit_contract/tester/requirements.txt" }}
   save_deposit_contract_tester_cached_venv:
     description: "Save the venv to cache for later use of the deposit contract tester"
     steps:
       - save_cached_venv:
-          venv_name: v20-deposit-contract-tester
+          venv_name: v21-deposit-contract-tester
           reqs_checksum: cache-{{ checksum "setup.py" }}-{{ checksum "deposit_contract/tester/requirements.txt" }}
           venv_path: ./deposit_contract/tester/venv
 jobs:

--- a/deposit_contract/compiler/requirements.txt
+++ b/deposit_contract/compiler/requirements.txt
@@ -2,7 +2,6 @@
 # On top of this beta version, a later change was backported, and included in the formal verification:
 #   https://github.com/vyperlang/vyper/issues/1761
 # The resulting vyper version is pinned and maintained as protected branch.
-pandoc
 git+https://github.com/hwwhww/vyper@1761-HOTFIX-v0.1.0-beta.13-markdown
 
 pytest==3.6.1

--- a/deposit_contract/compiler/requirements.txt
+++ b/deposit_contract/compiler/requirements.txt
@@ -3,6 +3,6 @@
 #   https://github.com/vyperlang/vyper/issues/1761
 # The resulting vyper version is pinned and maintained as protected branch.
 pandoc
-git+https://github.com/vyperlang/vyper@1761-HOTFIX-v0.1.0-beta.13
+git+https://github.com/hwwhww/vyper@1761-HOTFIX-v0.1.0-beta.13-markdown
 
 pytest==3.6.1

--- a/setup.py
+++ b/setup.py
@@ -513,7 +513,6 @@ setup(
         "lint": ["flake8==3.7.7", "mypy==0.750"],
     },
     install_requires=[
-        "pandoc",
         "eth-utils>=1.3.0,<2",
         "eth-typing>=2.1.0,<3.0.0",
         "pycryptodome==3.9.4",


### PR DESCRIPTION
I found that the [`setuptools-markdown` lib using by Vyper](https://github.com/vyperlang/vyper/blob/1761-HOTFIX-v0.1.0-beta.13/setup.py#L68) has been [deprecated](https://github.com/msabramo/setuptools-markdown/pull/20). So it can be removed.

I uploaded a workaround under my repo: https://github.com/hwwhww/vyper/tree/1761-HOTFIX-v0.1.0-beta.13-markdown to remove [setuptools-markdown](https://github.com/hwwhww/vyper/commit/591adc1b30428b96e133c42daf1595e982f9e930). And then our CI error is gone 🎉 


@fubuloubu @@jacqueswww is it a correct solution that we should update to the upstream?