### PR TITLE
clarify offsets serialization

### DIFF
--- a/ssz/simple-serialize.md
+++ b/ssz/simple-serialize.md
@@ -165,7 +165,7 @@ variable_lengths = [len(part) for part in variable_parts]
 assert sum(fixed_lengths + variable_lengths) < 2**(BYTES_PER_LENGTH_OFFSET * BITS_PER_BYTE)
 
 # Interleave offsets of variable-size parts with fixed-size parts
-variable_offsets = [serialize(sum(fixed_lengths + variable_lengths[:i])) for i in range(len(value))]
+variable_offsets = [serialize(uint32(sum(fixed_lengths + variable_lengths[:i]))) for i in range(len(value))]
 fixed_parts = [part if part != None else variable_offsets[i] for i, part in enumerate(fixed_parts)]
 
 # Return the concatenation of the fixed-size parts (offsets interleaved) with the variable-size parts


### PR DESCRIPTION
Small PR to clarify the offset length used in SSZ, thanks @imnisen, fix #1963.

Alternatively we could use `sum(fixed_lengths + variable_lengths[:i]).to_bytes(BYTES_PER_LENGTH_OFFSET, "little")`, but I think it's fine to just explicitly state it is an `uint32`, as the offset length is a constant, not configurable.

