### PR TITLE
Finality test generation PR, but with BLS enabled

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -141,11 +141,6 @@ def ceillog2(x: uint64) -> int:
     return (x - 1).bit_length()
 '''
 PHASE0_SUNDRY_FUNCTIONS = '''
-# Monkey patch hash cache
-_hash = hash
-hash_cache: Dict[bytes, Bytes32] = {}
-
-
 def get_eth1_data(block: Eth1Block) -> Eth1Data:
     """
     A stub function return mocking Eth1Data.
@@ -154,12 +149,6 @@ def get_eth1_data(block: Eth1Block) -> Eth1Data:
         deposit_root=block.deposit_root,
         deposit_count=block.deposit_count,
         block_hash=hash_tree_root(block))
-
-
-def hash(x: bytes) -> Bytes32:  # type: ignore
-    if x not in hash_cache:
-        hash_cache[x] = Bytes32(_hash(x))
-    return hash_cache[x]
 
 
 def cache_this(key_fn, value_fn, lru_size):  # type: ignore

--- a/tests/core/pyspec/eth2spec/test/conftest.py
+++ b/tests/core/pyspec/eth2spec/test/conftest.py
@@ -59,8 +59,8 @@ def bls_default(request):
 def bls_type(request):
     bls_type = request.config.getoption("--bls-type")
     if bls_type == "py_ecc":
-        bls_utils.bls = bls_utils.py_ecc_bls
+        bls_utils.use_py_ecc()
     elif bls_type == "milagro":
-        bls_utils.bls = bls_utils.milagro_bls
+        bls_utils.use_milagro()
     else:
         raise Exception(f"unrecognized bls type: {bls_type}")

--- a/tests/core/pyspec/eth2spec/test/phase0/finality/test_finality.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/finality/test_finality.py
@@ -1,4 +1,4 @@
-from eth2spec.test.context import PHASE0, spec_state_test, never_bls, with_all_phases, with_phases
+from eth2spec.test.context import PHASE0, spec_state_test, with_all_phases, with_phases
 from eth2spec.test.helpers.state import next_epoch_via_block
 from eth2spec.test.helpers.attestations import next_epoch_with_attestations
 
@@ -30,7 +30,6 @@ def check_finality(spec,
 
 @with_phases([PHASE0])
 @spec_state_test
-@never_bls
 def test_finality_no_updates_at_genesis(spec, state):
     assert spec.get_current_epoch(state) == spec.GENESIS_EPOCH
 
@@ -54,7 +53,6 @@ def test_finality_no_updates_at_genesis(spec, state):
 
 @with_all_phases
 @spec_state_test
-@never_bls
 def test_finality_rule_4(spec, state):
     # get past first two epochs that finality does not run on
     next_epoch_via_block(spec, state)
@@ -80,7 +78,6 @@ def test_finality_rule_4(spec, state):
 
 @with_all_phases
 @spec_state_test
-@never_bls
 def test_finality_rule_1(spec, state):
     # get past first two epochs that finality does not run on
     next_epoch_via_block(spec, state)
@@ -108,7 +105,6 @@ def test_finality_rule_1(spec, state):
 
 @with_all_phases
 @spec_state_test
-@never_bls
 def test_finality_rule_2(spec, state):
     # get past first two epochs that finality does not run on
     next_epoch_via_block(spec, state)
@@ -138,7 +134,6 @@ def test_finality_rule_2(spec, state):
 
 @with_all_phases
 @spec_state_test
-@never_bls
 def test_finality_rule_3(spec, state):
     """
     Test scenario described here

--- a/tests/core/pyspec/eth2spec/utils/bls.py
+++ b/tests/core/pyspec/eth2spec/utils/bls.py
@@ -14,6 +14,22 @@ Z2_SIGNATURE = b'\xc0' + b'\x00' * 95
 STUB_COORDINATES = _signature_to_G2(Z2_SIGNATURE)
 
 
