### PR TITLE
Make `cellog2` return `uint64`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -152,8 +152,8 @@ GeneralizedIndex = NewType('GeneralizedIndex', int)
 SSZObject = TypeVar('SSZObject', bound=View)
 '''
 SUNDRY_CONSTANTS_FUNCTIONS = '''
-def ceillog2(x: uint64) -> int:
-    return (x - 1).bit_length()
+def ceillog2(x: uint64) -> uint64:
+    return uint64((x - 1).bit_length())
 '''
 PHASE0_SUNDRY_FUNCTIONS = '''
 def get_eth1_data(block: Eth1Block) -> Eth1Data:

--- a/setup.py
+++ b/setup.py
@@ -152,7 +152,9 @@ GeneralizedIndex = NewType('GeneralizedIndex', int)
 SSZObject = TypeVar('SSZObject', bound=View)
 '''
 SUNDRY_CONSTANTS_FUNCTIONS = '''
-def ceillog2(x: uint64) -> uint64:
+def ceillog2(x: int) -> uint64:
+    if x < 1:
+        raise ValueError(f"ceillog2 accepts only positive values, x={x}")
     return uint64((x - 1).bit_length())
 '''
 PHASE0_SUNDRY_FUNCTIONS = '''


### PR DESCRIPTION
`CUSTODY_RESPONSE_DEPTH` has type `int` as it's defined using `ceillog2` function which returns `int` type.
As a result, there is a type-checking problem in [process_chunk_challenge_response](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase1/custody-game.md#custody-chunk-response): `CUSTODY_RESPONSE_DEPTH+1` is passed as a `depth` argument to [is_valid_merkle_branch](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase0/beacon-chain.md#is_valid_merkle_branch), which should have type `uint64`.

One way to fix this is to modify `cellog2` function, so that it returns `uint64`.
