### PR TITLE
change `get_custody_period_for_validator()` return type to `uint64`

### DIFF
--- a/specs/phase1/custody-game.md
+++ b/specs/phase1/custody-game.md
@@ -291,7 +291,7 @@ def get_randao_epoch_for_custody_period(period: uint64, validator_index: Validat
 ### `get_custody_period_for_validator`
 
 ```python
-def get_custody_period_for_validator(validator_index: ValidatorIndex, epoch: Epoch) -> int:
+def get_custody_period_for_validator(validator_index: ValidatorIndex, epoch: Epoch) -> uint64:
     '''
     Return the reveal period for a given validator.
     '''


### PR DESCRIPTION
There are type checking problems related to `get_custody_period_for_validator()` as it returns python `int`, however, it's expected to be `unit64` in several cases.
There are three kind of cases:
- the result of `int` type passed as a first argument to [`get_randao_epoch_for_custody_period()`](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase1/custody-game.md#get_custody_period_for_validator) which expects `unit64`.
- [`Validator.next_custody_secret_to_reveal`](next_custody_secret_to_reveal) of type `uint64` is set to the `get_custody_period_for_validator()` output.
- it's compared to a value of type `uint64`

The PR fixes the typing problem by changing return type to `uint64`. Actually, current implementation returns an instance of `Epoch`, which is a subclass of `uint64`, so such fix cannot change the spec behavior, just resolves the typing problem.