### PR TITLE
Fix epoch_boundary_block_root computation

### DIFF
--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -399,7 +399,7 @@ Set `attestation_data.beacon_block_root = hash_tree_root(head_block)`.
 *Note*: `epoch_boundary_block_root` can be looked up in the state using:
 
 - Let `start_slot = compute_start_slot_at_epoch(get_current_epoch(head_state))`.
-- Let `epoch_boundary_block_root = hash_tree_root(head_block) if start_slot == head_state.slot else get_block_root(state, start_slot)`.
+- Let `epoch_boundary_block_root = hash_tree_root(head_block) if start_slot == head_state.slot else get_block_root(state, get_current_epoch(head_state))`.
 
 #### Construct attestation
 


### PR DESCRIPTION
## What was done?
- Fixes `epoch_boundary_block_root` computation; it used to pass `start_slot` to `get_block_root` function while the function expects epoch instead