### PR TITLE
Fix active shard count issues

### DIFF
--- a/specs/phase1/beacon-chain.md
+++ b/specs/phase1/beacon-chain.md
@@ -47,6 +47,7 @@
     - [`compute_updated_gasprice`](#compute_updated_gasprice)
     - [`compute_committee_source_epoch`](#compute_committee_source_epoch)
   - [Beacon state accessors](#beacon-state-accessors)
+    - [New `get_committee_count_per_slot`](#new-get_committee_count_per_slot)
     - [`get_active_shard_count`](#get_active_shard_count)
     - [`get_online_validator_indices`](#get_online_validator_indices)
     - [`get_shard_committee`](#get_shard_committee)

--- a/specs/phase1/beacon-chain.md
+++ b/specs/phase1/beacon-chain.md
@@ -47,7 +47,7 @@
     - [`compute_updated_gasprice`](#compute_updated_gasprice)
     - [`compute_committee_source_epoch`](#compute_committee_source_epoch)
   - [Beacon state accessors](#beacon-state-accessors)
-    - [New `get_committee_count_per_slot`](#new-get_committee_count_per_slot)
+    - [Updated `get_committee_count_per_slot`](#updated-get_committee_count_per_slot)
     - [`get_active_shard_count`](#get_active_shard_count)
     - [`get_online_validator_indices`](#get_online_validator_indices)
     - [`get_shard_committee`](#get_shard_committee)
@@ -522,7 +522,7 @@ def compute_committee_source_epoch(epoch: Epoch, period: uint64) -> Epoch:
 
 ### Beacon state accessors
 
-#### New `get_committee_count_per_slot`
+#### Updated `get_committee_count_per_slot`
 
 ```python
 def get_committee_count_per_slot(state: BeaconState, epoch: Epoch) -> uint64:
@@ -539,6 +539,10 @@ def get_committee_count_per_slot(state: BeaconState, epoch: Epoch) -> uint64:
 
 ```python
 def get_active_shard_count(state: BeaconState) -> uint64:
+    """
+    Return the number of active shards.
+    Note that this puts an upper bound on the number of committees per slot.
+    """
     return INITIAL_ACTIVE_SHARDS
 ```
 

--- a/specs/phase1/phase1-fork.md
+++ b/specs/phase1/phase1-fork.md
@@ -36,7 +36,6 @@ Warning: this configuration is not definitive.
 | - | - |
 | `PHASE_1_FORK_VERSION` | `Version('0x01000000')` |
 | `PHASE_1_FORK_SLOT` | `Slot(0)` **TBD** |
-| `INITIAL_ACTIVE_SHARDS` | `2**6` (= 64) |
 
 ## Fork to Phase 1
 

--- a/tests/core/pyspec/eth2spec/test/conftest.py
+++ b/tests/core/pyspec/eth2spec/test/conftest.py
@@ -31,7 +31,7 @@ def pytest_addoption(parser):
         help="config: make the pyspec use the specified configuration"
     )
     parser.addoption(
-        "--disable-bls", action="store_true",
+        "--disable-bls", action="store_true", default=False,
         help="bls-default: make tests that are not dependent on BLS run without BLS"
     )
     parser.addoption(
@@ -50,11 +50,7 @@ def config(request):
 
 @fixture(autouse=True)
 def bls_default(request):
-    try:
-        disable_bls = request.config.getoption("--disable-bls")
-    except ValueError:
-        disable_bls = False
-
+    disable_bls = request.config.getoption("--disable-bls")
     if disable_bls:
         context.DEFAULT_BLS_ACTIVE = False
 

--- a/tests/core/pyspec/eth2spec/test/conftest.py
+++ b/tests/core/pyspec/eth2spec/test/conftest.py
@@ -50,7 +50,11 @@ def config(request):
 
 @fixture(autouse=True)
 def bls_default(request):
-    disable_bls = request.config.getoption("--disable-bls")
+    try:
+        disable_bls = request.config.getoption("--disable-bls")
+    except ValueError:
+        disable_bls = False
+
     if disable_bls:
         context.DEFAULT_BLS_ACTIVE = False
 

--- a/tests/core/pyspec/eth2spec/test/context.py
+++ b/tests/core/pyspec/eth2spec/test/context.py
@@ -151,6 +151,15 @@ def low_single_balance(spec):
     return [1]
 
 
+def large_validator_set(spec):
+    """
+    Helper method to create a series of default balances.
+    Usage: `@with_custom_state(balances_fn=default_balances, ...)`
+    """
+    num_validators = 2 * spec.SLOTS_PER_EPOCH * spec.MAX_COMMITTEES_PER_SLOT * spec.TARGET_COMMITTEE_SIZE
+    return [spec.MAX_EFFECTIVE_BALANCE] * num_validators
+
+
 def single_phase(fn):
     """
     Decorator that filters out the phases data.

--- a/tests/core/pyspec/eth2spec/test/phase0/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/sanity/test_blocks.py
@@ -73,11 +73,9 @@ def test_same_slot_block_transition(spec, state):
 def test_empty_block_transition(spec, state):
     pre_slot = state.slot
     pre_eth1_votes = len(state.eth1_data_votes)
+    pre_mix = spec.get_randao_mix(state, spec.get_current_epoch(state))
 
     yield 'pre', state
-
-    # Ensure pre-state has default randao
-    assert spec.get_randao_mix(state, spec.get_current_epoch(state)) == spec.Bytes32()
 
     block = build_empty_block_for_next_slot(spec, state)
 
@@ -88,7 +86,7 @@ def test_empty_block_transition(spec, state):
 
     assert len(state.eth1_data_votes) == pre_eth1_votes + 1
     assert spec.get_block_root_at_slot(state, pre_slot) == signed_block.message.parent_root
-    assert spec.get_randao_mix(state, spec.get_current_epoch(state)) != spec.Bytes32()
+    assert spec.get_randao_mix(state, spec.get_current_epoch(state)) != pre_mix
 
 
 @with_all_phases
@@ -98,11 +96,9 @@ def test_empty_block_transition(spec, state):
 def test_empty_block_transition_large_validator_set(spec, state):
     pre_slot = state.slot
     pre_eth1_votes = len(state.eth1_data_votes)
+    pre_mix = spec.get_randao_mix(state, spec.get_current_epoch(state))
 
     yield 'pre', state
-
-    # Ensure pre-state has default randao
-    assert spec.get_randao_mix(state, spec.get_current_epoch(state)) == spec.Bytes32()
 
     block = build_empty_block_for_next_slot(spec, state)
 
@@ -113,7 +109,7 @@ def test_empty_block_transition_large_validator_set(spec, state):
 
     assert len(state.eth1_data_votes) == pre_eth1_votes + 1
     assert spec.get_block_root_at_slot(state, pre_slot) == signed_block.message.parent_root
-    assert spec.get_randao_mix(state, spec.get_current_epoch(state)) != spec.Bytes32()
+    assert spec.get_randao_mix(state, spec.get_current_epoch(state)) != pre_mix
 
 
 def process_and_sign_block_without_header_validations(spec, state, block):

--- a/tests/core/pyspec/eth2spec/test/phase0/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/sanity/test_blocks.py
@@ -22,7 +22,10 @@ from eth2spec.test.helpers.shard_transitions import get_shard_transition_of_comm
 
 from eth2spec.test.context import (
     PHASE0, PHASE1,
+    spec_test,
     spec_state_test, with_all_phases, expect_assertion_error, always_bls, with_phases,
+    with_custom_state, single_phase,
+    large_validator_set,
 )
 
 
@@ -68,6 +71,28 @@ def test_same_slot_block_transition(spec, state):
 @with_all_phases
 @spec_state_test
 def test_empty_block_transition(spec, state):
+    pre_slot = state.slot
+    pre_eth1_votes = len(state.eth1_data_votes)
+
+    yield 'pre', state
+
+    block = build_empty_block_for_next_slot(spec, state)
+
+    signed_block = state_transition_and_sign_block(spec, state, block)
+
+    yield 'blocks', [signed_block]
+    yield 'post', state
+
+    assert len(state.eth1_data_votes) == pre_eth1_votes + 1
+    assert spec.get_block_root_at_slot(state, pre_slot) == signed_block.message.parent_root
+    assert spec.get_randao_mix(state, spec.get_current_epoch(state)) != spec.Bytes32()
+
+
+@with_all_phases
+@spec_test
+@with_custom_state(balances_fn=large_validator_set, threshold_fn=lambda spec: spec.EJECTION_BALANCE)
+@single_phase
+def test_empty_block_transition_large_validator_set(spec, state):
     pre_slot = state.slot
     pre_eth1_votes = len(state.eth1_data_votes)
 
@@ -273,6 +298,26 @@ def test_skipped_slots(spec, state):
 @with_all_phases
 @spec_state_test
 def test_empty_epoch_transition(spec, state):
+    pre_slot = state.slot
+    yield 'pre', state
+
+    block = build_empty_block(spec, state, state.slot + spec.SLOTS_PER_EPOCH)
+
+    signed_block = state_transition_and_sign_block(spec, state, block)
+
+    yield 'blocks', [signed_block]
+    yield 'post', state
+
+    assert state.slot == block.slot
+    for slot in range(pre_slot, state.slot):
+        assert spec.get_block_root_at_slot(state, slot) == block.parent_root
+
+
+@with_all_phases
+@spec_test
+@with_custom_state(balances_fn=large_validator_set, threshold_fn=lambda spec: spec.EJECTION_BALANCE)
+@single_phase
+def test_empty_epoch_transition_large_validator_set(spec, state):
     pre_slot = state.slot
     yield 'pre', state
 

--- a/tests/core/pyspec/eth2spec/test/phase0/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/sanity/test_blocks.py
@@ -76,6 +76,9 @@ def test_empty_block_transition(spec, state):
 
     yield 'pre', state
 
+    # Ensure pre-state has default randao
+    assert spec.get_randao_mix(state, spec.get_current_epoch(state)) == spec.Bytes32()
+
     block = build_empty_block_for_next_slot(spec, state)
 
     signed_block = state_transition_and_sign_block(spec, state, block)
@@ -97,6 +100,9 @@ def test_empty_block_transition_large_validator_set(spec, state):
     pre_eth1_votes = len(state.eth1_data_votes)
 
     yield 'pre', state
+
+    # Ensure pre-state has default randao
+    assert spec.get_randao_mix(state, spec.get_current_epoch(state)) == spec.Bytes32()
 
     block = build_empty_block_for_next_slot(spec, state)
 

--- a/tests/core/pyspec/eth2spec/test/phase1/unittests/test_get_start_shard.py
+++ b/tests/core/pyspec/eth2spec/test/phase1/unittests/test_get_start_shard.py
@@ -74,3 +74,16 @@ def test_get_start_shard_previous_slot(spec, state):
         - spec.get_committee_count_delta(state, start_slot=slot, stop_slot=current_epoch_start_slot)
     ) % active_shard_count
     assert start_shard == expected_start_shard
+
+
+@with_all_phases_except([PHASE0])
+@spec_state_test
+def test_get_start_shard_far_past_epoch(spec, state):
+    initial_epoch = spec.get_current_epoch(state)
+    initial_start_slot = spec.compute_start_slot_at_epoch(initial_epoch)
+    initial_start_shard = state.current_epoch_start_shard
+
+    for _ in range(spec.MAX_SHARDS + 2):
+        next_epoch(spec, state)
+
+    assert spec.get_start_shard(state, initial_start_slot) == initial_start_shard


### PR DESCRIPTION
`get_active_shard_count` was incorrectly using `len(state.shard_states)` which actually returned `MAX_SHARDS`. I also uncovered a couple of other small bugs in relation to the usage of active shard count.

Thanks @mkalinin for pointing out the initial exception (see first bullet point)!

changes:
* `get_active_shard_count` uses `INITIAL_ACTIVE_SHARDS`. This could result in an exception when # committees per slot exceeded `MAX_COMMITTTEES_PER_SLOT` (which it should be able to)
* `get_committee_count_per_slot` is rewritten for phase 1 to use `get_active_shard_count` as defining the upper range on the max committees per slot
* `get_start_shard` was incorrectly `max_committees_per_epoch * active_shard_count` as the "ensure positive" offset. Instead it should be the `max_committees_per_slot * slot_lookback`

tests:
* added unittest for `get_start_shard` that tests a long start shard lookback (which before the fix triggers an erroneous negative value)
* added two tests for a larger validator set in phase0/1 sanity tests. One for empty block transition, one for empty epoch transition. Tested that an error was thrown on the empty epoch transition test before the fixes from above were integrated
