### PR TITLE
Allow `len(signatures) == 0` in aggregate function and `len(pubkeys) == 0` in verify functions

### DIFF
--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -612,7 +612,7 @@ def bytes_to_uint64(data: bytes) -> uint64:
 This specification refers to [draft v4 of the IETF BLS signature standard](https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-04). Specifically, the following endpoints are used with the `BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_` ciphersuite:
 
 - `def Sign(secret_key: int, message: bytes) -> BLSSignature`
-- `def Aggregate(signatures: Sequence[BLSSignature]) -> BLSSignature`
+- `def _Aggregate(signatures: Sequence[BLSSignature]) -> BLSSignature`
 - `def _Verify(pubkey: BLSPubkey, message: bytes, signature: BLSSignature) -> bool`
 - `def _AggregateVerify(pubkeys: Sequence[BLSPubkey], messages: Sequence[bytes], signature: BLSSignature) -> bool`
 - `def _FastAggregateVerify(pubkeys: Sequence[BLSPubkey], message: bytes, signature: BLSSignature) -> bool`
@@ -625,6 +625,13 @@ Eth2 wraps the above endpoints from draft v4 of the IETF BLS signature standard 
 
 - allow infinity pubkeys (replicating [draft v3](https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-03) for historical reasons)
 - allow empty aggregate signatures for phases 1+
+
+```python
+def bls_aggregate_signatures(signatures: Sequence[BLSSignature]) -> BLSSignature:
+    if len(signatures) == 0:
+        return G2_INFINITY_POINT
+    return ietf._Aggregate(signatures)
+```
 
 ```python
 def bls_aggregate_verify(pubkeys: Sequence[BLSPubkey], messages: Sequence[bytes], signature: BLSSignature) -> bool:

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -628,9 +628,6 @@ Eth2 wraps the above endpoints from draft v4 of the IETF BLS signature standard 
 
 ```python
 def bls_aggregate_verify(pubkeys: Sequence[BLSPubkey], messages: Sequence[bytes], signature: BLSSignature) -> bool:
-    if len(pubkeys) == 0:
-        return False
-
     # Filter out (pubkey, message) pairs with an infinity pubkey
     pubkeys_and_messages = [(pubkey, message) for pubkey, message in zip(pubkeys, messages)
                             if pubkey != G1_INFINITY_POINT]

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -509,7 +509,7 @@ Set `aggregate_attestation.signature = aggregate_signature` where `aggregate_sig
 ```python
 def get_aggregate_signature(attestations: Sequence[Attestation]) -> BLSSignature:
     signatures = [attestation.signature for attestation in attestations]
-    return ietf.Aggregate(signatures)
+    return bls_aggregate_signatures(signatures)
 ```
 
 #### Broadcast aggregate

--- a/specs/phase1/beacon-chain.md
+++ b/specs/phase1/beacon-chain.md
@@ -14,7 +14,6 @@
   - [Misc](#misc)
   - [Shard block configs](#shard-block-configs)
   - [Gwei values](#gwei-values)
-  - [Initial values](#initial-values)
   - [Time parameters](#time-parameters)
   - [Domain types](#domain-types)
 - [Updated containers](#updated-containers)
@@ -125,12 +124,6 @@ Configuration is not namespaced. Instead it is strictly an extension;
 | - | - |
 | `MAX_GASPRICE` | `Gwei(2**14)` (= 16,384) | Gwei | 
 | `MIN_GASPRICE` | `Gwei(2**3)` (= 8) | Gwei | 
-
-### Initial values
-
-| Name | Value |
-| - | - |
-| `NO_SIGNATURE` | `BLSSignature(b'\x00' * 96)` | 
 
 ### Time parameters
 

--- a/specs/phase1/beacon-chain.md
+++ b/specs/phase1/beacon-chain.md
@@ -59,8 +59,6 @@
   - [Predicates](#predicates)
     - [`is_on_time_attestation`](#is_on_time_attestation)
     - [`is_winning_attestation`](#is_winning_attestation)
-    - [`optional_aggregate_verify`](#optional_aggregate_verify)
-    - [`optional_fast_aggregate_verify`](#optional_fast_aggregate_verify)
   - [Block processing](#block-processing)
     - [Operations](#operations)
       - [New Attestation processing](#new-attestation-processing)
@@ -686,36 +684,6 @@ def is_winning_attestation(state: BeaconState,
     )
 ```
 
