### PR TITLE
Fix timing attack

### DIFF
--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -89,8 +89,8 @@ All terminology, constants, functions, and protocol mechanics defined in the [Ph
 | `RANDOM_SUBNETS_PER_VALIDATOR` | `2**0` (= 1) | subnets | |
 | `EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION` | `2**8` (= 256) | epochs | ~27 hours |
 | `ATTESTATION_SUBNET_COUNT` | `64` | The number of attestation subnets used in the gossipsub protocol. |
-| `ATTESTATION_PRODUCTION_DIVISOR` | `3` | Defines the fraction of a slot at which attestations are produced on average. |
-| `ATTESTATION_ENTROPY_DIVISOR` | `12` | Defines the fraction of a slot within which period the attestation production is randomized. |
+| `ATTESTATION_PRODUCTION_DIVISOR` | `3` | The fraction of a slot at which attestations are produced on average. |
+| `ATTESTATION_ENTROPY_DIVISOR` | `12` | The fraction of a slot defining the interval upon which attestation production is randomized. |
 
 ## Becoming a validator
 
@@ -393,13 +393,13 @@ def get_block_signature(state: BeaconState, block: BeaconBlock, privkey: int) ->
 
 A validator is expected to create, sign, and broadcast an attestation during each epoch. The `committee`, assigned `index`, and assigned `slot` for which the validator performs this role during an epoch are defined by `get_committee_assignment(state, epoch, validator_index)`.
 
-For each `slot`, a validator should generate a uniform random variable `slot_timing_entropy` between `(-SECONDS_PER_SLOT/ATTESTATION_ENTROPY_DIVISOR, SECONDS_PER_SLOT/ATTESTATION_ENTROPY_DIVISOR)` with millisecond resolution and using local entropy.
+For each `slot`, a validator must generate a uniform random variable `slot_timing_entropy` between `(-SECONDS_PER_SLOT / ATTESTATION_ENTROPY_DIVISOR, SECONDS_PER_SLOT / ATTESTATION_ENTROPY_DIVISOR)` with millisecond resolution and using local entropy.
 
-A validator should create and broadcast the `attestation` to the associated attestation subnet when the earlier one of these two events occurs:
-  - the validator has received a valid block from the expected block proposer for the assigned `slot`, or
-  - `SECONDS_PER_SLOT/ATTESTATION_PRODUCTION_DIVISOR + slot_timing_entropy` seconds have elapsed since the start of the `slot` (using the `slot_timing_entropy` generated for this slot)
+A validator must create and broadcast the `attestation` to the associated attestation subnet when the earlier one of the following two events occurs:
+  - The validator has received a valid block from the expected block proposer for the assigned `slot`
+  - `SECONDS_PER_SLOT / ATTESTATION_PRODUCTION_DIVISOR + slot_timing_entropy` seconds have elapsed since the start of the `slot` (using the `slot_timing_entropy` generated for this slot)
 
-*Note*: The validator must compute `head_block = get_head(store)` when earlier of the two above listed events has occurred. Specifically, `head_block` must be the current head block according to the fork choice when the event was triggered, and not any cached/stored value from a previous time.
+*Note*: The validator must compute `head_block = get_head(store)` when the earlier of the two above events has occurred. Specifically, `head_block` must be the current head block according to the fork choice when the event was triggered, and not any cached/stored value from a previous time.
 
 *Note*: Although attestations during `GENESIS_EPOCH` do not count toward FFG finality, these initial attestations do give weight to the fork choice, are rewarded, and should be made.
 

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -89,6 +89,8 @@ All terminology, constants, functions, and protocol mechanics defined in the [Ph
 | `RANDOM_SUBNETS_PER_VALIDATOR` | `2**0` (= 1) | subnets | |
 | `EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION` | `2**8` (= 256) | epochs | ~27 hours |
 | `ATTESTATION_SUBNET_COUNT` | `64` | The number of attestation subnets used in the gossipsub protocol. |
+| `ATTESTATION_PRODUCTION_DIVISOR` | `3` | Defines the fraction of a slot at which attestations are produced on average. |
+| `ATTESTATION_ENTROPY_DIVISOR` | `6` | Defines the fraction of a slot within which period the attestation production is randomized. |
 
 ## Becoming a validator
 
@@ -391,11 +393,11 @@ def get_block_signature(state: BeaconState, block: BeaconBlock, privkey: int) ->
 
 A validator is expected to create, sign, and broadcast an attestation during each epoch. The `committee`, assigned `index`, and assigned `slot` for which the validator performs this role during an epoch are defined by `get_committee_assignment(state, epoch, validator_index)`.
 
-For each `slot`, a validator should generate a uniform random variable `slot_timing_entropy` between `(-SECONDS_PER_SLOT/6, SECONDS_PER_SLOT/6)` with millisecond resolution and using local entropy.
+For each `slot`, a validator should generate a uniform random variable `slot_timing_entropy` between `(-SECONDS_PER_SLOT/ATTESTATION_ENTROPY_DIVISOR, SECONDS_PER_SLOT/ATTESTATION_ENTROPY_DIVISOR)` with millisecond resolution and using local entropy.
 
 A validator should create and broadcast the `attestation` to the associated attestation subnet when the earlier one of these two events occurs:
   - the validator has received a valid block from the expected block proposer for the assigned `slot`, or
-  - `SECONDS_PER_SLOT/3 + slot_timing_entropy` seconds have elapsed since the start of the `slot` (using the `slot_timing_entropy` generated for this slot)
+  - `SECONDS_PER_SLOT/ATTESTATION_PRODUCTION_DIVISOR + slot_timing_entropy` seconds have elapsed since the start of the `slot` (using the `slot_timing_entropy` generated for this slot)
 
 *Note*: Although attestations during `GENESIS_EPOCH` do not count toward FFG finality, these initial attestations do give weight to the fork choice, are rewarded, and should be made.
 

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -399,6 +399,8 @@ A validator should create and broadcast the `attestation` to the associated atte
   - the validator has received a valid block from the expected block proposer for the assigned `slot`, or
   - `SECONDS_PER_SLOT/ATTESTATION_PRODUCTION_DIVISOR + slot_timing_entropy` seconds have elapsed since the start of the `slot` (using the `slot_timing_entropy` generated for this slot)
 
+*Note*: The validator must compute `head_block = get_head(store)` when earlier of the two above listed events has occurred. Specifically, `head_block` must be the current head block according to the fork choice when the event was triggered, and not any cached/stored value from a previous time.
+
 *Note*: Although attestations during `GENESIS_EPOCH` do not count toward FFG finality, these initial attestations do give weight to the fork choice, are rewarded, and should be made.
 
 #### Attestation data

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -391,11 +391,11 @@ def get_block_signature(state: BeaconState, block: BeaconBlock, privkey: int) ->
 
 A validator is expected to create, sign, and broadcast an attestation during each epoch. The `committee`, assigned `index`, and assigned `slot` for which the validator performs this role during an epoch are defined by `get_committee_assignment(state, epoch, validator_index)`.
 
-At the beginning of each `slot`, a validator should generate a uniform random variable `slot_timing_entropy` between `(-SECONDS_PER_SLOT/6, SECONDS_PER_SLOT/6)` with millisecond resolution and using local entropy.
+For each `slot`, a validator should generate a uniform random variable `slot_timing_entropy` between `(-SECONDS_PER_SLOT/6, SECONDS_PER_SLOT/6)` with millisecond resolution and using local entropy.
 
 A validator should create and broadcast the `attestation` to the associated attestation subnet when the earlier one of these two events occurs:
   - the validator has received a valid block from the expected block proposer for the assigned `slot`, or
-  - `SECONDS_PER_SLOT/3 + slot_timing_entropy` seconds have elapsed since the start of the `slot` (using the `slot_timing_entropy` generated in this slot)
+  - `SECONDS_PER_SLOT/3 + slot_timing_entropy` seconds have elapsed since the start of the `slot` (using the `slot_timing_entropy` generated for this slot)
 
 *Note*: Although attestations during `GENESIS_EPOCH` do not count toward FFG finality, these initial attestations do give weight to the fork choice, are rewarded, and should be made.
 

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -90,7 +90,7 @@ All terminology, constants, functions, and protocol mechanics defined in the [Ph
 | `EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION` | `2**8` (= 256) | epochs | ~27 hours |
 | `ATTESTATION_SUBNET_COUNT` | `64` | The number of attestation subnets used in the gossipsub protocol. |
 | `ATTESTATION_PRODUCTION_DIVISOR` | `3` | Defines the fraction of a slot at which attestations are produced on average. |
-| `ATTESTATION_ENTROPY_DIVISOR` | `6` | Defines the fraction of a slot within which period the attestation production is randomized. |
+| `ATTESTATION_ENTROPY_DIVISOR` | `12` | Defines the fraction of a slot within which period the attestation production is randomized. |
 
 ## Becoming a validator
 

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -391,7 +391,7 @@ def get_block_signature(state: BeaconState, block: BeaconBlock, privkey: int) ->
 
 A validator is expected to create, sign, and broadcast an attestation during each epoch. The `committee`, assigned `index`, and assigned `slot` for which the validator performs this role during an epoch are defined by `get_committee_assignment(state, epoch, validator_index)`.
 
-A validator should generate a uniform random variable `slot_timing_entropy` between `(-SECONDS_PER_SLOT/6, SECONDS_PER_SLOT/6)` using local entropy at the beginning of each slot.
+At the beginning of each `slot`, a validator should generate a uniform random variable `slot_timing_entropy` between `(-SECONDS_PER_SLOT/6, SECONDS_PER_SLOT/6)` with millisecond resolution and using local entropy.
 
 A validator should create and broadcast the `attestation` to the associated attestation subnet when the earlier one of these two events occurs:
   - the validator has received a valid block from the expected block proposer for the assigned `slot`, or

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -391,7 +391,11 @@ def get_block_signature(state: BeaconState, block: BeaconBlock, privkey: int) ->
 
 A validator is expected to create, sign, and broadcast an attestation during each epoch. The `committee`, assigned `index`, and assigned `slot` for which the validator performs this role during an epoch are defined by `get_committee_assignment(state, epoch, validator_index)`.
 
-A validator should create and broadcast the `attestation` to the associated attestation subnet when either (a) the validator has received a valid block from the expected block proposer for the assigned `slot` or (b) one-third of the `slot` has transpired (`SECONDS_PER_SLOT / 3` seconds after the start of `slot`) -- whichever comes _first_.
+A validator should generate a uniform random variable `slot_timing_entropy` between `(-SECONDS_PER_SLOT/6, SECONDS_PER_SLOT/6)` using local entropy at the beginning of each slot.
+
+A validator should create and broadcast the `attestation` to the associated attestation subnet when the earlier of either of these two events occurs:
+  - the validator has received a valid block from the expected block proposer for the assigned `slot`, or
+  - `SECONDS_PER_SLOT/3 + slot_timing_entropy` seconds have elapsed since the start of the `slot` (using the `slot_timing_entropy` generated in this slot)
 
 *Note*: Although attestations during `GENESIS_EPOCH` do not count toward FFG finality, these initial attestations do give weight to the fork choice, are rewarded, and should be made.
 

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -393,7 +393,7 @@ A validator is expected to create, sign, and broadcast an attestation during eac
 
 A validator should generate a uniform random variable `slot_timing_entropy` between `(-SECONDS_PER_SLOT/6, SECONDS_PER_SLOT/6)` using local entropy at the beginning of each slot.
 
-A validator should create and broadcast the `attestation` to the associated attestation subnet when the earlier of either of these two events occurs:
+A validator should create and broadcast the `attestation` to the associated attestation subnet when the earlier one of these two events occurs:
   - the validator has received a valid block from the expected block proposer for the assigned `slot`, or
   - `SECONDS_PER_SLOT/3 + slot_timing_entropy` seconds have elapsed since the start of the `slot` (using the `slot_timing_entropy` generated in this slot)
 

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -396,10 +396,10 @@ A validator is expected to create, sign, and broadcast an attestation during eac
 For each `slot`, a validator must generate a uniform random variable `slot_timing_entropy` between `(-SECONDS_PER_SLOT / ATTESTATION_ENTROPY_DIVISOR, SECONDS_PER_SLOT / ATTESTATION_ENTROPY_DIVISOR)` with millisecond resolution and using local entropy.
 
 A validator must create and broadcast the `attestation` to the associated attestation subnet when the earlier one of the following two events occurs:
-  - The validator has received a valid block from the expected block proposer for the assigned `slot`
+  - The validator has received a valid block from the expected block proposer for the assigned `slot`. In this case, the validator must set a timer for `abs(slot_timing_entropy)`. The end of this timer will be the trigger for attestation production.
   - `SECONDS_PER_SLOT / ATTESTATION_PRODUCTION_DIVISOR + slot_timing_entropy` seconds have elapsed since the start of the `slot` (using the `slot_timing_entropy` generated for this slot)
 
-*Note*: The validator must compute `head_block = get_head(store)` when the earlier of the two above events has occurred. Specifically, `head_block` must be the current head block according to the fork choice when the event was triggered, and not any cached/stored value from a previous time.
+*Note*: The validator must compute `head_block = get_head(store)` when the earlier of the two above events has occurred. Specifically, `head_block` must be the current head block according to the fork choice when the attestation production was triggered, and not any cached/stored value from a previous time.
 
 *Note*: Although attestations during `GENESIS_EPOCH` do not count toward FFG finality, these initial attestations do give weight to the fork choice, are rewarded, and should be made.
 


### PR DESCRIPTION
The PR introduces a simple fix for the fork choice timing attack presented in this paper: https://arxiv.org/abs/2009.04987

By making the attestation production time unpredictable to the attacker & unique for each validator, we make it harder for an attacker to separately influence the fork choice of disjoint subsets of validators by sending well-timed messages to each set, such that these messages are not gossiped with the other subset of validators before attestations for the slot are produced.