### PR TITLE
fix multi-operation test runner helper

### DIFF
--- a/tests/core/pyspec/eth2spec/test/helpers/multi_operations.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/multi_operations.py
@@ -148,8 +148,9 @@ def run_test_full_random_operations(spec, state, rng=Random(2080)):
         slashed_indices = slashed_indices.union(attester_slashing.attestation_2.attesting_indices)
     block.body.voluntary_exits = get_random_voluntary_exits(spec, state, slashed_indices, rng)
 
+    yield 'pre', state
+
     signed_block = state_transition_and_sign_block(spec, state, block)
 
-    yield 'pre', state
     yield 'blocks', [signed_block]
     yield 'post', state


### PR DESCRIPTION
Test gen was rendering the post state for pre and post. Fix order of operations to render properly.

Thanks @ajsutton!

Note, this has already been patched to the test vector release. Plans is to merge into master here. Then backport to dev. Will _not_ cut a new spec release