+def use_milagro():
+    """
+    Shortcut to use Milagro as BLS library
+    """
+    global bls
+    bls = milagro_bls
+
+
+def use_py_ecc():
+    """
+    Shortcut to use Py-ecc as BLS library
+    """
+    global bls
+    bls = py_ecc_bls
+
+
 def only_with_bls(alt_return=None):
     """
     Decorator factory to make a function only run when BLS is active. Otherwise return the default.

--- a/tests/generators/bls/main.py
+++ b/tests/generators/bls/main.py
@@ -321,6 +321,7 @@ def create_provider(handler_name: str,
 
 
 if __name__ == "__main__":
+    bls.use_py_ecc()  # Py-ecc is chosen instead of Milagro, since the code is better understood to be correct.
     gen_runner.run_generator("bls", [
         create_provider('sign', case01_sign),
         create_provider('verify', case02_verify),

--- a/tests/generators/epoch_processing/main.py
+++ b/tests/generators/epoch_processing/main.py
@@ -14,6 +14,7 @@ from gen_from_tests.gen import generate_from_tests
 from importlib import reload
 from eth2spec.config import config_util
 from eth2spec.test.context import PHASE0
+from eth2spec.utils import bls
 
 
 def create_provider(handler_name: str, tests_src, config_name: str) -> gen_typing.TestProvider:
@@ -22,6 +23,7 @@ def create_provider(handler_name: str, tests_src, config_name: str) -> gen_typin
         config_util.prepare_config(configs_path, config_name)
         reload(spec_phase0)
         reload(spec_phase1)
+        bls.use_milagro()
         return config_name
 
     def cases_fn() -> Iterable[gen_typing.TestCase]:

--- a/tests/generators/finality/main.py
+++ b/tests/generators/finality/main.py
@@ -9,6 +9,7 @@ from eth2spec.test.phase0.finality import test_finality
 from eth2spec.config import config_util
 from eth2spec.phase0 import spec as spec_phase0
 from eth2spec.phase1 import spec as spec_phase1
+from eth2spec.utils import bls
 
 
 def create_provider(handler_name: str, tests_src, config_name: str) -> gen_typing.TestProvider:
@@ -17,6 +18,7 @@ def create_provider(handler_name: str, tests_src, config_name: str) -> gen_typin
         config_util.prepare_config(configs_path, config_name)
         reload(spec_phase0)
         reload(spec_phase1)
+        bls.use_milagro()
         return config_name
 
     def cases_fn() -> Iterable[gen_typing.TestCase]:

--- a/tests/generators/genesis/main.py
+++ b/tests/generators/genesis/main.py
@@ -8,6 +8,7 @@ from gen_from_tests.gen import generate_from_tests
 from eth2spec.phase0 import spec as spec
 from importlib import reload
 from eth2spec.config import config_util
+from eth2spec.utils import bls
 
 
 def create_provider(handler_name: str, tests_src, config_name: str) -> gen_typing.TestProvider:
@@ -15,6 +16,7 @@ def create_provider(handler_name: str, tests_src, config_name: str) -> gen_typin
     def prepare_fn(configs_path: str) -> str:
         config_util.prepare_config(configs_path, config_name)
         reload(spec)
+        bls.use_milagro()
         return config_name
 
     def cases_fn() -> Iterable[gen_typing.TestCase]:

--- a/tests/generators/operations/main.py
+++ b/tests/generators/operations/main.py
@@ -16,6 +16,7 @@ from eth2spec.config import config_util
 from eth2spec.phase0 import spec as spec_phase0
 from eth2spec.phase1 import spec as spec_phase1
 from eth2spec.test.context import PHASE0
+from eth2spec.utils import bls
 
 
 def create_provider(handler_name: str, tests_src, config_name: str) -> gen_typing.TestProvider:
@@ -24,6 +25,7 @@ def create_provider(handler_name: str, tests_src, config_name: str) -> gen_typin
         config_util.prepare_config(configs_path, config_name)
         reload(spec_phase0)
         reload(spec_phase1)
+        bls.use_milagro()
         return config_name
 
     def cases_fn() -> Iterable[gen_typing.TestCase]:

--- a/tests/generators/rewards/main.py
+++ b/tests/generators/rewards/main.py
@@ -12,6 +12,7 @@ from gen_from_tests.gen import generate_from_tests
 from importlib import reload
 from eth2spec.config import config_util
 from eth2spec.test.context import PHASE0
+from eth2spec.utils import bls
 
 
 def create_provider(tests_src, config_name: str) -> gen_typing.TestProvider:
@@ -20,6 +21,7 @@ def create_provider(tests_src, config_name: str) -> gen_typing.TestProvider:
         config_util.prepare_config(configs_path, config_name)
         reload(spec_phase0)
         reload(spec_phase1)
+        bls.use_milagro()
         return config_name
 
     def cases_fn() -> Iterable[gen_typing.TestCase]:

--- a/tests/generators/sanity/main.py
+++ b/tests/generators/sanity/main.py
@@ -9,6 +9,7 @@ from eth2spec.test.phase0.sanity import test_blocks, test_slots
 from eth2spec.config import config_util
 from eth2spec.phase0 import spec as spec_phase0
 from eth2spec.phase1 import spec as spec_phase1
+from eth2spec.utils import bls
 
 
 def create_provider(handler_name: str, tests_src, config_name: str) -> gen_typing.TestProvider:
@@ -17,6 +18,7 @@ def create_provider(handler_name: str, tests_src, config_name: str) -> gen_typin
         config_util.prepare_config(configs_path, config_name)
         reload(spec_phase0)
         reload(spec_phase1)
+        bls.use_milagro()
         return config_name
 
     def cases_fn() -> Iterable[gen_typing.TestCase]:


### PR DESCRIPTION
- Enable BLS in finality tests
- Use Milagro BLS in state-transition tests, makes test-generation faster, more bearable
- Remove old hash monkey-patch: a long time ago it used to help with SSZ speed, but right now it's only doing some caching within the shuffling function. However, the shuffling is already cached, so it doesn't help much. At the same time, 100.000+ hashes are made during test generation of large shuffling lists, putting them all in the hash cache (since they are mostly unique) should be avoided.
