### PR TITLE
Bump milagro_bls_binding to 1.5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -537,7 +537,7 @@ setup(
         "eth-typing>=2.1.0,<3.0.0",
         "pycryptodome==3.9.4",
         "py_ecc==5.0.0",
-        "milagro_bls_binding==1.4.0",
+        "milagro_bls_binding==1.5.0",
         "dataclasses==0.6",
         "remerkleable==0.1.17",
         "ruamel.yaml==0.16.5",

--- a/tests/core/pyspec/eth2spec/utils/bls.py
+++ b/tests/core/pyspec/eth2spec/utils/bls.py
@@ -67,11 +67,6 @@ def AggregateVerify(pubkeys, messages, signature):
 
 @only_with_bls(alt_return=True)
 def FastAggregateVerify(pubkeys, message, signature):
-    # TODO: remove it when milagro_bls_binding is fixed
-    # https://github.com/ChihChengLiang/milagro_bls_binding/issues/19
-    if Z1_PUBKEY in pubkeys:
-        return False
-
     try:
         result = bls.FastAggregateVerify(list(pubkeys), message, signature)
     except Exception:
@@ -87,9 +82,6 @@ def Aggregate(signatures):
 
 @only_with_bls(alt_return=STUB_SIGNATURE)
 def Sign(SK, message):
-    # TODO: remove it when https://github.com/sigp/milagro_bls/issues/39 is fixed
-    if SK == 0:
-        raise Exception("SK should not be zero")
     if bls == py_ecc_bls:
         return bls.Sign(SK, message)
     else:

--- a/tests/generators/bls/main.py
+++ b/tests/generators/bls/main.py
@@ -83,8 +83,7 @@ def case01_sign():
             }
     # Edge case: privkey == 0
     expect_exception(bls.Sign, ZERO_PRIVKEY, message)
-    # TODO enable it when milagro_bls is ready for IETF BLS draft 04
-    # expect_exception(milagro_bls.Sign, ZERO_PRIVKEY_BYTES, message)
+    expect_exception(milagro_bls.Sign, ZERO_PRIVKEY_BYTES, message)
     yield f'sign_case_zero_privkey', {
         'input': {
             'privkey': encode_hex(ZERO_PRIVKEY_BYTES),
@@ -267,8 +266,7 @@ def case04_fast_aggregate_verify():
     signatures = [bls.Sign(privkey, SAMPLE_MESSAGE) for privkey in PRIVKEYS]
     aggregate_signature = bls.Aggregate(signatures)
     assert not bls.FastAggregateVerify(pubkeys_with_infinity, SAMPLE_MESSAGE, aggregate_signature)
-    # TODO enable it when milagro_bls is ready for IETF BLS draft 04
-    # assert not milagro_bls.FastAggregateVerify(pubkeys_with_infinity, SAMPLE_MESSAGE, aggregate_signature)
+    assert not milagro_bls.FastAggregateVerify(pubkeys_with_infinity, SAMPLE_MESSAGE, aggregate_signature)
     yield f'fast_aggregate_verify_infinity_pubkey', {
         'input': {
             'pubkeys': [encode_hex(pubkey) for pubkey in pubkeys_with_infinity],


### PR DESCRIPTION
### Issue
https://github.com/ethereum/eth2.0-specs/pull/2080#issuecomment-703654081

### How did I fix it
- [`milagro_bls` v1.3.0](https://github.com/sigp/milagro_bls/releases/tag/v1.3.0) [fixed the edge cases](https://github.com/sigp/milagro_bls/pull/41).
- [`milagro_bls_binding` v1.5.0](https://github.com/ChihChengLiang/milagro_bls_binding/releases/tag/v1.5.0) updated correspondingly.

So we can bump `milagro_bls_binding` to 1.5.0 and remove the workaround code now. 🎉 