### PR TITLE
add deposit chain id and network id to config

### DIFF
--- a/configs/mainnet/phase0.yaml
+++ b/configs/mainnet/phase0.yaml
@@ -51,6 +51,9 @@ SECONDS_PER_ETH1_BLOCK: 14
 
 # Deposit contract
 # ---------------------------------------------------------------
+# Ethereum PoW Mainnet
+DEPOSIT_CHAIN_ID: 1
+DEPOSIT_NETWORK_ID: 1
 # **TBD**
 DEPOSIT_CONTRACT_ADDRESS: 0x1234567890123456789012345678901234567890
 

--- a/configs/minimal/phase0.yaml
+++ b/configs/minimal/phase0.yaml
@@ -51,6 +51,9 @@ SECONDS_PER_ETH1_BLOCK: 14
 
 # Deposit contract
 # ---------------------------------------------------------------
+# Ethereum Goerli testnet
+DEPOSIT_CHAIN_ID: 5
+DEPOSIT_NETWORK_ID: 5
 # **TBD**
 DEPOSIT_CONTRACT_ADDRESS: 0x1234567890123456789012345678901234567890
 

--- a/specs/phase0/deposit-contract.md
+++ b/specs/phase0/deposit-contract.md
@@ -31,12 +31,14 @@ This document represents the specification for the beacon chain deposit contract
 
 | Name | Value |
 | - | - |
+| `DEPOSIT_CHAIN_ID` | `1` |
+| `DEPOSIT_NETWORK_ID` | `1` |
 | `DEPOSIT_CONTRACT_ADDRESS` | **TBD** |
 | `DEPOSIT_CONTRACT_TREE_DEPTH` | `2**5` (= 32) |
 
 ## Ethereum 1.0 deposit contract
 
-The initial deployment phases of Ethereum 2.0 are implemented without consensus changes to Ethereum 1.0. A deposit contract at address `DEPOSIT_CONTRACT_ADDRESS` is added to Ethereum 1.0 for deposits of ETH to the beacon chain. Validator balances will be withdrawable to the shards in Phase 2.
+The initial deployment phases of Ethereum 2.0 are implemented without consensus changes to Ethereum 1.0. A deposit contract at address `DEPOSIT_CONTRACT_ADDRESS` is added to Ethereum 1.0 chain defined by `DEPOSIT_CHAIN_ID` and `DEPOSIT_NETWORK_ID` for deposits of ETH to the beacon chain. Validator balances will be withdrawable to the shards in Phase 2.
 
 ### `deposit` function
 

--- a/specs/phase0/deposit-contract.md
+++ b/specs/phase0/deposit-contract.md
@@ -10,7 +10,7 @@
 
 - [Introduction](#introduction)
 - [Constants](#constants)
-  - [Contract](#contract)
+- [Configuration](#configuration)
 - [Ethereum 1.0 deposit contract](#ethereum-10-deposit-contract)
   - [`deposit` function](#deposit-function)
     - [Deposit amount](#deposit-amount)
@@ -27,14 +27,23 @@ This document represents the specification for the beacon chain deposit contract
 
 ## Constants
 
-### Contract
+The following values are (non-configurable) constants used throughout the specification.
+
+| Name | Value |
+| - | - |
+| `DEPOSIT_CONTRACT_TREE_DEPTH` | `2**5` (= 32) |
+
+## Configuration
+
+*Note*: The default mainnet configuration values are included here for spec-design purposes.
+The different configurations for mainnet, testnets, and YAML-based testing can be found in the [`configs/constant_presets`](../../configs) directory.
+These configurations are updated for releases and may be out of sync during `dev` changes.
 
 | Name | Value |
 | - | - |
 | `DEPOSIT_CHAIN_ID` | `1` |
 | `DEPOSIT_NETWORK_ID` | `1` |
 | `DEPOSIT_CONTRACT_ADDRESS` | **TBD** |
-| `DEPOSIT_CONTRACT_TREE_DEPTH` | `2**5` (= 32) |
 
 ## Ethereum 1.0 deposit contract
 

--- a/specs/phase0/deposit-contract.md
+++ b/specs/phase0/deposit-contract.md
@@ -38,7 +38,9 @@ This document represents the specification for the beacon chain deposit contract
 
 ## Ethereum 1.0 deposit contract
 
-The initial deployment phases of Ethereum 2.0 are implemented without consensus changes to Ethereum 1.0. A deposit contract at address `DEPOSIT_CONTRACT_ADDRESS` is added to Ethereum 1.0 chain defined by `DEPOSIT_CHAIN_ID` and `DEPOSIT_NETWORK_ID` for deposits of ETH to the beacon chain. Validator balances will be withdrawable to the shards in Phase 2.
+The initial deployment phases of Ethereum 2.0 are implemented without consensus changes to Ethereum 1.0. A deposit contract at address `DEPOSIT_CONTRACT_ADDRESS` is added to the Ethereum 1.0 chain defined by the [chain-id](https://eips.ethereum.org/EIPS/eip-155) -- `DEPOSIT_CHAIN_ID` -- and the network-id -- `DEPOSIT_NETWORK_ID` -- for deposits of ETH to the beacon chain. Validator balances will be withdrawable to the shards in Phase 2.
+
+_Note_: See [here](https://chainid.network/) for a comprehensive list of public Ethereum chain chain-id's and network-id's.
 
 ### `deposit` function
 

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -111,7 +111,7 @@ The validator constructs their `withdrawal_credentials` via the following:
 
 ### Submit deposit
 
-In Phase 0, all incoming validator deposits originate from the Ethereum 1.0 proof-of-work chain. Deposits are made to the [deposit contract](./deposit-contract.md) located at `DEPOSIT_CONTRACT_ADDRESS`.
+In Phase 0, all incoming validator deposits originate from the Ethereum 1.0 chain defined by `DEPOSIT_CHAIN_ID` and `DEPOSIT_NETWORK_ID`. Deposits are made to the [deposit contract](./deposit-contract.md) located at `DEPOSIT_CONTRACT_ADDRESS`.
 
 To submit a deposit:
 


### PR DESCRIPTION
add `DEPOSIT_CHAIN_ID` and `DEPOSIT_NETWORK_ID` to be able to define the eth1 network where the deposit contract lives. Up to this point, it's been implicit (and generally georli), but we need to be able to make a distinction as we move toward having both eth2 mainnet and testnets