### PR TITLE
skip large_validator_set tests if too large (mainnet config)

### DIFF
--- a/tests/core/pyspec/eth2spec/test/context.py
+++ b/tests/core/pyspec/eth2spec/test/context.py
@@ -62,8 +62,6 @@ def _prepare_state(balances_fn: Callable[[Any], Sequence[int]], threshold_fn: Ca
 
     p0 = phases[PHASE0]
     balances = balances_fn(p0)
-    if balances is None:
-        return None
     activation_threshold = threshold_fn(p0)
 
     state = create_genesis_state(spec=p0, validator_balances=balances,
@@ -90,9 +88,6 @@ def with_custom_state(balances_fn: Callable[[Any], Sequence[int]],
             global _custom_state_cache_dict
             if key not in _custom_state_cache_dict:
                 state = _prepare_state(balances_fn, threshold_fn, spec, phases)
-                if state is None:
-                    dump_skipping_message(f"doesn't support this configuration: {spec.CONFIG_NAME}")
-                    return None
                 _custom_state_cache_dict[key] = state.get_backing()
 
             # Take an entry out of the LRU.
@@ -166,13 +161,9 @@ def low_single_balance(spec):
 def large_validator_set(spec):
     """
     Helper method to create a large series of default balances.
-    Return None if too large for standard test processing.
     Usage: `@with_custom_state(balances_fn=default_balances, ...)`
     """
     num_validators = 2 * spec.SLOTS_PER_EPOCH * spec.MAX_COMMITTEES_PER_SLOT * spec.TARGET_COMMITTEE_SIZE
-    if num_validators > spec.SLOTS_PER_EPOCH * 256:
-        # Larger than limit of public/private keys pre-generated
-        return None
     return [spec.MAX_EFFECTIVE_BALANCE] * num_validators
 
 

--- a/tests/core/pyspec/eth2spec/test/phase0/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/sanity/test_blocks.py
@@ -21,11 +21,12 @@ from eth2spec.test.helpers.deposits import prepare_state_and_deposit
 from eth2spec.test.helpers.shard_transitions import get_shard_transition_of_committee
 
 from eth2spec.test.context import (
-    PHASE0, PHASE1,
+    PHASE0, PHASE1, MINIMAL,
     spec_test, spec_state_test, dump_skipping_message,
     with_phases, with_all_phases, single_phase,
     expect_assertion_error, always_bls,
     disable_process_reveal_deadlines,
+    with_configs,
     with_custom_state,
     large_validator_set,
 )
@@ -92,6 +93,8 @@ def test_empty_block_transition(spec, state):
 
 
 @with_all_phases
+@with_configs([MINIMAL],
+              reason="mainnet config leads to larger validator set than limit of public/private keys pre-generated")
 @spec_test
 @with_custom_state(balances_fn=large_validator_set, threshold_fn=lambda spec: spec.EJECTION_BALANCE)
 @single_phase
@@ -318,6 +321,8 @@ def test_empty_epoch_transition(spec, state):
 
 
 @with_all_phases
+@with_configs([MINIMAL],
+              reason="mainnet config leads to larger validator set than limit of public/private keys pre-generated")
 @spec_test
 @with_custom_state(balances_fn=large_validator_set, threshold_fn=lambda spec: spec.EJECTION_BALANCE)
 @single_phase


### PR DESCRIPTION
based on `testgenphase1`

skipping huge mainnet test for test generators before v0.12.3 release