### PR TITLE
Configurable genesis time (implements #1894)

### DIFF
--- a/configs/mainnet/phase0.yaml
+++ b/configs/mainnet/phase0.yaml
@@ -77,7 +77,9 @@ BLS_WITHDRAWAL_PREFIX: 0x00
 # Time parameters
 # ---------------------------------------------------------------
 # 172800 seconds (2 days)
-GENESIS_DELAY: 172800
+MIN_GENESIS_DELAY: 172800
+# 86400 seconds (1 day)
+GENESIS_ALIGNMENT: 86400
 # 12 seconds
 SECONDS_PER_SLOT: 12
 # 2**0 (= 1) slots 12 seconds

--- a/configs/minimal/phase0.yaml
+++ b/configs/minimal/phase0.yaml
@@ -77,7 +77,9 @@ BLS_WITHDRAWAL_PREFIX: 0x00
 # Time parameters
 # ---------------------------------------------------------------
 # [customized] Faster to spin up testnets, but does not give validator reasonable warning time for genesis
-GENESIS_DELAY: 300
+MIN_GENESIS_DELAY: 300
+# [customized] Faster for testing purposes
+GENESIS_ALIGNMENT: 1
 # [customized] Faster for testing purposes
 SECONDS_PER_SLOT: 6
 # 2**0 (= 1) slots 6 seconds

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -218,7 +218,8 @@ The following values are (non-configurable) constants used throughout the specif
 
 | Name | Value | Unit | Duration |
 | - | - | :-: | :-: |
-| `GENESIS_DELAY` | `uint64(172800)` | seconds | 2 days |
+| `MIN_GENESIS_DELAY` | `uint64(172800)` | seconds | 2 days |
+| `GENESIS_ALIGNMENT` | `uint64(86400)` | seconds | 1 day |
 | `SECONDS_PER_SLOT` | `uint64(12)` | seconds | 12 seconds |
 | `SECONDS_PER_ETH1_BLOCK` | `uint64(14)` | seconds | 14 seconds |
 | `MIN_ATTESTATION_INCLUSION_DELAY` | `uint64(2**0)` (= 1) | slots | 12 seconds |
@@ -1135,7 +1136,7 @@ Before the Ethereum 2.0 genesis has been triggered, and for every Ethereum 1.0 b
 - `eth1_timestamp` is the Unix timestamp corresponding to `eth1_block_hash`
 - `deposits` is the sequence of all deposits, ordered chronologically, up to (and including) the block with hash `eth1_block_hash`
 
-Eth1 blocks must only be considered once they are at least `SECONDS_PER_ETH1_BLOCK * ETH1_FOLLOW_DISTANCE` seconds old (i.e. `eth1_timestamp + SECONDS_PER_ETH1_BLOCK * ETH1_FOLLOW_DISTANCE <= current_unix_time`). Due to this constraint, if `GENESIS_DELAY < SECONDS_PER_ETH1_BLOCK * ETH1_FOLLOW_DISTANCE`, then the `genesis_time` can happen before the time/state is first known. Values should be configured to avoid this case.
+Eth1 blocks must only be considered once they are at least `SECONDS_PER_ETH1_BLOCK * ETH1_FOLLOW_DISTANCE` seconds old (i.e. `eth1_timestamp + SECONDS_PER_ETH1_BLOCK * ETH1_FOLLOW_DISTANCE <= current_unix_time`). Due to this constraint, if `MIN_GENESIS_DELAY < SECONDS_PER_ETH1_BLOCK * ETH1_FOLLOW_DISTANCE`, then the `genesis_time` can happen before the time/state is first known. Values should be configured to avoid this case.
 
 ```python
 def initialize_beacon_state_from_eth1(eth1_block_hash: Bytes32,
@@ -1147,7 +1148,7 @@ def initialize_beacon_state_from_eth1(eth1_block_hash: Bytes32,
         epoch=GENESIS_EPOCH,
     )
     state = BeaconState(
-        genesis_time=eth1_timestamp + GENESIS_DELAY,
+        genesis_time=genesis_time=eth1_timestamp + MIN_GENESIS_DELAY + GENESIS_ALIGNMENT - eth1_timestamp % GENESIS_ALIGNMENT,
         fork=fork,
         eth1_data=Eth1Data(block_hash=eth1_block_hash, deposit_count=len(deposits)),
         latest_block_header=BeaconBlockHeader(body_root=hash_tree_root(BeaconBlockBody())),

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -1148,7 +1148,7 @@ def initialize_beacon_state_from_eth1(eth1_block_hash: Bytes32,
         epoch=GENESIS_EPOCH,
     )
     state = BeaconState(
-        genesis_time=genesis_time=eth1_timestamp + MIN_GENESIS_DELAY + GENESIS_ALIGNMENT - eth1_timestamp % GENESIS_ALIGNMENT,
+        genesis_time=eth1_timestamp + MIN_GENESIS_DELAY + GENESIS_ALIGNMENT - eth1_timestamp % GENESIS_ALIGNMENT,
         fork=fork,
         eth1_data=Eth1Data(block_hash=eth1_block_hash, deposit_count=len(deposits)),
         latest_block_header=BeaconBlockHeader(body_root=hash_tree_root(BeaconBlockBody())),

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -1428,7 +1428,7 @@ ENRs contain `fork_digest` which utilizes the `genesis_validators_root` for a cl
 so prior to knowing genesis, we cannot use `fork_digest` to cleanly find peers on our intended chain.
 Once genesis data is known, we can then form ENRs and safely find peers.
 
-When using an eth1 deposit contract for deposits, `fork_digest` will be known `GENESIS_DELAY` (48hours in mainnet configuration) before `genesis_time`,
+When using an eth1 deposit contract for deposits, `fork_digest` will be known at least `MIN_GENESIS_DELAY` (48hours in mainnet configuration) before `genesis_time`,
 providing ample time to find peers and form initial connections and gossip subnets prior to genesis.
 
 ## Compression/Encoding

--- a/tests/core/pyspec/eth2spec/test/genesis/test_initialization.py
+++ b/tests/core/pyspec/eth2spec/test/genesis/test_initialization.py
@@ -21,8 +21,8 @@ def test_initialize_beacon_state_from_eth1(spec):
     # initialize beacon_state
     state = spec.initialize_beacon_state_from_eth1(eth1_block_hash, eth1_timestamp, deposits)
 
-    genesis_time = eth1_timestamp + spec.MIN_GENESIS_DELAY + spec.GENESIS_ALIGNMENT - eth1_timestamp % spec.GENESIS_ALIGNMENT
-    assert state.genesis_time == genesis_time
+    genesis_delay = spec.MIN_GENESIS_DELAY + spec.GENESIS_ALIGNMENT - eth1_timestamp % spec.GENESIS_ALIGNMENT
+    assert state.genesis_time == eth1_timestamp + genesis_delay
     assert len(state.validators) == deposit_count
     assert state.eth1_data.deposit_root == deposit_root
     assert state.eth1_data.deposit_count == deposit_count
@@ -58,8 +58,8 @@ def test_initialize_beacon_state_some_small_balances(spec):
     # initialize beacon_state
     state = spec.initialize_beacon_state_from_eth1(eth1_block_hash, eth1_timestamp, deposits)
 
-    genesis_time = eth1_timestamp + spec.MIN_GENESIS_DELAY + spec.GENESIS_ALIGNMENT - eth1_timestamp % spec.GENESIS_ALIGNMENT
-    assert state.genesis_time == genesis_time
+    genesis_delay = spec.MIN_GENESIS_DELAY + spec.GENESIS_ALIGNMENT - eth1_timestamp % spec.GENESIS_ALIGNMENT
+    assert state.genesis_time == eth1_timestamp + genesis_delay
     assert len(state.validators) == small_deposit_count
     assert state.eth1_data.deposit_root == deposit_root
     assert state.eth1_data.deposit_count == len(deposits)

--- a/tests/core/pyspec/eth2spec/test/genesis/test_initialization.py
+++ b/tests/core/pyspec/eth2spec/test/genesis/test_initialization.py
@@ -21,7 +21,8 @@ def test_initialize_beacon_state_from_eth1(spec):
     # initialize beacon_state
     state = spec.initialize_beacon_state_from_eth1(eth1_block_hash, eth1_timestamp, deposits)
 
-    assert state.genesis_time == eth1_timestamp + spec.GENESIS_DELAY
+    genesis_time = eth1_timestamp + spec.MIN_GENESIS_DELAY + spec.GENESIS_ALIGNMENT - eth1_timestamp % spec.GENESIS_ALIGNMENT
+    assert state.genesis_time == genesis_time
     assert len(state.validators) == deposit_count
     assert state.eth1_data.deposit_root == deposit_root
     assert state.eth1_data.deposit_count == deposit_count
@@ -57,7 +58,8 @@ def test_initialize_beacon_state_some_small_balances(spec):
     # initialize beacon_state
     state = spec.initialize_beacon_state_from_eth1(eth1_block_hash, eth1_timestamp, deposits)
 
-    assert state.genesis_time == eth1_timestamp + spec.GENESIS_DELAY
+    genesis_time = eth1_timestamp + spec.MIN_GENESIS_DELAY + spec.GENESIS_ALIGNMENT - eth1_timestamp % spec.GENESIS_ALIGNMENT
+    assert state.genesis_time == genesis_time
     assert len(state.validators) == small_deposit_count
     assert state.eth1_data.deposit_root == deposit_root
     assert state.eth1_data.deposit_count == len(deposits)


### PR DESCRIPTION
Implement #1894 to have a configurable genesis time. The minimal config uses `GENESIS_ALIGNMENT = 1` and the mainnet config uses `GENESIS_ALIGNMENT = 86400`.