### PR TITLE
Increase gossipsub mesh degree

### DIFF
--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -214,8 +214,8 @@ including the [gossipsub v1.1](https://github.com/libp2p/specs/blob/master/pubsu
 
 The following gossipsub [parameters](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.0.md#parameters) will be used:
 
-- `D` (topic stable mesh target count): 6
-- `D_low` (topic stable mesh low watermark): 5
+- `D` (topic stable mesh target count): 8
+- `D_low` (topic stable mesh low watermark): 6
 - `D_high` (topic stable mesh high watermark): 12
 - `D_lazy` (gossip target): 6
 - `heartbeat_interval` (frequency of heartbeat, seconds): 0.7


### PR DESCRIPTION
I'm aware this is late, apologies.

After some discussion with various people, including vyzo, it is generally thought that increasing the degree of the mesh slightly provides better gossip performance. These updated values are used in Lotus (filecoin) and currently in Lighthouse. 

It's not critical that all clients use these values, but potentially it may be better to update the spec to encourage this increased mesh degree. 