### PR TITLE
`compute_weak_subjectivity_period` should use integer division (//)

### DIFF
--- a/specs/phase0/weak-subjectivity.md
+++ b/specs/phase0/weak-subjectivity.md
@@ -69,9 +69,9 @@ def compute_weak_subjectivity_period(state: BeaconState) -> uint64:
     weak_subjectivity_period = MIN_VALIDATOR_WITHDRAWABILITY_DELAY
     validator_count = len(get_active_validator_indices(state, get_current_epoch(state)))
     if validator_count >= MIN_PER_EPOCH_CHURN_LIMIT * CHURN_LIMIT_QUOTIENT:
-        weak_subjectivity_period += SAFETY_DECAY * CHURN_LIMIT_QUOTIENT / (2 * 100)
+        weak_subjectivity_period += SAFETY_DECAY * CHURN_LIMIT_QUOTIENT // (2 * 100)
     else:
-        weak_subjectivity_period += SAFETY_DECAY * validator_count / (2 * 100 * MIN_PER_EPOCH_CHURN_LIMIT)
+        weak_subjectivity_period += SAFETY_DECAY * validator_count // (2 * 100 * MIN_PER_EPOCH_CHURN_LIMIT)
     return weak_subjectivity_period
 ```
 


### PR DESCRIPTION
Perhaps because of a typo, [compute_weak_subjectivity_period](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase0/weak-subjectivity.md#calculating-the-weak-subjectivity-period) uses non-integer division '/':
```python
weak_subjectivity_period += SAFETY_DECAY * CHURN_LIMIT_QUOTIENT / (2 * 100)
```
This results in an exception raised:
```
>>> compute_weak_subjectivity_period(BeaconState())
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/mnt/c/Users/ericsson/IdeaProjects/eth2.0-specs/tests/core/pyspec/eth2spec/phase1/spec.py", line 2072, in compute_weak_subjectivity_period
    weak_subjectivity_period += SAFETY_DECAY * validator_count / (2 * 100 * MIN_PER_EPOCH_CHURN_LIMIT)
  File "/mnt/c/Users/ericsson/IdeaProjects/eth2.0-specs/venv/lib/python3.8/site-packages/remerkleable/basic.py", line 116, in __truediv__
    raise OperationNotSupported(f"non-integer division '{self} / {other}' "
remerkleable.basic.OperationNotSupported: non-integer division '0 / 800' is not valid for uint64 left hand type
```