-#### `optional_aggregate_verify`
-
-```python
-def optional_aggregate_verify(pubkeys: Sequence[BLSPubkey],
-                              messages: Sequence[Bytes32],
-                              signature: BLSSignature) -> bool:
-    """
-    If ``pubkeys`` is an empty list, the given ``signature`` should be a stub ``NO_SIGNATURE``.
-    Otherwise, verify it with standard BLS AggregateVerify API.
-    """
-    if len(pubkeys) == 0:
-        return signature == NO_SIGNATURE
-    else:
-        return bls_aggregate_verify(pubkeys, messages, signature)
-```
-
-#### `optional_fast_aggregate_verify`
-
-```python
-def optional_fast_aggregate_verify(pubkeys: Sequence[BLSPubkey], message: Bytes32, signature: BLSSignature) -> bool:
-    """
-    If ``pubkeys`` is an empty list, the given ``signature`` should be a stub ``NO_SIGNATURE``.
-    Otherwise, verify it with standard BLS FastAggregateVerify API.
-    """
-    if len(pubkeys) == 0:
-        return signature == NO_SIGNATURE
-    else:
-        return bls_fast_aggregate_verify(pubkeys, message, signature)
-```
-
 ### Block processing
 
 ```python
@@ -873,7 +841,7 @@ def apply_shard_transition(state: BeaconState, shard: Shard, transition: ShardTr
         for header in headers
     ]
     # Verify combined proposer signature
-    assert optional_aggregate_verify(pubkeys, signing_roots, transition.proposer_signature_aggregate)
+    assert bls_aggregate_verify(pubkeys, signing_roots, transition.proposer_signature_aggregate)
 
     # Copy and save updated shard state
     shard_state = copy(transition.shard_states[len(transition.shard_states) - 1])
@@ -1043,7 +1011,7 @@ def process_light_client_aggregate(state: BeaconState, block_body: BeaconBlockBo
 
     signing_root = compute_signing_root(previous_block_root,
                                         get_domain(state, DOMAIN_LIGHT_CLIENT, compute_epoch_at_slot(previous_slot)))
-    assert optional_fast_aggregate_verify(signer_pubkeys, signing_root, block_body.light_client_signature)
+    assert bls_fast_aggregate_verify(signer_pubkeys, signing_root, block_body.light_client_signature)
 ```
 
 ### Epoch transition

