### PR TITLE
Fix block data root type

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -228,7 +228,7 @@ PHASE1_SUNDRY_FUNCTIONS = '''
 def get_block_data_merkle_root(data: ByteList) -> Root:
     # To get the Merkle root of the block data, we need the Merkle root without the length mix-in
     # The below implements this in the Remerkleable framework
-    return data.get_backing().get_left().merkle_root()
+    return Root(data.get_backing().get_left().merkle_root())
 
 
 _get_start_shard = get_start_shard


### PR DESCRIPTION
Fix block data root type, thanks @ericsson49 for highlighting the type issue.

The problem is that Root is a type in the specs, but remerkleable doesn't know about it, and returns bytes.
Or what it really does is wrapping it with `Root = NewType(bytes), but that's ignored during runtime, and different from the specs Root type, which is explicitly 32 bytes.

So we simply wrap it with `Root`, and it will be coerced into the specs type.



