### PR TITLE
Clean up `get_forkchoice_store`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ apply_constants_config(globals())
 
 PHASE0_IMPORTS = '''from eth2spec.config.config_util import apply_constants_config
 from typing import (
-    Any, Callable, Dict, Set, Sequence, Tuple, Optional, TypeVar
+    Any, Callable, Dict, Set, Sequence, Tuple, Optional, TypeVar, Union
 )
 
 from dataclasses import (
@@ -123,7 +123,7 @@ SSZObject = TypeVar('SSZObject', bound=View)
 PHASE1_IMPORTS = '''from eth2spec.phase0 import spec as phase0
 from eth2spec.config.config_util import apply_constants_config
 from typing import (
-    Any, Dict, Set, Sequence, NewType, Tuple, TypeVar, Callable, Optional
+    Any, Dict, Set, Sequence, NewType, Tuple, TypeVar, Callable, Optional, Union
 )
 
 from dataclasses import (
@@ -292,7 +292,7 @@ ignored_dependencies = [
     'Bytes1', 'Bytes4', 'Bytes32', 'Bytes48', 'Bytes96', 'Bitlist', 'Bitvector',
     'uint8', 'uint16', 'uint32', 'uint64', 'uint128', 'uint256',
     'bytes', 'byte', 'ByteList', 'ByteVector',
-    'Dict', 'dict', 'field',
+    'Dict', 'dict', 'field', 'Union'
 ]
 
 


### PR DESCRIPTION
### Issue

Fix #1977

### Proposed solution
1. Change `Store.blocks` from `Dict[Root, BeaconBlock]` to `Dict[Root, Union[BeaconBlock, BeaconBlockHeader]]`.
    - The value of `Store.blocks` could be either `BeaconBlock` or `BeaconBlockHeader` (nonhomogeneous)
2. `anchor_block` can only be `BeaconHeader` at genesis.