### PR TITLE
Ignore voluntary exits for slashed validators.

### DIFF
--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -1809,6 +1809,11 @@ def process_deposit(state: BeaconState, deposit: Deposit) -> None:
 def process_voluntary_exit(state: BeaconState, signed_voluntary_exit: SignedVoluntaryExit) -> None:
     voluntary_exit = signed_voluntary_exit.message
     validator = state.validators[voluntary_exit.validator_index]
+
+    # Slashed validators cannot voluntarily exit
+    if validator.slashed:
+        return
+
     # Verify the validator is active
     assert is_active_validator(validator, get_current_epoch(state))
     # Verify exit has not been initiated


### PR DESCRIPTION
Fixes #2084.

In the current spec, including a voluntary exit in the same block as a slashing would result in an invalid block, implying an invalid slashing. We would like any valid slashings on-chain to remain valid in all contexts to ensure protocol safety.

This PR implements a straightforward solution to this problem by simply ignoring any exits for slashed validators.

NOTE: this potentially opens a DoS vector as any block w/ a slashing can now contain the maximum number of exits for the slashed validators and allow excess networking burden (bigger blocks) for no gain to the protocol. However, given the small number of max exits allowed per block, this doesn't seem like a profitable avenue of attack.