### PR TITLE
Add self-consistency check to attestation gossip validation

### DIFF
--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -403,6 +403,8 @@ The following validations MUST pass before forwarding the `attestation` on the s
 - _[REJECT]_ The current `finalized_checkpoint` is an ancestor of the `block` defined by `attestation.data.beacon_block_root` -- i.e.
   `get_ancestor(store, attestation.data.beacon_block_root, compute_start_slot_at_epoch(store.finalized_checkpoint.epoch))
   == store.finalized_checkpoint.root`
+- _[REJECT]_ The attestation's epoch matches its target -- i.e. `attestation.data.target.epoch ==
+  compute_epoch_at_slot(attestation.data.slot)`
 
 
 

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -391,6 +391,8 @@ The following validations MUST pass before forwarding the `attestation` on the s
   (within a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance) --
   i.e. `attestation.data.slot + ATTESTATION_PROPAGATION_SLOT_RANGE >= current_slot >= attestation.data.slot`
   (a client MAY queue future attestations for processing at the appropriate slot).
+- _[REJECT]_ The attestation's epoch matches its target -- i.e. `attestation.data.target.epoch ==
+  compute_epoch_at_slot(attestation.data.slot)`
 - _[REJECT]_ The attestation is unaggregated --
   that is, it has exactly one participating validator (`len([bit in bit attestation.aggregation_bits if bit]) == 1`, i.e. exactly 1 bit is set).
 - _[IGNORE]_ There has been no other valid attestation seen on an attestation subnet
@@ -400,11 +402,12 @@ The following validations MUST pass before forwarding the `attestation` on the s
   (via both gossip and non-gossip sources)
   (a client MAY queue aggregates for processing once block is retrieved).
 - _[REJECT]_ The block being voted for (`attestation.data.beacon_block_root`) passes validation.
+- _[REJECT]_ The attestation's target block is an ancestor of the block named in the LMD vote -- i.e.
+  `get_ancestor(store, attestation.data.beacon_block_root, compute_start_slot_at_epoch(attestation.data.target.epoch)) == attestation.data.target.root`
 - _[REJECT]_ The current `finalized_checkpoint` is an ancestor of the `block` defined by `attestation.data.beacon_block_root` -- i.e.
   `get_ancestor(store, attestation.data.beacon_block_root, compute_start_slot_at_epoch(store.finalized_checkpoint.epoch))
   == store.finalized_checkpoint.root`
-- _[REJECT]_ The attestation's epoch matches its target -- i.e. `attestation.data.target.epoch ==
-  compute_epoch_at_slot(attestation.data.slot)`
+
 
 
 


### PR DESCRIPTION
Addresses https://github.com/ethereum/eth2.0-specs/issues/1998 and #2001

Namely, adds a `REJECT` stipulation if attestation's target epoch differs from that of the attestation itself, and `REJECT` condition if the attestations target root is not in the chain defined by the LMD vote