### PR TITLE
Non-substantive typing clean-up

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -125,6 +125,7 @@ from eth2spec.config.config_util import apply_constants_config
 from typing import (
     Any, Dict, Set, Sequence, NewType, Tuple, TypeVar, Callable, Optional
 )
+from typing import List as PyList
 
 from dataclasses import (
     dataclass,

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -773,7 +773,7 @@ def compute_committee(indices: Sequence[ValidatorIndex],
     Return the committee corresponding to ``indices``, ``seed``, ``index``, and committee ``count``.
     """
     start = (len(indices) * index) // count
-    end = (len(indices) * (index + 1)) // count
+    end = (len(indices) * uint64(index + 1)) // count
     return [indices[compute_shuffled_index(uint64(i), uint64(len(indices)), seed)] for i in range(start, end)]
 ```
 
@@ -1454,7 +1454,7 @@ def get_inclusion_delay_deltas(state: BeaconState) -> Tuple[Sequence[Gwei], Sequ
             if index in get_attesting_indices(state, a.data, a.aggregation_bits)
         ], key=lambda a: a.inclusion_delay)
         rewards[attestation.proposer_index] += get_proposer_reward(state, index)
-        max_attester_reward = get_base_reward(state, index) - get_proposer_reward(state, index)
+        max_attester_reward = Gwei(get_base_reward(state, index) - get_proposer_reward(state, index))
         rewards[index] += Gwei(max_attester_reward // attestation.inclusion_delay)
 
     # No penalties associated with inclusion delay
@@ -1574,7 +1574,7 @@ def process_final_updates(state: BeaconState) -> None:
     # Update effective balances with hysteresis
     for index, validator in enumerate(state.validators):
         balance = state.balances[index]
-        HYSTERESIS_INCREMENT = EFFECTIVE_BALANCE_INCREMENT // HYSTERESIS_QUOTIENT
+        HYSTERESIS_INCREMENT = uint64(EFFECTIVE_BALANCE_INCREMENT // HYSTERESIS_QUOTIENT)
         DOWNWARD_THRESHOLD = HYSTERESIS_INCREMENT * HYSTERESIS_DOWNWARD_MULTIPLIER
         UPWARD_THRESHOLD = HYSTERESIS_INCREMENT * HYSTERESIS_UPWARD_MULTIPLIER
         if (

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -168,7 +168,7 @@ def get_committee_assignment(state: BeaconState,
         * ``assignment[2]`` is the slot at which the committee is assigned
     Return None if no assignment.
     """
-    next_epoch = get_current_epoch(state) + 1
+    next_epoch = Epoch(get_current_epoch(state) + 1)
     assert epoch <= next_epoch
 
     start_slot = compute_start_slot_at_epoch(epoch)
@@ -460,7 +460,7 @@ def compute_subnet_for_attestation(committees_per_slot: uint64, slot: Slot, comm
     Compute the correct subnet for an attestation for Phase 0.
     Note, this mimics expected Phase 1 behavior where attestations will be mapped to their shard subnet.
     """
-    slots_since_epoch_start = slot % SLOTS_PER_EPOCH
+    slots_since_epoch_start = uint64(slot % SLOTS_PER_EPOCH)
     committees_since_epoch_start = committees_per_slot * slots_since_epoch_start
 
     return uint64((committees_since_epoch_start + committee_index) % ATTESTATION_SUBNET_COUNT)

--- a/specs/phase1/beacon-chain.md
+++ b/specs/phase1/beacon-chain.md
@@ -105,20 +105,20 @@ Configuration is not namespaced. Instead it is strictly an extension;
 
 | Name | Value |
 | - | - | 
-| `MAX_SHARDS` | `2**10` (= 1024) |
-| `INITIAL_ACTIVE_SHARDS` | `2**6` (= 64) |
-| `LIGHT_CLIENT_COMMITTEE_SIZE` | `2**7` (= 128) |
-| `GASPRICE_ADJUSTMENT_COEFFICIENT` | `2**3` (= 8) | 
+| `MAX_SHARDS` | `uint64(2**10)` (= 1024) |
+| `INITIAL_ACTIVE_SHARDS` | `uint64(2**6)` (= 64) |
+| `LIGHT_CLIENT_COMMITTEE_SIZE` | `uint64(2**7)` (= 128) |
+| `GASPRICE_ADJUSTMENT_COEFFICIENT` | `uint64(2**3)` (= 8) | 
 
 ### Shard block configs
 
 | Name | Value | Unit |
 | - | - | - |
-| `MAX_SHARD_BLOCK_SIZE` | `2**20` (= 1,048,576) | bytes |
-| `TARGET_SHARD_BLOCK_SIZE` | `2**18` (= 262,144) |  bytes |
-| `SHARD_BLOCK_OFFSETS` | `[1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233]` | - |
+| `MAX_SHARD_BLOCK_SIZE` | `uint64(2**20)` (= 1,048,576) | bytes |
+| `TARGET_SHARD_BLOCK_SIZE` | `uint64(2**18)` (= 262,144) |  bytes |
+| `SHARD_BLOCK_OFFSETS` | `List[uint64, 12]([1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233])` | - |
 | `MAX_SHARD_BLOCKS_PER_ATTESTATION` | `len(SHARD_BLOCK_OFFSETS)` | - |
-| `BYTES_PER_CUSTODY_CHUNK` | `2**12` (= 4,096) | bytes |
+| `BYTES_PER_CUSTODY_CHUNK` | `uint64(2**12)` (= 4,096) | bytes |
 | `CUSTODY_RESPONSE_DEPTH` | `ceillog2(MAX_SHARD_BLOCK_SIZE // BYTES_PER_CUSTODY_CHUNK)` | - | 
 
 ### Gwei values
@@ -504,7 +504,7 @@ def compute_committee_source_epoch(epoch: Epoch, period: uint64) -> Epoch:
     """
     Return the source epoch for computing the committee.
     """
-    source_epoch = epoch - epoch % period
+    source_epoch = Epoch(epoch - epoch % period)
     if source_epoch >= period:
         source_epoch -= period  # `period` epochs lookahead
     return source_epoch
@@ -575,7 +575,7 @@ def get_light_client_committee(beacon_state: BeaconState, epoch: Epoch) -> Seque
     return compute_committee(
         indices=active_validator_indices,
         seed=seed,
-        index=0,
+        index=uint64(0),
         count=get_active_shard_count(beacon_state),
     )[:LIGHT_CLIENT_COMMITTEE_SIZE]
 ```
@@ -601,10 +601,10 @@ def get_committee_count_delta(state: BeaconState, start_slot: Slot, stop_slot: S
     """
     Return the sum of committee counts in range ``[start_slot, stop_slot)``.
     """
-    return sum(
+    return uint64(sum(
         get_committee_count_per_slot(state, compute_epoch_at_slot(Slot(slot)))
         for slot in range(start_slot, stop_slot)
-    )
+    ))
 ```
 
 #### `get_start_shard`

--- a/specs/phase1/validator.md
+++ b/specs/phase1/validator.md
@@ -281,9 +281,9 @@ def get_shard_transition_fields(
     shard: Shard,
     shard_blocks: Sequence[SignedShardBlock],
 ) -> Tuple[Sequence[uint64], Sequence[Root], Sequence[ShardState]]:
-    shard_states = []
-    shard_data_roots = []
-    shard_block_lengths = []
+    shard_block_lengths = []  # type: PyList[uint64]
+    shard_data_roots = []  # type: PyList[Root]
+    shard_states = []  # type: PyList[ShardState]
 
     shard_state = beacon_state.shard_states[shard]
     shard_block_slots = [shard_block.message.slot for shard_block in shard_blocks]
@@ -301,7 +301,7 @@ def get_shard_transition_fields(
         shard_state = shard_state.copy()
         process_shard_block(shard_state, shard_block.message)
         shard_states.append(shard_state)
-        shard_block_lengths.append(len(shard_block.message.body))
+        shard_block_lengths.append(uint64(len(shard_block.message.body)))
 
     return shard_block_lengths, shard_data_roots, shard_states
 ```


### PR DESCRIPTION
1. Add more type castings.
2. Add `uint64()` castings to phase 1 constants and configurations.