### PR TITLE
Make `state_transition` not return post-state

### DIFF
--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -1202,7 +1202,7 @@ Let `genesis_block = BeaconBlock(state_root=hash_tree_root(genesis_state))`.
 The post-state corresponding to a pre-state `state` and a signed block `signed_block` is defined as `state_transition(state, signed_block)`. State transitions that trigger an unhandled exception (e.g. a failed `assert` or an out-of-range list access) are considered invalid. State transitions that cause a `uint64` overflow or underflow are also considered invalid.
 
 ```python
-def state_transition(state: BeaconState, signed_block: SignedBeaconBlock, validate_result: bool=True) -> BeaconState:
+def state_transition(state: BeaconState, signed_block: SignedBeaconBlock, validate_result: bool=True) -> None:
     block = signed_block.message
     # Process slots (including those with no blocks) since block
     process_slots(state, block.slot)
@@ -1214,8 +1214,6 @@ def state_transition(state: BeaconState, signed_block: SignedBeaconBlock, valida
     # Verify state root
     if validate_result:
         assert block.state_root == hash_tree_root(state)
-    # Return post-state
-    return state
 ```
 
 ```python

--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -355,7 +355,8 @@ def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
     assert get_ancestor(store, block.parent_root, finalized_slot) == store.finalized_checkpoint.root
 
     # Check the block is valid and compute the post-state
-    state = state_transition(pre_state, signed_block, True)
+    state = pre_state.copy()
+    state_transition(state, signed_block, True)
     # Add new block to the store
     store.blocks[hash_tree_root(block)] = block
     # Add new state for this block to the store

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -372,7 +372,7 @@ It is useful to be able to run a state transition function (working on a copy of
 def compute_new_state_root(state: BeaconState, block: BeaconBlock) -> Root:
     temp_state: BeaconState = state.copy()
     signed_block = SignedBeaconBlock(message=block)
-    temp_state = state_transition(temp_state, signed_block, validate_result=False)
+    state_transition(temp_state, signed_block, validate_result=False)
     return hash_tree_root(temp_state)
 ```
 

--- a/specs/phase1/shard-transition.md
+++ b/specs/phase1/shard-transition.md
@@ -72,14 +72,13 @@ The post-state corresponding to a pre-state `shard_state` and a signed block `si
 def shard_state_transition(shard_state: ShardState,
                            signed_block: SignedShardBlock,
                            beacon_parent_state: BeaconState,
-                           validate_result: bool = True) -> ShardState:
+                           validate_result: bool = True) -> None:
     assert verify_shard_block_message(beacon_parent_state, shard_state, signed_block.message)
 
     if validate_result:
         assert verify_shard_block_signature(beacon_parent_state, signed_block)
 
     process_shard_block(shard_state, signed_block.message)
-    return shard_state
 ```
 
 ```python


### PR DESCRIPTION
### Issue
1. It's arguable that the mutability side effect is smell (see #1932 discussion). Although I personally want to remove the side effect, we decide to keep it for now for the code concision and stability.
2. What worse than the mutability side effect is that the `state_transition` provides two patterns: (i) it mutates the given `state` and also (ii) returns the post-state. We're using (i) in the whole specs and (ii) only exists in `state_transition`.

### How did I fix it
Make `state_transition` not return post-state. The given pre-state should have been mutated to post-state.