--- a/specs/phase1/validator.md
+++ b/specs/phase1/validator.md
@@ -321,13 +321,8 @@ def get_shard_transition(beacon_state: BeaconState,
     shard_block_lengths, shard_data_roots, shard_states = (
         get_shard_transition_fields(beacon_state, shard, shard_blocks)
     )
-
-    if len(shard_blocks) > 0:
-        proposer_signatures = [shard_block.signature for shard_block in shard_blocks]
-        proposer_signature_aggregate = ietf.Aggregate(proposer_signatures)
-    else:
-        proposer_signature_aggregate = NO_SIGNATURE
-
+    proposer_signatures = [shard_block.signature for shard_block in shard_blocks]
+    proposer_signature_aggregate = bls_aggregate_signatures(proposer_signatures)
     return ShardTransition(
         start_slot=offset_slots[0],
         shard_block_lengths=shard_block_lengths,
@@ -483,7 +478,7 @@ Collect `light_client_votes` seen via gossip during the `slot` that have an equi
 ```python
 def get_aggregate_light_client_signature(light_client_votes: Sequence[LightClientVote]) -> BLSSignature:
     signatures = [light_client_vote.signature for light_client_vote in light_client_votes]
-    return ietf.Aggregate(signatures)
+    return bls_aggregate_signatures(signatures)
 ```
 
 #### Broadcast aggregate

--- a/tests/core/pyspec/eth2spec/test/helpers/attestations.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/attestations.py
@@ -184,7 +184,7 @@ def sign_aggregate_attestation(spec, state, attestation_data, participants: List
                 privkey
             )
         )
-    return bls.Aggregate(signatures)
+    return spec.bls_aggregate_signatures(signatures)
 
 
 def sign_indexed_attestation(spec, state, indexed_attestation):

--- a/tests/core/pyspec/eth2spec/test/helpers/block.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/block.py
@@ -2,6 +2,7 @@ from eth2spec.test.helpers.keys import privkeys
 from eth2spec.utils import bls
 from eth2spec.utils.bls import only_with_bls
 from eth2spec.utils.ssz.ssz_impl import hash_tree_root
+from eth2spec.test.context import PHASE0
 
 
 def get_proposer_index_maybe(spec, state, slot, proposer_index=None):
@@ -87,9 +88,13 @@ def build_empty_block(spec, state, slot=None):
     empty_block = spec.BeaconBlock()
     empty_block.slot = slot
     empty_block.proposer_index = spec.get_beacon_proposer_index(state)
-    empty_block.body.eth1_data.deposit_count = state.eth1_deposit_index
     empty_block.parent_root = parent_block_root
+    empty_block.body.eth1_data.deposit_count = state.eth1_deposit_index
     apply_randao_reveal(spec, state, empty_block)
+
+    if spec.fork != PHASE0:
+        empty_block.body.light_client_signature = spec.G2_INFINITY_POINT
+
     return empty_block
 
 

--- a/tests/core/pyspec/eth2spec/test/helpers/custody.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/custody.py
@@ -23,7 +23,7 @@ def get_valid_early_derived_secret_reveal(spec, state, epoch=None):
     # Generate masker's signature on the mask
     signing_root = spec.compute_signing_root(mask, domain)
     masker_signature = bls.Sign(privkeys[masker_index], signing_root)
-    masked_reveal = bls.Aggregate([reveal, masker_signature])
+    masked_reveal = spec.bls_aggregate_signatures([reveal, masker_signature])
 
     return spec.EarlyDerivedSecretReveal(
         revealed_index=revealed_index,

--- a/tests/core/pyspec/eth2spec/test/phase0/unittests/eth2_bls/test_eth2_bls.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/unittests/eth2_bls/test_eth2_bls.py
@@ -27,7 +27,7 @@ def test_eth2_aggregate_verify_point_at_infinity(spec, state):
     for privkey in range(1, 3):
         pubkeys.append(spec.ietf.SkToPk(privkey))
         signatures.append(spec.ietf.Sign(privkey, message))
-    signature = spec.ietf.Aggregate(signatures)
+    signature = spec.bls_aggregate_signatures(signatures)
     messages = [message] * 3
 
     # Valid in IETF BLS v3
@@ -56,10 +56,20 @@ def test_eth2_fast_aggregate_verify_point_at_infinity(spec, state):
     for privkey in range(1, 3):
         pubkeys.append(spec.ietf.SkToPk(privkey))
         signatures.append(spec.ietf.Sign(privkey, message))
-    signature = spec.ietf.Aggregate(signatures)
+    signature = spec.bls_aggregate_signatures(signatures)
 
     # Valid in IETF BLS v3
     # TODO: check if it should be invalid in v4
     assert spec.ietf._FastAggregateVerify(pubkeys, message, signature)
     # Valid in Eth2 spec
     assert spec.bls_fast_aggregate_verify(pubkeys, message, signature)
+
+
+@with_all_phases
+@spec_state_test
+@always_bls
+def test_eth2_fast_aggregate_verify_no_signature(spec, state):
+    # Invalid in IETF BLS v3
+    assert not spec.ietf._FastAggregateVerify([], message, infinity_signature)
+    # Valid in Eth2 spec
+    assert spec.bls_fast_aggregate_verify([], message, infinity_signature)

--- a/tests/core/pyspec/eth2spec/test/phase0/unittests/eth2_bls/test_eth2_bls.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/unittests/eth2_bls/test_eth2_bls.py
@@ -10,8 +10,7 @@ message = b'\x12' * 32
 @with_all_phases
 @spec_state_test
 @always_bls
-def test_eth2_verify(spec, state):
-
+def test_eth2_verify_point_at_infinity(spec, state):
     # Valid in IETF BLS v3
     # TODO: will be invalid when we update it to v4
     assert spec.ietf._Verify(infinity_pubkey, message, infinity_signature)
@@ -22,7 +21,7 @@ def test_eth2_verify(spec, state):
 @with_all_phases
 @spec_state_test
 @always_bls
-def test_eth2_aggregate_verify(spec, state):
+def test_eth2_aggregate_verify_point_at_infinity(spec, state):
     pubkeys = [infinity_pubkey]
     signatures = [infinity_signature]
     for privkey in range(1, 3):
@@ -41,7 +40,17 @@ def test_eth2_aggregate_verify(spec, state):
 @with_all_phases
 @spec_state_test
 @always_bls
-def test_eth2_fast_aggregate_verify(spec, state):
+def test_eth2_aggregate_verify_no_signature(spec, state):
+    # Invalid in IETF BLS v3
+    assert not spec.ietf._AggregateVerify([], [], infinity_signature)
+    # Valid in Eth2 spec
+    assert spec.bls_aggregate_verify([], [], infinity_signature)
+
+
+@with_all_phases
+@spec_state_test
+@always_bls
+def test_eth2_fast_aggregate_verify_point_at_infinity(spec, state):
     pubkeys = [infinity_pubkey]
     signatures = [infinity_signature]
     for privkey in range(1, 3):

--- a/tests/core/pyspec/eth2spec/utils/bls.py
+++ b/tests/core/pyspec/eth2spec/utils/bls.py
@@ -75,7 +75,7 @@ def _FastAggregateVerify(pubkeys, message, signature):
 
 
 @only_with_bls(alt_return=STUB_SIGNATURE)
-def Aggregate(signatures):
+def _Aggregate(signatures):
     return bls.Aggregate(signatures)
 
 

--- a/tests/generators/bls/main.py
+++ b/tests/generators/bls/main.py
@@ -138,12 +138,12 @@ def case03_aggregate():
         sigs = [bls.Sign(privkey, message) for privkey in PRIVKEYS]
         yield f'aggregate_{encode_hex(message)}', {
             'input': [encode_hex(sig) for sig in sigs],
-            'output': encode_hex(bls.Aggregate(sigs)),
+            'output': encode_hex(bls._Aggregate(sigs)),
         }
 
     # Invalid pubkeys -- len(pubkeys) == 0
     try:
-        bls.Aggregate([])
+        bls._Aggregate([])
     except Exception:
         pass
     else:
@@ -161,7 +161,7 @@ def case04_fast_aggregate_verify():
     for i, message in enumerate(MESSAGES):
         privkeys = PRIVKEYS[:i + 1]
         sigs = [bls.Sign(privkey, message) for privkey in privkeys]
-        aggregate_signature = bls.Aggregate(sigs)
+        aggregate_signature = bls._Aggregate(sigs)
         pubkeys = [bls.SkToPk(privkey) for privkey in privkeys]
         pubkeys_serial = [encode_hex(pubkey) for pubkey in pubkeys]
 
@@ -247,7 +247,7 @@ def case05_aggregate_verify():
         messages_serial.append(encode_hex(message))
         sigs.append(sig)
 
-    aggregate_signature = bls.Aggregate(sigs)
+    aggregate_signature = bls._Aggregate(sigs)
     assert bls._AggregateVerify(pubkeys, messages, aggregate_signature)
     assert milagro_bls.AggregateVerify(pubkeys, messages, aggregate_signature)
     yield f'aggregate_verify_valid', {


### PR DESCRIPTION
Based on #2068 

Also suggested by @JustinDrake, we can go farther to allow empty aggregate signatures in the verification for phases 1+.

### Issue

IETF BLS draft 2 requires (preconditions):
1. `len(signatures) >= 1` in `Aggregate(signatures)`
2. `len(pubkeys) >= 1` in `-AggregateVerify` functions.

For phase 1 `light_client_signature` and shard block `proposer_signature_aggregate` use cases, there are two phase 1 helper functions were added in #1812 to allow no-signatures case (`len(signatures) == 0`/`len(pubkeys) == 0`):
1. `optional_aggregate_verify`
2. `optional_fast_aggregate_verify`


### Proposed solution

Some BLSv4 compatible wrappers are added in #2068.

If we implement wrappers to allow `len(signatures) == 0` in `Aggregate(signatures)`, we could also make -verify function wrappers allow `len(pubkeys) == 0` and remove the `optional_` helpers.

Note that it's a non-substantive change for phase 0.
