### PR TITLE
apply_shard_transition: validate shard_parent_root

### DIFF
--- a/specs/phase1/beacon-chain.md
+++ b/specs/phase1/beacon-chain.md
@@ -851,6 +851,7 @@ def apply_shard_transition(state: BeaconState, shard: Shard, transition: ShardTr
                 body_root=transition.shard_data_roots[i]
             )
             shard_parent_root = hash_tree_root(header)
+            assert shard_state.latest_block_root == shard_parent_root
             headers.append(header)
             proposers.append(proposal_index)
         else:


### PR DESCRIPTION
My gut feeling is we are missing an assertion for `shard_parent_root`. I think the `shard_parent_root` should equal to `shard_state`'s `latest_block_root`. Opening this PR for discussions, feel free to let me know if I'm wrong 😅 