### PR TITLE
additional genesis init tests

### DIFF
--- a/tests/core/pyspec/eth2spec/test/helpers/deposits.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/deposits.py
@@ -66,16 +66,16 @@ def deposit_from_context(spec, deposit_data_list, index):
 
 def prepare_full_genesis_deposits(spec,
                                   amount,
-                                  pubkey_max_range,
-                                  pubkey_min_range=0,
+                                  deposit_count,
+                                  min_pubkey_index=0,
                                   signed=False,
                                   deposit_data_list=None):
     if deposit_data_list is None:
         deposit_data_list = []
     genesis_deposits = []
-    for validator_index in range(pubkey_min_range, pubkey_max_range):
-        pubkey = pubkeys[validator_index]
-        privkey = privkeys[validator_index]
+    for pubkey_index in range(min_pubkey_index, min_pubkey_index + deposit_count):
+        pubkey = pubkeys[pubkey_index]
+        privkey = privkeys[pubkey_index]
         # insecurely use pubkey as withdrawal key if no credentials provided
         withdrawal_credentials = spec.BLS_WITHDRAWAL_PREFIX + spec.hash(pubkey)[1:]
         deposit, root, deposit_data_list = build_deposit(
@@ -93,7 +93,7 @@ def prepare_full_genesis_deposits(spec,
 
 
 def prepare_random_genesis_deposits(spec,
-                                    num_deposits,
+                                    deposit_count,
                                     max_pubkey_index,
                                     min_pubkey_index=0,
                                     max_amount=None,
@@ -107,7 +107,7 @@ def prepare_random_genesis_deposits(spec,
     if deposit_data_list is None:
         deposit_data_list = []
     deposits = []
-    for _ in range(num_deposits):
+    for _ in range(deposit_count):
         pubkey_index = rng.randint(min_pubkey_index, max_pubkey_index)
         pubkey = pubkeys[pubkey_index]
         privkey = privkeys[pubkey_index]

--- a/tests/core/pyspec/eth2spec/test/helpers/deposits.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/deposits.py
@@ -1,4 +1,4 @@
-import random
+from random import Random
 
 from eth2spec.test.helpers.keys import pubkeys, privkeys
 from eth2spec.utils import bls
@@ -98,7 +98,8 @@ def prepare_random_genesis_deposits(spec,
                                     min_pubkey_index=0,
                                     max_amount=None,
                                     min_amount=None,
-                                    deposit_data_list=None):
+                                    deposit_data_list=None,
+                                    rng=Random(3131)):
     if max_amount is None:
         max_amount = spec.MAX_EFFECTIVE_BALANCE
     if min_amount is None:
@@ -107,11 +108,11 @@ def prepare_random_genesis_deposits(spec,
         deposit_data_list = []
     deposits = []
     for _ in range(num_deposits):
-        pubkey_index = random.randint(min_pubkey_index, max_pubkey_index)
+        pubkey_index = rng.randint(min_pubkey_index, max_pubkey_index)
         pubkey = pubkeys[pubkey_index]
         privkey = privkeys[pubkey_index]
-        amount = random.randint(min_amount, max_amount)
-        random_byte = bytes([random.randint(0, 255)])
+        amount = rng.randint(min_amount, max_amount)
+        random_byte = bytes([rng.randint(0, 255)])
         withdrawal_credentials = spec.BLS_WITHDRAWAL_PREFIX + spec.hash(random_byte)[1:]
         deposit, root, deposit_data_list = build_deposit(
             spec,

--- a/tests/core/pyspec/eth2spec/test/helpers/deposits.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/deposits.py
@@ -80,12 +80,12 @@ def prepare_full_genesis_deposits(spec,
         withdrawal_credentials = spec.BLS_WITHDRAWAL_PREFIX + spec.hash(pubkey)[1:]
         deposit, root, deposit_data_list = build_deposit(
             spec,
-            deposit_data_list,
-            pubkey,
-            privkey,
-            amount,
-            withdrawal_credentials,
-            signed,
+            deposit_data_list=deposit_data_list,
+            pubkey=pubkey,
+            privkey=privkey,
+            amount=amount,
+            withdrawal_credentials=withdrawal_credentials,
+            signed=signed,
         )
         genesis_deposits.append(deposit)
 
@@ -116,11 +116,11 @@ def prepare_random_genesis_deposits(spec,
         withdrawal_credentials = spec.BLS_WITHDRAWAL_PREFIX + spec.hash(random_byte)[1:]
         deposit, root, deposit_data_list = build_deposit(
             spec,
-            deposit_data_list,
-            pubkey,
-            privkey,
-            amount,
-            withdrawal_credentials,
+            deposit_data_list=deposit_data_list,
+            pubkey=pubkey,
+            privkey=privkey,
+            amount=amount,
+            withdrawal_credentials=withdrawal_credentials,
             signed=True,
         )
         deposits.append(deposit)

--- a/tests/core/pyspec/eth2spec/test/phase0/genesis/test_initialization.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/genesis/test_initialization.py
@@ -156,7 +156,7 @@ def test_initialize_beacon_state_random_valid_genesis(spec):
     # Make a bunch of random deposits
     random_deposits, _, deposit_data_list = prepare_random_genesis_deposits(
         spec,
-        num_deposits=30,
+        num_deposits=20,
         min_pubkey_index=spec.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT - 5,
         max_pubkey_index=spec.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT + 5,
     )

--- a/tests/core/pyspec/eth2spec/test/phase0/genesis/test_initialization.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/genesis/test_initialization.py
@@ -45,13 +45,13 @@ def test_initialize_beacon_state_some_small_balances(spec):
     main_deposit_count = spec.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT
     main_deposits, _, deposit_data_list = prepare_full_genesis_deposits(
         spec, spec.MAX_EFFECTIVE_BALANCE,
-        pubkey_max_range=main_deposit_count, signed=True,
+        deposit_count=main_deposit_count, signed=True,
     )
     # For deposits above, and for another deposit_count, add a balance of EFFECTIVE_BALANCE_INCREMENT
     small_deposit_count = main_deposit_count * 2
     small_deposits, deposit_root, _ = prepare_full_genesis_deposits(
         spec, spec.MIN_DEPOSIT_AMOUNT,
-        pubkey_max_range=small_deposit_count,
+        deposit_count=small_deposit_count,
         signed=True,
         deposit_data_list=deposit_data_list,
     )
@@ -83,32 +83,32 @@ def test_initialize_beacon_state_some_small_balances(spec):
 @spec_test
 @single_phase
 def test_initialize_beacon_state_one_topup_activation(spec):
-    # submit all but one deposit as MAX_EFFECTIVE_BALANCE
+    # Submit all but one deposit as MAX_EFFECTIVE_BALANCE
     main_deposit_count = spec.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT - 1
     main_deposits, _, deposit_data_list = prepare_full_genesis_deposits(
         spec, spec.MAX_EFFECTIVE_BALANCE,
-        pubkey_max_range=main_deposit_count, signed=True,
+        deposit_count=main_deposit_count, signed=True,
     )
 
-    # submit last pubkey deposit as MAX_EFFECTIVE_BALANCE - MIN_DEPOSIT_AMOUNT
+    # Submit last pubkey deposit as MAX_EFFECTIVE_BALANCE - MIN_DEPOSIT_AMOUNT
     partial_deposits, _, deposit_data_list = prepare_full_genesis_deposits(
         spec, spec.MAX_EFFECTIVE_BALANCE - spec.MIN_DEPOSIT_AMOUNT,
-        pubkey_max_range=main_deposit_count + 1,
-        pubkey_min_range=main_deposit_count,
+        deposit_count=1,
+        min_pubkey_index=main_deposit_count,
         signed=True,
         deposit_data_list=deposit_data_list,
     )
 
-    # submit last pubkey deposit as MIN_DEPOSIT_AMOUNT to complete the deposit
-    completed_deposits, deposit_root, deposit_data_list = prepare_full_genesis_deposits(
+    # Top up thelast pubkey deposit as MIN_DEPOSIT_AMOUNT to complete the deposit
+    top_up_deposits, _, _ = prepare_full_genesis_deposits(
         spec, spec.MIN_DEPOSIT_AMOUNT,
-        pubkey_max_range=main_deposit_count + 1,
-        pubkey_min_range=main_deposit_count,
+        deposit_count=1,
+        min_pubkey_index=main_deposit_count,
         signed=True,
         deposit_data_list=deposit_data_list,
     )
 
-    deposits = main_deposits + partial_deposits + completed_deposits
+    deposits = main_deposits + partial_deposits + top_up_deposits
 
     eth1_block_hash = b'\x13' * 32
     eth1_timestamp = spec.MIN_GENESIS_TIME
@@ -132,7 +132,7 @@ def test_initialize_beacon_state_random_invalid_genesis(spec):
     # Make a bunch of random deposits
     deposits, _, deposit_data_list = prepare_random_genesis_deposits(
         spec,
-        num_deposits=20,
+        deposit_count=20,
         max_pubkey_index=10,
     )
     eth1_block_hash = b'\x14' * 32
@@ -156,7 +156,7 @@ def test_initialize_beacon_state_random_valid_genesis(spec):
     # Make a bunch of random deposits
     random_deposits, _, deposit_data_list = prepare_random_genesis_deposits(
         spec,
-        num_deposits=20,
+        deposit_count=20,
         min_pubkey_index=spec.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT - 5,
         max_pubkey_index=spec.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT + 5,
     )
@@ -165,7 +165,7 @@ def test_initialize_beacon_state_random_valid_genesis(spec):
     full_deposits, _, _ = prepare_full_genesis_deposits(
         spec,
         spec.MAX_EFFECTIVE_BALANCE,
-        pubkey_max_range=spec.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT,
+        deposit_count=spec.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT,
         signed=True,
         deposit_data_list=deposit_data_list
     )

--- a/tests/core/pyspec/eth2spec/test/phase0/genesis/test_initialization.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/genesis/test_initialization.py
@@ -1,6 +1,7 @@
 from eth2spec.test.context import PHASE0, spec_test, with_phases, single_phase
 from eth2spec.test.helpers.deposits import (
-    prepare_genesis_deposits,
+    prepare_full_genesis_deposits,
+    prepare_random_genesis_deposits,
 )
 
 
@@ -9,7 +10,12 @@ from eth2spec.test.helpers.deposits import (
 @single_phase
 def test_initialize_beacon_state_from_eth1(spec):
     deposit_count = spec.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT
-    deposits, deposit_root, _ = prepare_genesis_deposits(spec, deposit_count, spec.MAX_EFFECTIVE_BALANCE, signed=True)
+    deposits, deposit_root, _ = prepare_full_genesis_deposits(
+        spec,
+        spec.MAX_EFFECTIVE_BALANCE,
+        deposit_count,
+        signed=True,
+    )
 
     eth1_block_hash = b'\x12' * 32
     eth1_timestamp = spec.MIN_GENESIS_TIME
@@ -37,14 +43,18 @@ def test_initialize_beacon_state_from_eth1(spec):
 @single_phase
 def test_initialize_beacon_state_some_small_balances(spec):
     main_deposit_count = spec.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT
-    main_deposits, _, deposit_data_list = prepare_genesis_deposits(spec, main_deposit_count,
-                                                                   spec.MAX_EFFECTIVE_BALANCE, signed=True)
+    main_deposits, _, deposit_data_list = prepare_full_genesis_deposits(
+        spec, spec.MAX_EFFECTIVE_BALANCE,
+        pubkey_max_range=main_deposit_count, signed=True,
+    )
     # For deposits above, and for another deposit_count, add a balance of EFFECTIVE_BALANCE_INCREMENT
     small_deposit_count = main_deposit_count * 2
-    small_deposits, deposit_root, _ = prepare_genesis_deposits(spec, small_deposit_count,
-                                                               spec.MIN_DEPOSIT_AMOUNT,
-                                                               signed=True,
-                                                               deposit_data_list=deposit_data_list)
+    small_deposits, deposit_root, _ = prepare_full_genesis_deposits(
+        spec, spec.MIN_DEPOSIT_AMOUNT,
+        pubkey_max_range=small_deposit_count,
+        signed=True,
+        deposit_data_list=deposit_data_list,
+    )
     deposits = main_deposits + small_deposits
 
     eth1_block_hash = b'\x12' * 32
@@ -66,4 +76,110 @@ def test_initialize_beacon_state_some_small_balances(spec):
     assert spec.get_total_active_balance(state) == main_deposit_count * spec.MAX_EFFECTIVE_BALANCE
 
     # yield state
+    yield 'state', state
+
+
+@with_phases([PHASE0])
+@spec_test
+@single_phase
+def test_initialize_beacon_state_one_topup_activation(spec):
+    # submit all but one deposit as MAX_EFFECTIVE_BALANCE
+    main_deposit_count = spec.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT - 1
+    main_deposits, _, deposit_data_list = prepare_full_genesis_deposits(
+        spec, spec.MAX_EFFECTIVE_BALANCE,
+        pubkey_max_range=main_deposit_count, signed=True,
+    )
+
+    # submit last pubkey deposit as MAX_EFFECTIVE_BALANCE - MIN_DEPOSIT_AMOUNT
+    partial_deposits, _, deposit_data_list = prepare_full_genesis_deposits(
+        spec, spec.MAX_EFFECTIVE_BALANCE - spec.MIN_DEPOSIT_AMOUNT,
+        pubkey_max_range=main_deposit_count + 1,
+        pubkey_min_range=main_deposit_count,
+        signed=True,
+        deposit_data_list=deposit_data_list,
+    )
+
+    # submit last pubkey deposit as MIN_DEPOSIT_AMOUNT to complete the deposit
+    completed_deposits, deposit_root, deposit_data_list = prepare_full_genesis_deposits(
+        spec, spec.MIN_DEPOSIT_AMOUNT,
+        pubkey_max_range=main_deposit_count + 1,
+        pubkey_min_range=main_deposit_count,
+        signed=True,
+        deposit_data_list=deposit_data_list,
+    )
+
+    deposits = main_deposits + partial_deposits + completed_deposits
+
+    eth1_block_hash = b'\x13' * 32
+    eth1_timestamp = spec.MIN_GENESIS_TIME
+
+    yield 'eth1_block_hash', eth1_block_hash
+    yield 'eth1_timestamp', eth1_timestamp
+    yield 'deposits', deposits
+
+    # initialize beacon_state
+    state = spec.initialize_beacon_state_from_eth1(eth1_block_hash, eth1_timestamp, deposits)
+    assert spec.is_valid_genesis_state(state)
+
+    # yield state
+    yield 'state', state
+
+
+@with_phases([PHASE0])
+@spec_test
+@single_phase
+def test_initialize_beacon_state_random_invalid_genesis(spec):
+    # Make a bunch of random deposits
+    deposits, _, deposit_data_list = prepare_random_genesis_deposits(
+        spec,
+        num_deposits=20,
+        max_pubkey_index=10,
+    )
+    eth1_block_hash = b'\x14' * 32
+    eth1_timestamp = spec.MIN_GENESIS_TIME + 1
+
+    yield 'eth1_block_hash', eth1_block_hash
+    yield 'eth1_timestamp', eth1_timestamp
+    yield 'deposits', deposits
+
+    # initialize beacon_state
+    state = spec.initialize_beacon_state_from_eth1(eth1_block_hash, eth1_timestamp, deposits)
+    assert not spec.is_valid_genesis_state(state)
+
+    yield 'state', state
+
+
+@with_phases([PHASE0])
+@spec_test
+@single_phase
+def test_initialize_beacon_state_random_valid_genesis(spec):
+    # Make a bunch of random deposits
+    random_deposits, _, deposit_data_list = prepare_random_genesis_deposits(
+        spec,
+        num_deposits=30,
+        min_pubkey_index=spec.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT - 5,
+        max_pubkey_index=spec.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT + 5,
+    )
+
+    # Then make spec.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT full deposits
+    full_deposits, _, _ = prepare_full_genesis_deposits(
+        spec,
+        spec.MAX_EFFECTIVE_BALANCE,
+        pubkey_max_range=spec.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT,
+        signed=True,
+        deposit_data_list=deposit_data_list
+    )
+
+    deposits = random_deposits + full_deposits
+    eth1_block_hash = b'\x15' * 32
+    eth1_timestamp = spec.MIN_GENESIS_TIME + 2
+
+    yield 'eth1_block_hash', eth1_block_hash
+    yield 'eth1_timestamp', eth1_timestamp
+    yield 'deposits', deposits
+
+    # initialize beacon_state
+    state = spec.initialize_beacon_state_from_eth1(eth1_block_hash, eth1_timestamp, deposits)
+    assert spec.is_valid_genesis_state(state)
+
     yield 'state', state

--- a/tests/core/pyspec/eth2spec/test/phase0/genesis/test_validity.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/genesis/test_validity.py
@@ -9,7 +9,7 @@ def create_valid_beacon_state(spec):
     deposits, _, _ = prepare_full_genesis_deposits(
         spec,
         amount=spec.MAX_EFFECTIVE_BALANCE,
-        pubkey_max_range=deposit_count,
+        deposit_count=deposit_count,
         signed=True,
     )
 
@@ -77,7 +77,7 @@ def test_is_valid_genesis_state_true_one_more_validator(spec):
     deposits, _, _ = prepare_full_genesis_deposits(
         spec,
         amount=spec.MAX_EFFECTIVE_BALANCE,
-        pubkey_max_range=deposit_count,
+        deposit_count=deposit_count,
         signed=True,
     )
 
@@ -96,7 +96,7 @@ def test_is_valid_genesis_state_false_not_enough_validator(spec):
     deposits, _, _ = prepare_full_genesis_deposits(
         spec,
         amount=spec.MAX_EFFECTIVE_BALANCE,
-        pubkey_max_range=deposit_count,
+        deposit_count=deposit_count,
         signed=True,
     )
 

--- a/tests/core/pyspec/eth2spec/test/phase0/genesis/test_validity.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/genesis/test_validity.py
@@ -1,12 +1,12 @@
 from eth2spec.test.context import PHASE0, spec_test, with_phases, single_phase
 from eth2spec.test.helpers.deposits import (
-    prepare_genesis_deposits,
+    prepare_full_genesis_deposits,
 )
 
 
 def create_valid_beacon_state(spec):
     deposit_count = spec.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT
-    deposits, _, _ = prepare_genesis_deposits(spec, deposit_count, spec.MAX_EFFECTIVE_BALANCE, signed=True)
+    deposits, _, _ = prepare_full_genesis_deposits(spec, deposit_count, spec.MAX_EFFECTIVE_BALANCE, signed=True)
 
     eth1_block_hash = b'\x12' * 32
     eth1_timestamp = spec.MIN_GENESIS_TIME
@@ -69,7 +69,7 @@ def test_is_valid_genesis_state_true_more_balance(spec):
 @single_phase
 def test_is_valid_genesis_state_true_one_more_validator(spec):
     deposit_count = spec.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT + 1
-    deposits, _, _ = prepare_genesis_deposits(spec, deposit_count, spec.MAX_EFFECTIVE_BALANCE, signed=True)
+    deposits, _, _ = prepare_full_genesis_deposits(spec, deposit_count, spec.MAX_EFFECTIVE_BALANCE, signed=True)
 
     eth1_block_hash = b'\x12' * 32
     eth1_timestamp = spec.MIN_GENESIS_TIME
@@ -83,7 +83,7 @@ def test_is_valid_genesis_state_true_one_more_validator(spec):
 @single_phase
 def test_is_valid_genesis_state_false_not_enough_validator(spec):
     deposit_count = spec.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT - 1
-    deposits, _, _ = prepare_genesis_deposits(spec, deposit_count, spec.MAX_EFFECTIVE_BALANCE, signed=True)
+    deposits, _, _ = prepare_full_genesis_deposits(spec, deposit_count, spec.MAX_EFFECTIVE_BALANCE, signed=True)
 
     eth1_block_hash = b'\x12' * 32
     eth1_timestamp = spec.MIN_GENESIS_TIME

--- a/tests/core/pyspec/eth2spec/test/phase0/genesis/test_validity.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/genesis/test_validity.py
@@ -6,7 +6,12 @@ from eth2spec.test.helpers.deposits import (
 
 def create_valid_beacon_state(spec):
     deposit_count = spec.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT
-    deposits, _, _ = prepare_full_genesis_deposits(spec, deposit_count, spec.MAX_EFFECTIVE_BALANCE, signed=True)
+    deposits, _, _ = prepare_full_genesis_deposits(
+        spec,
+        amount=spec.MAX_EFFECTIVE_BALANCE,
+        pubkey_max_range=deposit_count,
+        signed=True,
+    )
 
     eth1_block_hash = b'\x12' * 32
     eth1_timestamp = spec.MIN_GENESIS_TIME
@@ -69,7 +74,12 @@ def test_is_valid_genesis_state_true_more_balance(spec):
 @single_phase
 def test_is_valid_genesis_state_true_one_more_validator(spec):
     deposit_count = spec.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT + 1
-    deposits, _, _ = prepare_full_genesis_deposits(spec, deposit_count, spec.MAX_EFFECTIVE_BALANCE, signed=True)
+    deposits, _, _ = prepare_full_genesis_deposits(
+        spec,
+        amount=spec.MAX_EFFECTIVE_BALANCE,
+        pubkey_max_range=deposit_count,
+        signed=True,
+    )
 
     eth1_block_hash = b'\x12' * 32
     eth1_timestamp = spec.MIN_GENESIS_TIME
@@ -83,7 +93,12 @@ def test_is_valid_genesis_state_true_one_more_validator(spec):
 @single_phase
 def test_is_valid_genesis_state_false_not_enough_validator(spec):
     deposit_count = spec.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT - 1
-    deposits, _, _ = prepare_full_genesis_deposits(spec, deposit_count, spec.MAX_EFFECTIVE_BALANCE, signed=True)
+    deposits, _, _ = prepare_full_genesis_deposits(
+        spec,
+        amount=spec.MAX_EFFECTIVE_BALANCE,
+        pubkey_max_range=deposit_count,
+        signed=True,
+    )
 
     eth1_block_hash = b'\x12' * 32
     eth1_timestamp = spec.MIN_GENESIS_TIME


### PR DESCRIPTION
Covers the top-up case that was missing in Teku Spadina genesis (https://github.com/PegaSysEng/teku/pull/2855).
Also adds some randomized tests covering partial deposits, top-ups, different withdrawal creds, etc

Note: these tests are pretty expensive to run so I don't suggest adding any more. I think the randomized cases should cover a lot of what we are worried about. 