### PR TITLE
Simplify fork choice spec

### DIFF
--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -230,7 +230,7 @@ def get_head(store: Store) -> Root:
     while True:
         children = [
             root for root in blocks.keys()
-            if blocks[root].parent_root == head and blocks[root].slot > justified_slot
+            if blocks[root].parent_root == head
         ]
         if len(children) == 0:
             return head

--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -226,7 +226,6 @@ def get_head(store: Store) -> Root:
     blocks = get_filtered_block_tree(store)
     # Execute the LMD-GHOST fork choice
     head = store.justified_checkpoint.root
-    justified_slot = compute_start_slot_at_epoch(store.justified_checkpoint.epoch)
     while True:
         children = [
             root for root in blocks.keys()


### PR DESCRIPTION
This change should be non-substantive as any blocks in `blocks` should be descendants (inclusive) of the `store.justified_checkpoint` (refer `get_filtered_block_tree`) so that in `get_head` all blocks considered as potential heads will have `slot > justified_slot`. Considering this condition universally applies, adding the `and ...` arm to the conditional is unnecessary overhead.