### PR TITLE
Match gossip v1.1 D_low, extend gossip_history param, add FAQ section

### DIFF
--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -1160,7 +1160,6 @@ Some examples of where messages could be duplicated:
   enough for `IWANT`s to respond to `IHAVE`s in the context of the shorter
   `heartbeat_interval`. If `mcache_gossip` is increased, this param should be
   increased to be at least `3` (~2 seconds) more than `mcache_gossip`.
-  should be increased to be at least 
 - `mcache_gossip`: 3, recommended default. This can be increased to 5 or 6
   (~4 seconds) if gossip times are longer than expected and the current window
   does not provide enough responsiveness during adverse conditions.

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -79,6 +79,7 @@ It consists of four main sections:
     - [Why must all clients use the same gossip topic instead of one negotiated between each peer pair?](#why-must-all-clients-use-the-same-gossip-topic-instead-of-one-negotiated-between-each-peer-pair)
     - [Why are the topics strings and not hashes?](#why-are-the-topics-strings-and-not-hashes)
     - [Why are we overriding the default libp2p pubsub `message-id`?](#why-are-we-overriding-the-default-libp2p-pubsub-message-id)
+    - [Why are these specific gossip parameters chosen?](#why-are-these-specific-gossip-parameters-chosen)
     - [Why is there `MAXIMUM_GOSSIP_CLOCK_DISPARITY` when validating slot ranges of messages in gossip subnets?](#why-is-there-maximum_gossip_clock_disparity-when-validating-slot-ranges-of-messages-in-gossip-subnets)
     - [Why are there `ATTESTATION_SUBNET_COUNT` attestation subnets?](#why-are-there-attestation_subnet_count-attestation-subnets)
     - [Why are attestations limited to be broadcast on gossip channels within `SLOTS_PER_EPOCH` slots?](#why-are-attestations-limited-to-be-broadcast-on-gossip-channels-within-slots_per_epoch-slots)
@@ -213,12 +214,12 @@ including the [gossipsub v1.1](https://github.com/libp2p/specs/blob/master/pubsu
 The following gossipsub [parameters](https://github.com/libp2p/specs/tree/master/pubsub/gossipsub#meshsub-an-overlay-mesh-router) will be used:
 
 - `D` (topic stable mesh target count): 6
-- `D_low` (topic stable mesh low watermark): 4
+- `D_low` (topic stable mesh low watermark): 5
 - `D_high` (topic stable mesh high watermark): 12
 - `D_lazy` (gossip target): 6
 - `fanout_ttl` (ttl for fanout maps for topics we are not subscribed to but have published to, seconds): 60
 - `gossip_advertise` (number of windows to gossip about): 3
-- `gossip_history` (number of heartbeat intervals to retain message IDs): 5
+- `gossip_history` (number of heartbeat intervals to retain message IDs): 385
 - `heartbeat_interval` (frequency of heartbeat, seconds): 1
 
 ### Topics and messages
@@ -1145,6 +1146,17 @@ Some examples of where messages could be duplicated:
 * Attestation aggregation strategies where clients partially aggregate attestations and propagate them.
   Partial aggregates could be duplicated
 * Clients re-publishing seen messages
+
+### Why are these specific gossip parameters chosen?
+
+- `D`, `D_low`, `D_high`, `D_lazy`: recommended defaults.
+- `fanout_ttl`: 60  (TODO: increase to cover an epoch?)
+- `gossip_advertise`: 3 (TODO: to increase to 6?)
+- `gossip_history`: `SLOTS_PER_EPOCH * SECONDS_PER_SLOT / heartbeat_interval = approx. 385`. Attestation validity is bounded by an epoch, so this is the safe max bound.
+- `heartbeat_interval`: 1 second, recommended default.
+  For Eth2 specifically, 0.6-0.7s was recommended in the [GossipSub evaluation report by Protocol Labs](https://gateway.ipfs.io/ipfs/QmRAFP5DBnvNjdYSbWhEhVRJJDFCLpPyvew5GwCCB4VxM4).
+  And this parameter will be experimented with in testnets.
+
 
 ### Why is there `MAXIMUM_GOSSIP_CLOCK_DISPARITY` when validating slot ranges of messages in gossip subnets?
 

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -1151,8 +1151,8 @@ Some examples of where messages could be duplicated:
 ### Why are these specific gossip parameters chosen?
 
 - `D`, `D_low`, `D_high`, `D_lazy`: recommended defaults.
-- `heartbeat_interval`: 0.7 second, recommended for eth2 in the [GossipSub evaluation report by Protocol Labs](https://gateway.ipfs.io/ipfs/QmRAFP5DBnvNjdYSbWhEhVRJJDFCLpPyvew5GwCCB4VxM4).
-- `fanout_ttl`: 60, recommended default.
+- `heartbeat_interval`: 0.7 seconds, recommended for eth2 in the [GossipSub evaluation report by Protocol Labs](https://gateway.ipfs.io/ipfs/QmRAFP5DBnvNjdYSbWhEhVRJJDFCLpPyvew5GwCCB4VxM4).
+- `fanout_ttl`: 60 seconds, recommended default.
   Fanout is primarily used by committees publishing attestations to subnets.
   This happens once per epoch per validator and the subnet changes each epoch
   so there is little to gain in having a `fanout_ttl` be increased from the recommended default.


### PR DESCRIPTION
This PR updates the gossip sub parameters in the spec:
- Match the `D_low` default recommend parameter [which changed in v1.1](https://github.com/libp2p/go-libp2p-pubsub/pull/263)
- rename `gossip_history`  to `mcache_len` to match param names in spec
- rename `gossip_advertise`  to `mcache_gossip` to match param names in spec
- add `seen_ttl` as seen in spec
- Change `heartbeat_interval` from 1s to 0.7s as per the recommendation of [v1.1 PL report](https://gateway.ipfs.io/ipfs/QmRAFP5DBnvNjdYSbWhEhVRJJDFCLpPyvew5GwCCB4VxM4) to allow for more responsiveness in the event that gossip is not performing optimally
- Change `mcache_len` from `5` to `6` to allow for at least ~2s for IWANT queries after IHAVEs have been sent. This it to match original time window but to compensate or our faster `heartbeat_interval` 
- Set `seen_ttl` to `550` to match the length of an epoch (contextualized by `heartbeat_interval`)
- Add a FAQ section to the spec, explaining the parameter choices.


