### PR TITLE
Initialize `online_countdown` for each new validator

### DIFF
--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -1133,6 +1133,9 @@ def slash_validator(state: BeaconState,
 
 ```python
 def add_validator(state: BeaconState, deposit: Deposit, amount: Gwei) -> None:
+    """
+    Add a new validator to the given ``state``.
+    """
     state.validators.append(get_validator_from_deposit(state, deposit))
     state.balances.append(amount)
 ```

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -102,6 +102,7 @@
     - [`decrease_balance`](#decrease_balance)
     - [`initiate_validator_exit`](#initiate_validator_exit)
     - [`slash_validator`](#slash_validator)
+    - [`add_validator`](#add_validator)
 - [Genesis](#genesis)
   - [Genesis state](#genesis-state)
   - [Genesis block](#genesis-block)
@@ -1128,6 +1129,14 @@ def slash_validator(state: BeaconState,
     increase_balance(state, whistleblower_index, Gwei(whistleblower_reward - proposer_reward))
 ```
 
+#### `add_validator`
+
+```python
+def add_validator(state: BeaconState, deposit: Deposit, amount: Gwei) -> None:
+    state.validators.append(get_validator_from_deposit(state, deposit))
+    state.balances.append(amount)
+```
+
 ## Genesis
 
 Before the Ethereum 2.0 genesis has been triggered, and for every Ethereum 1.0 block, let `candidate_state = initialize_beacon_state_from_eth1(eth1_block_hash, eth1_timestamp, deposits)` where:
@@ -1827,8 +1836,7 @@ def process_deposit(state: BeaconState, deposit: Deposit) -> None:
             return
 
         # Add validator and balance entries
-        state.validators.append(get_validator_from_deposit(state, deposit))
-        state.balances.append(amount)
+        add_validator(state, deposit, amount)
     else:
         # Increase balance by deposit amount
         index = ValidatorIndex(validator_pubkeys.index(pubkey))

--- a/specs/phase1/beacon-chain.md
+++ b/specs/phase1/beacon-chain.md
@@ -41,7 +41,6 @@
   - [`CompactCommittee`](#compactcommittee)
 - [Helper functions](#helper-functions)
   - [Misc](#misc-1)
-    - [`bitwise_or`](#bitwise_or)
     - [`compute_previous_slot`](#compute_previous_slot)
     - [`pack_compact_validator`](#pack_compact_validator)
     - [`unpack_compact_validator`](#unpack_compact_validator)
@@ -473,13 +472,6 @@ class CompactCommittee(Container):
 
 ### Misc
 
-#### `bitwise_or`
-
-```python
-def bitwise_or(a: Bitlist, b: Bitlist) -> Bitlist:
-    return Bitlist([a_item or b_item for a_item, b_item in zip(a, b)])
-```
-
 #### `compute_previous_slot`
 
 ```python
@@ -776,8 +768,12 @@ def optional_fast_aggregate_verify(pubkeys: Sequence[BLSPubkey], message: Bytes3
 
 ```python
 def add_validator(state: BeaconState, deposit: Deposit, amount: Gwei) -> None:
+    """
+    Add a new validator to the given ``state``.
+    """
     state.validators.append(get_validator_from_deposit(state, deposit))
     state.balances.append(amount)
+    # Phase 1 new `online_countdown` field.
     state.online_countdown.append(ONLINE_PERIOD)
 ```
 

--- a/tests/core/pyspec/eth2spec/test/phase0/block_processing/test_process_deposit.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/block_processing/test_process_deposit.py
@@ -1,4 +1,4 @@
-from eth2spec.test.context import spec_state_test, expect_assertion_error, always_bls, with_all_phases
+from eth2spec.test.context import spec_state_test, expect_assertion_error, always_bls, with_all_phases, PHASE0
 from eth2spec.test.helpers.deposits import (
     build_deposit,
     prepare_state_and_deposit,
@@ -56,6 +56,9 @@ def run_deposit_processing(spec, state, deposit, validator_index, valid=True, ef
         assert state.validators[validator_index].effective_balance == effective
 
     assert state.eth1_deposit_index == state.eth1_data.deposit_count
+
+    if spec.fork != PHASE0:
+        assert len(state.online_countdown) == len(state.validators)
 
 
 @with_all_phases

--- a/tests/core/pyspec/eth2spec/test/phase0/epoch_processing/run_epoch_process_base.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/epoch_processing/run_epoch_process_base.py
@@ -43,3 +43,7 @@ def run_epoch_processing_with(spec, state, process_name: str):
     yield 'pre', state
     getattr(spec, process_name)(state)
     yield 'post', state
+
+
+def run_process_final_updates(spec, state):
+    yield from run_epoch_processing_with(spec, state, 'process_final_updates')

--- a/tests/core/pyspec/eth2spec/test/phase0/epoch_processing/test_process_final_updates.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/epoch_processing/test_process_final_updates.py
@@ -1,12 +1,8 @@
 from eth2spec.test.context import spec_state_test, with_all_phases
 from eth2spec.test.phase0.epoch_processing.run_epoch_process_base import (
-    run_epoch_processing_with, run_epoch_processing_to
+    run_process_final_updates, run_epoch_processing_to
 )
 from eth2spec.test.helpers.state import transition_to
-
-
-def run_process_final_updates(spec, state):
-    yield from run_epoch_processing_with(spec, state, 'process_final_updates')
 
 
 @with_all_phases

--- a/tests/core/pyspec/eth2spec/test/phase0/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/sanity/test_blocks.py
@@ -316,6 +316,10 @@ def test_empty_epoch_transition(spec, state):
     for slot in range(pre_slot, state.slot):
         assert spec.get_block_root_at_slot(state, slot) == block.parent_root
 
+    if spec.fork != PHASE0:
+        for count in state.online_countdown:
+            assert count == spec.ONLINE_PERIOD - 1
+
 
 @with_all_phases
 @spec_test

--- a/tests/core/pyspec/eth2spec/test/phase1/epoch_processing/test_process_final_updates.py
+++ b/tests/core/pyspec/eth2spec/test/phase1/epoch_processing/test_process_final_updates.py
@@ -1,0 +1,49 @@
+from eth2spec.test.context import PHASE1, spec_state_test, with_phases
+from eth2spec.test.phase0.epoch_processing.run_epoch_process_base import (
+    run_epoch_processing_to, run_process_final_updates,
+)
+from eth2spec.test.helpers.attestations import get_valid_attestation
+from eth2spec.test.helpers.block import build_empty_block_for_next_slot
+from eth2spec.test.helpers.state import state_transition_and_sign_block, transition_to
+
+
+@with_phases([PHASE1])
+@spec_state_test
+def test_process_online_tracking_no_participants(spec, state):
+    run_epoch_processing_to(spec, state, 'process_final_updates')
+
+    for count in state.online_countdown:
+        assert count == spec.ONLINE_PERIOD
+
+    yield from run_process_final_updates(spec, state)
+
+    for count in state.online_countdown:
+        assert count == spec.ONLINE_PERIOD - 1
+
+
+@with_phases([PHASE1])
+@spec_state_test
+def test_process_online_tracking_has_participants(spec, state):
+    # Build a block and apply it
+    block = build_empty_block_for_next_slot(spec, state)
+    attestation = get_valid_attestation(spec, state, index=0, signed=True)
+    block.body.attestations.append(attestation)
+    participants = set(spec.get_attesting_indices(state, attestation.data, attestation.aggregation_bits))
+    assert len(participants) != 0
+    state_transition_and_sign_block(spec, state, block)
+
+    # Transition to before `process_final_updates`
+    next_epoch = spec.get_current_epoch(state) + 1
+    transition_to(spec, state, spec.compute_start_slot_at_epoch(next_epoch) - 1)
+    run_epoch_processing_to(spec, state, 'process_final_updates')
+
+    for count in state.online_countdown:
+        assert count == spec.ONLINE_PERIOD
+
+    yield from run_process_final_updates(spec, state)
+
+    for index, count in enumerate(state.online_countdown):
+        if index in participants:
+            assert count == spec.ONLINE_PERIOD
+        else:
+            assert count == spec.ONLINE_PERIOD - 1


### PR DESCRIPTION
### Issue

`state.online_countdown` slot should have been allocated for each new validator. (`state.online_countdown.append(ONLINE_PERIOD)`)

### Proposed solution

1. Refactor `process_deposit`: extract new validator allocation logic into a `add_validator` helper.
2. Add `state.online_countdown.append(ONLINE_PERIOD)` in phase 1 `add_validator` helper.
3. Update `process_online_tracking`:  only reduce the `online_countdown` when the validator has been activated.
4. Update tests: add `assert len(state.online_countdown) == len(state.validators)` check.


It is a bugfix that could be targeted on the `dev` branch directly. However, I refactored `process_deposit` to make minimum changes, so I'm inclined to include it *after* v1.0.0 release. Thus it's targeting on `vbuterin-patch-1` branch now.