### PR TITLE
ensure aggregate attestation's slot and target are consistent

### DIFF
--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -333,6 +333,8 @@ The following validations MUST pass before forwarding the `signed_aggregate_and_
 - _[IGNORE]_ `aggregate.data.slot` is within the last `ATTESTATION_PROPAGATION_SLOT_RANGE` slots (with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance) --
   i.e. `aggregate.data.slot + ATTESTATION_PROPAGATION_SLOT_RANGE >= current_slot >= aggregate.data.slot`
   (a client MAY queue future aggregates for processing at the appropriate slot).
+- _[REJECT]_ The aggregate attestation's epoch matches its target -- i.e. `aggregate.data.target.epoch ==
+  compute_epoch_at_slot(aggregate.data.slot)`
 - _[IGNORE]_ The valid aggregate attestation defined by `hash_tree_root(aggregate)` has _not_ already been seen
   (via aggregate gossip, within a verified block, or through the creation of an equivalent aggregate locally).
 - _[IGNORE]_ The `aggregate` is the first valid aggregate received for the aggregator


### PR DESCRIPTION
@terencechain pointed out that `beacon_aggregate_and_proof` does not have a consistency check for an attestation's `slot` and `target.epoch`, while `beacon_attestation_{subnet_id}` does.

This could lead to a dos vector via malformed aggregates