### PR TITLE
Disable these 2 tests in phase 1 due to #1974 Issue 3

### DIFF
--- a/tests/core/pyspec/eth2spec/test/phase0/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/sanity/test_blocks.py
@@ -762,7 +762,7 @@ def prepare_signed_exits(spec, state, indices):
 # exceeding the minimal-config randao mixes memory size.
 # Applies to all voluntary-exit sanity block tests.
 
-@with_all_phases
+@with_phases([PHASE0])
 @spec_state_test
 def test_voluntary_exit(spec, state):
     validator_index = spec.get_active_validator_indices(state, spec.get_current_epoch(state))[-1]
@@ -811,7 +811,7 @@ def test_double_validator_exit_same_block(spec, state):
     yield 'post', None
 
 
-@with_all_phases
+@with_phases([PHASE0])
 @spec_state_test
 def test_multiple_different_validator_exits_same_block(spec, state):
     validator_indices = [


### PR DESCRIPTION
#1989 enabled BLS in CI and #1971 enabled `eth2spec/test/phase0/sanity/test_blocks.py::test_voluntary_exit ` and `eth2spec/test/phase0/sanity/test_blocks.py::test_multiple_different_validator_exits_same_block` with phase 1 spec.

Because of #1974 Issue 3, these two tests are broken now. I should have merged `dev` branch to #1989 again before merging #1989! This is a hotfix of CI.