### PR TITLE
apply_shard_transition: copy shard state

### DIFF
--- a/specs/phase1/beacon-chain.md
+++ b/specs/phase1/beacon-chain.md
@@ -867,7 +867,7 @@ def apply_shard_transition(state: BeaconState, shard: Shard, transition: ShardTr
     # Verify combined proposer signature
     assert optional_aggregate_verify(pubkeys, signing_roots, transition.proposer_signature_aggregate)
 
-    # Save updated state
+    # Copy and save updated shard state
     shard_state = copy(transition.shard_states[len(transition.shard_states) - 1])
     shard_state.slot = compute_previous_slot(state.slot)
     state.shard_states[shard] = shard_state

--- a/specs/phase1/beacon-chain.md
+++ b/specs/phase1/beacon-chain.md
@@ -868,8 +868,9 @@ def apply_shard_transition(state: BeaconState, shard: Shard, transition: ShardTr
     assert optional_aggregate_verify(pubkeys, signing_roots, transition.proposer_signature_aggregate)
 
     # Save updated state
-    state.shard_states[shard] = transition.shard_states[len(transition.shard_states) - 1]
-    state.shard_states[shard].slot = compute_previous_slot(state.slot)
+    shard_state = transition.shard_states[len(transition.shard_states) - 1].copy()
+    shard_state.slot = compute_previous_slot(state.slot)
+    state.shard_states[shard] = shard_state
 ```
 
 ###### `process_crosslink_for_shard`

--- a/specs/phase1/beacon-chain.md
+++ b/specs/phase1/beacon-chain.md
@@ -868,7 +868,7 @@ def apply_shard_transition(state: BeaconState, shard: Shard, transition: ShardTr
     assert optional_aggregate_verify(pubkeys, signing_roots, transition.proposer_signature_aggregate)
 
     # Save updated state
-    shard_state = transition.shard_states[len(transition.shard_states) - 1].copy()
+    shard_state = copy(transition.shard_states[len(transition.shard_states) - 1])
     shard_state.slot = compute_previous_slot(state.slot)
     state.shard_states[shard] = shard_state
 ```


### PR DESCRIPTION
It feels a bit odd to be mutating `transition`'s last `shard_state`'s slot to latest beacon state slot in the event of a skip slots. I'm not entirely sure what the implications are, but a copy feels safer?