### PR TITLE
executable light client patch: beacon-chain.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ eth2.0-spec-tests/
 # Dynamically built from Markdown spec
 tests/core/pyspec/eth2spec/phase0/
 tests/core/pyspec/eth2spec/phase1/
-tests/core/pyspec/eth2spec/lightclient/
+tests/core/pyspec/eth2spec/lightclient_patch/
 
 # coverage reports
 .htmlcov

--- a/Makefile
+++ b/Makefile
@@ -86,11 +86,11 @@ install_test:
 
 test: pyspec
 	. venv/bin/activate; cd $(PY_SPEC_DIR); \
-	python -m pytest -n 4 --disable-bls --cov=eth2spec.phase0.spec --cov=eth2spec.phase1.spec --cov-report="html:$(COV_HTML_OUT)" --cov-branch eth2spec
+	python -m pytest -n 4 --disable-bls --cov=eth2spec.phase0.spec --cov=eth2spec.phase1.spec --cov=eth2spec.lightclient.spec -cov-report="html:$(COV_HTML_OUT)" --cov-branch eth2spec
 
 find_test: pyspec
 	. venv/bin/activate; cd $(PY_SPEC_DIR); \
-	python -m pytest -k=$(K) --disable-bls --cov=eth2spec.phase0.spec --cov=eth2spec.phase1.spec --cov-report="html:$(COV_HTML_OUT)" --cov-branch eth2spec
+	python -m pytest -k=$(K) --disable-bls --cov=eth2spec.phase0.spec --cov=eth2spec.phase1.spec --cov=eth2spec.lightclient.spec --cov-report="html:$(COV_HTML_OUT)" --cov-branch eth2spec
 
 citest: pyspec
 	mkdir -p tests/core/pyspec/test-reports/eth2spec; . venv/bin/activate; cd $(PY_SPEC_DIR); \

--- a/Makefile
+++ b/Makefile
@@ -86,11 +86,11 @@ install_test:
 
 test: pyspec
 	. venv/bin/activate; cd $(PY_SPEC_DIR); \
-	python -m pytest -n 4 --disable-bls --cov=eth2spec.phase0.spec --cov=eth2spec.phase1.spec --cov=eth2spec.lightclient.spec -cov-report="html:$(COV_HTML_OUT)" --cov-branch eth2spec
+	python -m pytest -n 4 --disable-bls --cov=eth2spec.phase0.spec --cov=eth2spec.phase1.spec --cov=eth2spec.lightclient_patch.spec -cov-report="html:$(COV_HTML_OUT)" --cov-branch eth2spec
 
 find_test: pyspec
 	. venv/bin/activate; cd $(PY_SPEC_DIR); \
-	python -m pytest -k=$(K) --disable-bls --cov=eth2spec.phase0.spec --cov=eth2spec.phase1.spec --cov=eth2spec.lightclient.spec --cov-report="html:$(COV_HTML_OUT)" --cov-branch eth2spec
+	python -m pytest -k=$(K) --disable-bls --cov=eth2spec.phase0.spec --cov=eth2spec.phase1.spec --cov=eth2spec.lightclient_patch.spec --cov-report="html:$(COV_HTML_OUT)" --cov-branch eth2spec
 
 citest: pyspec
 	mkdir -p tests/core/pyspec/test-reports/eth2spec; . venv/bin/activate; cd $(PY_SPEC_DIR); \
@@ -113,7 +113,7 @@ codespell:
 lint: pyspec
 	. venv/bin/activate; cd $(PY_SPEC_DIR); \
 	flake8  --config $(LINTER_CONFIG_FILE) ./eth2spec \
-	&& mypy --config-file $(LINTER_CONFIG_FILE) -p eth2spec.phase0 -p eth2spec.phase1 -p eth2spec.lightclient
+	&& mypy --config-file $(LINTER_CONFIG_FILE) -p eth2spec.phase0 -p eth2spec.phase1 -p eth2spec.lightclient_patch
 
 lint_generators: pyspec
 	. venv/bin/activate; cd $(TEST_GENERATORS_DIR); \

--- a/configs/mainnet/lightclient_patch.yaml
+++ b/configs/mainnet/lightclient_patch.yaml
@@ -1,6 +1,6 @@
 # Mainnet preset - lightclient patch
 
-CONFIG_NAME: "minimal"
+CONFIG_NAME: "mainnet"
 
 # ---------------------------------------------------------------
 

--- a/configs/mainnet/lightclient_patch.yaml
+++ b/configs/mainnet/lightclient_patch.yaml
@@ -2,9 +2,20 @@
 
 CONFIG_NAME: "mainnet"
 
+# Misc
 # ---------------------------------------------------------------
-
 # 2**10 (=1,024)
 SYNC_COMMITTEE_SIZE: 1024
 # 2**6 (=64)
 SYNC_COMMITTEE_PUBKEY_AGGREGATES_SIZE: 64
+
+
+# Time parameters
+# ---------------------------------------------------------------
+# 2**8 (= 256)
+EPOCHS_PER_SYNC_COMMITTEE_PERIOD: 256
+
+
+# Signature domains
+# ---------------------------------------------------------------
+DOMAIN_SYNC_COMMITTEE: 0x07000000

--- a/configs/mainnet/lightclient_patch.yaml
+++ b/configs/mainnet/lightclient_patch.yaml
@@ -1,0 +1,10 @@
+# Mainnet preset - lightclient patch
+
+CONFIG_NAME: "minimal"
+
+# ---------------------------------------------------------------
+
+# 2**10 (=1,024)
+SYNC_COMMITTEE_SIZE: 1024
+# 2**6 (=64)
+SYNC_COMMITTEE_PUBKEY_AGGREGATES_SIZE: 64

--- a/configs/minimal/lightclient_patch.yaml
+++ b/configs/minimal/lightclient_patch.yaml
@@ -1,0 +1,8 @@
+# Minimal preset - lightclient patch
+
+CONFIG_NAME: "minimal"
+
+# ---------------------------------------------------------------
+
+SYNC_COMMITTEE_SIZE: 64
+SYNC_COMMITTEE_PUBKEY_AGGREGATES_SIZE: 16

--- a/configs/minimal/lightclient_patch.yaml
+++ b/configs/minimal/lightclient_patch.yaml
@@ -2,7 +2,20 @@
 
 CONFIG_NAME: "minimal"
 
+# Misc
 # ---------------------------------------------------------------
-
+# [customized]
 SYNC_COMMITTEE_SIZE: 64
+# [customized]
 SYNC_COMMITTEE_PUBKEY_AGGREGATES_SIZE: 16
+
+
+# Time parameters
+# ---------------------------------------------------------------
+# 2**8 (= 256)
+EPOCHS_PER_SYNC_COMMITTEE_PERIOD: 256
+
+
+# Signature domains
+# ---------------------------------------------------------------
+DOMAIN_SYNC_COMMITTEE: 0x07000000

--- a/setup.py
+++ b/setup.py
@@ -173,7 +173,7 @@ from lru import LRU
 from eth2spec.utils.ssz.ssz_impl import hash_tree_root, copy, uint_to_bytes
 from eth2spec.utils.ssz.ssz_typing import (
     View, boolean, Container, List, Vector, uint8, uint32, uint64,
-    Bytes1, Bytes4, Bytes32, Bytes48, Bytes96, Bitlist,
+    Bytes1, Bytes4, Bytes32, Bytes48, Bytes96, Bitlist, Bitvector,
 )
 from eth2spec.utils import bls
 
@@ -460,8 +460,8 @@ class PySpecCommand(Command):
                     specs/phase0/validator.md
                     specs/phase0/weak-subjectivity.md
                     specs/lightclient/beacon-chain.md
-                    specs/lightclient/sync-protocol.md
                 """
+                # TODO: add specs/lightclient/sync-protocol.md back when the GeneralizedIndex helpers are included.
             else:
                 raise Exception('no markdown files specified, and spec fork "%s" is unknown', self.spec_fork)
 

--- a/setup.py
+++ b/setup.py
@@ -584,7 +584,7 @@ setup(
         "py_ecc==5.0.0",
         "milagro_bls_binding==1.5.0",
         "dataclasses==0.6",
-        "remerkleable==0.1.17",
+        "remerkleable==0.1.18",
         "ruamel.yaml==0.16.5",
         "lru-dict==1.1.6"
     ]

--- a/setup.py
+++ b/setup.py
@@ -460,6 +460,7 @@ class PySpecCommand(Command):
                     specs/phase0/validator.md
                     specs/phase0/weak-subjectivity.md
                     specs/lightclient/beacon-chain.md
+                    specs/lightclient/lightclient-fork.md
                 """
                 # TODO: add specs/lightclient/sync-protocol.md back when the GeneralizedIndex helpers are included.
             else:

--- a/setup.py
+++ b/setup.py
@@ -386,7 +386,7 @@ def combine_spec_objects(spec0: SpecObject, spec1: SpecObject) -> SpecObject:
 fork_imports = {
     'phase0': PHASE0_IMPORTS,
     'phase1': PHASE1_IMPORTS,
-    'lightclient': LIGHTCLIENT_IMPORT,
+    'lightclient_patch': LIGHTCLIENT_IMPORT,
 }
 
 
@@ -453,7 +453,7 @@ class PySpecCommand(Command):
                     specs/phase1/shard-fork-choice.md
                     specs/phase1/validator.md
                 """
-            elif self.spec_fork == "lightclient":
+            elif self.spec_fork == "lightclient_patch":
                 self.md_doc_paths = """
                     specs/phase0/beacon-chain.md
                     specs/phase0/fork-choice.md

--- a/specs/lightclient/beacon-chain.md
+++ b/specs/lightclient/beacon-chain.md
@@ -20,6 +20,8 @@
   - [New containers](#new-containers)
     - [`SyncCommittee`](#synccommittee)
 - [Helper functions](#helper-functions)
+  - [`Predicates`](#predicates)
+    - [`optional_fast_aggregate_verify`](#optional_fast_aggregate_verify)
   - [Beacon state accessors](#beacon-state-accessors)
     - [`get_sync_committee_indices`](#get_sync_committee_indices)
     - [`get_sync_committee`](#get_sync_committee)

--- a/specs/lightclient/beacon-chain.md
+++ b/specs/lightclient/beacon-chain.md
@@ -111,6 +111,16 @@ class SyncCommittee(Container):
     pubkey_aggregates: Vector[BLSPubkey, SYNC_COMMITTEE_SIZE // SYNC_COMMITTEE_PUBKEY_AGGREGATES_SIZE]
 ```
 
+## Upgrade from phase0
+
+```python
+def upgrade_to_lightclient_patch(pre: phase0.BeaconState) -> BeaconState:
+    """
+    The light client patch copies over all phase0 fields, and initializes new fields with default values.
+    """
+    return BeaconState(**{k: getattr(pre, k) for k in pre.fields().keys()})
+```
+
 ## Helper functions
 
 ### `Predicates`

--- a/specs/lightclient/beacon-chain.md
+++ b/specs/lightclient/beacon-chain.md
@@ -9,6 +9,7 @@
 - [Introduction](#introduction)
 - [Constants](#constants)
 - [Configuration](#configuration)
+  - [Constants](#constants-1)
   - [Misc](#misc)
   - [Time parameters](#time-parameters)
   - [Domain types](#domain-types)
@@ -47,13 +48,18 @@ This is a standalone beacon chain patch adding light client support via sync com
 
 ## Configuration
 
+### Constants
+
+| Name | Value |
+| - | - |
+| `G2_POINT_AT_INFINITY` | `BLSSignature(b'\xc0' + b'\x00' * 95)` |
+
 ### Misc
 
 | Name | Value |
 | - | - | 
 | `SYNC_COMMITTEE_SIZE` | `uint64(2**10)` (= 1024) |
 | `SYNC_COMMITTEE_PUBKEY_AGGREGATES_SIZE` | `uint64(2**6)` (= 64) |
-| `G2_POINT_AT_INFINITY` | `BLSSignature(b'\xc0' + b'\x00' * 95)` |
 
 ### Time parameters
 

--- a/specs/lightclient/beacon-chain.md
+++ b/specs/lightclient/beacon-chain.md
@@ -186,11 +186,11 @@ def process_block(state: BeaconState, block: BeaconBlock) -> None:
 ```python
 def process_sync_committee(state: BeaconState, block: BeaconBlock) -> None:
     # Verify sync committee aggregate signature signing over the previous slot block root
-    previous_slot = Slot(max(state.slot, 1) - 1)
+    previous_slot = Slot(max(int(state.slot), 1) - 1)
     committee_indices = get_sync_committee_indices(state, get_current_epoch(state))
-    participant_indices = [index for index, bit in zip(committee_indices, body.sync_committee_bits) if bit]
+    participant_indices = [index for index, bit in zip(committee_indices, block.sync_committee_bits) if bit]
     committee_pubkeys = state.current_sync_committee.pubkeys
-    participant_pubkeys = [pubkey for pubkey, bit in zip(committee_pubkeys, body.sync_committee_bits) if bit]
+    participant_pubkeys = [pubkey for pubkey, bit in zip(committee_pubkeys, block.sync_committee_bits) if bit]
     domain = get_domain(state, DOMAIN_SYNC_COMMITTEE, compute_epoch_at_slot(previous_slot))
     signing_root = compute_signing_root(get_block_root_at_slot(state, previous_slot), domain)
     assert eth2_fast_aggregate_verify(participant_pubkeys, signing_root, block.sync_committee_signature)

--- a/specs/lightclient/beacon-chain.md
+++ b/specs/lightclient/beacon-chain.md
@@ -96,6 +96,8 @@ class BeaconBlockHeader(phase0.BeaconBlockHeader):
 
 ```python
 class BeaconState(phase0.BeaconState):
+    # Updated field
+    latest_block_header: BeaconBlockHeader
     # Sync committees
     current_sync_committee: SyncCommittee
     next_sync_committee: SyncCommittee

--- a/specs/lightclient/beacon-chain.md
+++ b/specs/lightclient/beacon-chain.md
@@ -21,7 +21,7 @@
     - [`SyncCommittee`](#synccommittee)
 - [Helper functions](#helper-functions)
   - [`Predicates`](#predicates)
-    - [`optional_fast_aggregate_verify`](#optional_fast_aggregate_verify)
+    - [`eth2_fast_aggregate_verify`](#eth2_fast_aggregate_verify)
   - [Beacon state accessors](#beacon-state-accessors)
     - [`get_sync_committee_indices`](#get_sync_committee_indices)
     - [`get_sync_committee`](#get_sync_committee)
@@ -114,10 +114,10 @@ class SyncCommittee(Container):
 
 ### `Predicates`
 
-#### `optional_fast_aggregate_verify`
+#### `eth2_fast_aggregate_verify`
 
 ```python
-def optional_fast_aggregate_verify(pubkeys: Sequence[BLSPubkey], message: Bytes32, signature: BLSSignature) -> bool:
+def eth2_fast_aggregate_verify(pubkeys: Sequence[BLSPubkey], message: Bytes32, signature: BLSSignature) -> bool:
     """
     If ``pubkeys`` is an empty list, the given ``signature`` should be a stub ``G2_INFINITY_POINT_SIG``.
     Otherwise, verify it with standard BLS FastAggregateVerify API.
@@ -192,7 +192,7 @@ def process_sync_committee(state: BeaconState, block: BeaconBlock) -> None:
     participant_pubkeys = [pubkey for pubkey, bit in zip(committee_pubkeys, body.sync_committee_bits) if bit]
     domain = get_domain(state, DOMAIN_SYNC_COMMITTEE, compute_epoch_at_slot(previous_slot))
     signing_root = compute_signing_root(get_block_root_at_slot(state, previous_slot), domain)
-    assert optional_fast_aggregate_verify(participant_pubkeys, signing_root, block.sync_committee_signature)
+    assert eth2_fast_aggregate_verify(participant_pubkeys, signing_root, block.sync_committee_signature)
 
     # Reward sync committee participants
     participant_rewards = Gwei(0)

--- a/specs/lightclient/beacon-chain.md
+++ b/specs/lightclient/beacon-chain.md
@@ -49,6 +49,7 @@ This is a standalone beacon chain patch adding light client support via sync com
 | - | - | 
 | `SYNC_COMMITTEE_SIZE` | `uint64(2**10)` (= 1024) |
 | `SYNC_COMMITTEE_PUBKEY_AGGREGATES_SIZE` | `uint64(2**6)` (= 64) |
+| `G2_INFINITY_POINT_SIG` | `BLSSignature(b'\xc0' + b'\x00' * 95)` |
 
 ### Time parameters
 
@@ -108,6 +109,22 @@ class SyncCommittee(Container):
 ```
 
 ## Helper functions
+
+### `Predicates`
+
+#### `optional_fast_aggregate_verify`
+
+```python
+def optional_fast_aggregate_verify(pubkeys: Sequence[BLSPubkey], message: Bytes32, signature: BLSSignature) -> bool:
+    """
+    If ``pubkeys`` is an empty list, the given ``signature`` should be a stub ``G2_INFINITY_POINT_SIG``.
+    Otherwise, verify it with standard BLS FastAggregateVerify API.
+    """
+    if len(pubkeys) == 0:
+        return signature == G2_INFINITY_POINT_SIG
+    else:
+        return bls.FastAggregateVerify(pubkeys, message, signature)
+```
 
 ### Beacon state accessors
 
@@ -173,7 +190,7 @@ def process_sync_committee(state: BeaconState, block: BeaconBlock) -> None:
     participant_pubkeys = [pubkey for pubkey, bit in zip(committee_pubkeys, body.sync_committee_bits) if bit]
     domain = get_domain(state, DOMAIN_SYNC_COMMITTEE, compute_epoch_at_slot(previous_slot))
     signing_root = compute_signing_root(get_block_root_at_slot(state, previous_slot), domain)
-    assert bls.FastAggregateVerify(participant_pubkeys, signing_root, block.sync_committee_signature)
+    assert optional_fast_aggregate_verify(participant_pubkeys, signing_root, block.sync_committee_signature)
 
     # Reward sync committee participants
     participant_rewards = Gwei(0)

--- a/specs/lightclient/beacon-chain.md
+++ b/specs/lightclient/beacon-chain.md
@@ -6,7 +6,6 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
 - [Introduction](#introduction)
 - [Constants](#constants)
 - [Configuration](#configuration)
@@ -15,7 +14,8 @@
   - [Domain types](#domain-types)
 - [Containers](#containers)
   - [Extended containers](#extended-containers)
-    - [`BeaconBlockBody`](#beaconblockbody)
+    - [`BeaconBlock`](#beaconblock)
+    - [`BeaconBlockHeader`](#beaconblockheader)
     - [`BeaconState`](#beaconstate)
   - [New containers](#new-containers)
     - [`SyncCommittee`](#synccommittee)

--- a/specs/lightclient/beacon-chain.md
+++ b/specs/lightclient/beacon-chain.md
@@ -225,8 +225,8 @@ def process_sync_committee(state: BeaconState, block: BeaconBlock) -> None:
     for participant_index in participant_indices:
         base_reward = get_base_reward(state, participant_index)
         max_participant_reward = base_reward - base_reward // PROPOSER_REWARD_QUOTIENT
-        participant_reward = Gwei(max_participant_reward * active_validator_count // len(committee_indices) // SLOTS_PER_EPOCH)
-        increase_balance(state, participant_index, participant_reward)
+        reward = Gwei(max_participant_reward * active_validator_count // len(committee_indices) // SLOTS_PER_EPOCH)
+        increase_balance(state, participant_index, reward)
         proposer_reward += base_reward // PROPOSER_REWARD_QUOTIENT
 
     # Reward beacon proposer

--- a/specs/lightclient/beacon-chain.md
+++ b/specs/lightclient/beacon-chain.md
@@ -123,7 +123,8 @@ def get_sync_committee_indices(state: BeaconState, epoch: Epoch) -> Sequence[Val
     active_validator_indices = get_active_validator_indices(state, base_epoch)
     active_validator_count = uint64(len(active_validator_indices))
     seed = get_seed(state, base_epoch, DOMAIN_SYNC_COMMITTEE)
-    i, sync_committee_indices = 0, []
+    i = 0
+    sync_committee_indices: List[ValidatorIndex] = []
     while len(sync_committee_indices) < SYNC_COMMITTEE_SIZE:
         shuffled_index = compute_shuffled_index(uint64(i % active_validator_count), active_validator_count, seed)
         candidate_index = active_validator_indices[shuffled_index]

--- a/specs/lightclient/lightclient-fork.md
+++ b/specs/lightclient/lightclient-fork.md
@@ -1,0 +1,83 @@
+# Ethereum 2.0 Light Client Support -- From Phase 0 to Light Client Patch
+
+**Notice**: This document is a work-in-progress for researchers and implementers.
+
+## Table of contents
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Introduction](#introduction)
+- [Configuration](#configuration)
+- [Fork to Light-client patch](#fork-to-light-client-patch)
+  - [Fork trigger](#fork-trigger)
+  - [Upgrading the state](#upgrading-the-state)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Introduction
+
+This document describes the process of moving from Phase 0 to Phase 1 of Ethereum 2.0.
+
+## Configuration
+
+Warning: this configuration is not definitive.
+
+| Name | Value |
+| - | - |
+| `LIGHTCLIENT_PATCH_FORK_VERSION` | `Version('0x01000000')` |
+| `LIGHTCLIENT_PATCH_FORK_SLOT` | `Slot(0)` **TBD** |
+
+## Fork to Light-client patch
+
+### Fork trigger
+
+TBD. Social consensus, along with state conditions such as epoch boundary, finality, deposits, active validator count, etc. may be part of the decision process to trigger the fork. For now we assume the condition will be triggered at slot `LIGHTCLIENT_PATCH_FORK_SLOT`, where `LIGHTCLIENT_PATCH_FORK_SLOT % SLOTS_PER_EPOCH == 0`.
+
+### Upgrading the state
+
+After `process_slots` of Phase 0 finishes, if `state.slot == LIGHTCLIENT_PATCH_FORK_SLOT`, an irregular state change is made to upgrade to light-client patch.
+
+```python
+def upgrade_to_lightclient_patch(pre: phase0.BeaconState) -> BeaconState:
+    epoch = get_current_epoch(pre)
+    post = BeaconState(
+        genesis_time=pre.genesis_time,
+        slot=pre.slot,
+        fork=Fork(
+            previous_version=pre.fork.current_version,
+            current_version=LIGHTCLIENT_PATCH_FORK_VERSION,
+            epoch=epoch,
+        ),
+        # History
+        latest_block_header=pre.latest_block_header,
+        block_roots=pre.block_roots,
+        state_roots=pre.state_roots,
+        historical_roots=pre.historical_roots,
+        # Eth1
+        eth1_data=pre.eth1_data,
+        eth1_data_votes=pre.eth1_data_votes,
+        eth1_deposit_index=pre.eth1_deposit_index,
+        # Registry
+        validators=pre.validators,
+        balances=pre.balances,
+        # Randomness
+        randao_mixes=pre.randao_mixes,
+        # Slashings
+        slashings=pre.slashings,
+        # Attestations
+        # previous_epoch_attestations is cleared on upgrade. 
+        previous_epoch_attestations=List[PendingAttestation, MAX_ATTESTATIONS * SLOTS_PER_EPOCH](),
+        # empty in pre state, since the upgrade is performed just after an epoch boundary.
+        current_epoch_attestations=List[PendingAttestation, MAX_ATTESTATIONS * SLOTS_PER_EPOCH](),
+        # Finality
+        justification_bits=pre.justification_bits,
+        previous_justified_checkpoint=pre.previous_justified_checkpoint,
+        current_justified_checkpoint=pre.current_justified_checkpoint,
+        finalized_checkpoint=pre.finalized_checkpoint,
+        # Light-client
+        current_sync_committee=SyncCommittee(),
+        next_sync_committee=SyncCommittee(),
+    )
+    return post
+```

--- a/specs/lightclient/sync-protocol.md
+++ b/specs/lightclient/sync-protocol.md
@@ -100,7 +100,7 @@ class LightClientStore(Container):
 
 ## Light client state updates
 
-A light client maintains its state in a `store` object of type `LightClientStore` and receives `update` objects of type `LightClientUpdate`. Every `update` triggers `process_light_client_update(store, update, current_slot)` where `current_slot` is the currect slot based on some local clock.
+A light client maintains its state in a `store` object of type `LightClientStore` and receives `update` objects of type `LightClientUpdate`. Every `update` triggers `process_light_client_update(store, update, current_slot)` where `current_slot` is the current slot based on some local clock.
 
 #### `is_valid_light_client_update`
 

--- a/specs/lightclient/sync-protocol.md
+++ b/specs/lightclient/sync-protocol.md
@@ -8,7 +8,6 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
 - [Introduction](#introduction)
 - [Constants](#constants)
 - [Configuration](#configuration)

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -327,8 +327,13 @@ def get_eth1_vote(state: BeaconState, eth1_chain: Sequence[Eth1Block]) -> Eth1Da
     valid_votes = [vote for vote in state.eth1_data_votes if vote in votes_to_consider]
 
     # Default vote on latest eth1 block data in the period range unless eth1 chain is not live
-    default_vote = (votes_to_consider[len(votes_to_consider) - 1] if any(votes_to_consider)
-                    else Eth1Data(state.eth1_data))
+    # FIXME: Non-substantive casting: a workaround for passing typing linter for future patch forks
+    state_eth1_data = Eth1Data(
+        deposit_root=state.eth1_data.deposit_root,
+        deposit_count=state.eth1_data.deposit_count,
+        block_hash=state.eth1_data.block_hash,
+    )
+    default_vote = (votes_to_consider[len(votes_to_consider) - 1] if any(votes_to_consider) else state_eth1_data)
 
     return max(
         valid_votes,

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -333,7 +333,7 @@ def get_eth1_vote(state: BeaconState, eth1_chain: Sequence[Eth1Block]) -> Eth1Da
         deposit_count=state.eth1_data.deposit_count,
         block_hash=state.eth1_data.block_hash,
     )
-    default_vote = (votes_to_consider[len(votes_to_consider) - 1] if any(votes_to_consider) else state_eth1_data)
+    default_vote = votes_to_consider[len(votes_to_consider) - 1] if any(votes_to_consider) else state.eth1_data
 
     return max(
         valid_votes,

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -327,7 +327,8 @@ def get_eth1_vote(state: BeaconState, eth1_chain: Sequence[Eth1Block]) -> Eth1Da
     valid_votes = [vote for vote in state.eth1_data_votes if vote in votes_to_consider]
 
     # Default vote on latest eth1 block data in the period range unless eth1 chain is not live
-    default_vote = votes_to_consider[len(votes_to_consider) - 1] if any(votes_to_consider) else state.eth1_data
+    default_vote = (votes_to_consider[len(votes_to_consider) - 1] if any(votes_to_consider)
+                    else Eth1Data(state.eth1_data))
 
     return max(
         valid_votes,

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -327,13 +327,9 @@ def get_eth1_vote(state: BeaconState, eth1_chain: Sequence[Eth1Block]) -> Eth1Da
     valid_votes = [vote for vote in state.eth1_data_votes if vote in votes_to_consider]
 
     # Default vote on latest eth1 block data in the period range unless eth1 chain is not live
-    # FIXME: Non-substantive casting: a workaround for passing typing linter for future patch forks
-    state_eth1_data = Eth1Data(
-        deposit_root=state.eth1_data.deposit_root,
-        deposit_count=state.eth1_data.deposit_count,
-        block_hash=state.eth1_data.block_hash,
-    )
-    default_vote = votes_to_consider[len(votes_to_consider) - 1] if any(votes_to_consider) else state.eth1_data
+    # Non-substantive casting for linter
+    state_eth1_data: Eth1Data = state.eth1_data
+    default_vote = votes_to_consider[len(votes_to_consider) - 1] if any(votes_to_consider) else state_eth1_data
 
     return max(
         valid_votes,

--- a/tests/core/pyspec/eth2spec/test/context.py
+++ b/tests/core/pyspec/eth2spec/test/context.py
@@ -2,6 +2,7 @@ import pytest
 
 from eth2spec.phase0 import spec as spec_phase0
 from eth2spec.phase1 import spec as spec_phase1
+from eth2spec.lightclient import spec as spec_lightclient
 from eth2spec.utils import bls
 
 from .exceptions import SkippedTest
@@ -19,6 +20,7 @@ from importlib import reload
 def reload_specs():
     reload(spec_phase0)
     reload(spec_phase1)
+    reload(spec_lightclient)
 
 
 # Some of the Spec module functionality is exposed here to deal with phase-specific changes.
@@ -28,7 +30,9 @@ ConfigName = NewType("ConfigName", str)
 
 PHASE0 = SpecForkName('phase0')
 PHASE1 = SpecForkName('phase1')
-ALL_PHASES = (PHASE0, PHASE1)
+LIGHTCLIENT = SpecForkName('lightclient')
+
+ALL_PHASES = (PHASE0, PHASE1, LIGHTCLIENT)
 
 MAINNET = ConfigName('mainnet')
 MINIMAL = ConfigName('minimal')
@@ -51,10 +55,15 @@ class SpecPhase1(Spec):
         ...
 
 
+class SpecLightclient(Spec):
+    ...
+
+
 # add transfer, bridge, etc. as the spec evolves
 class SpecForks(TypedDict, total=False):
     PHASE0: SpecPhase0
     PHASE1: SpecPhase1
+    LIGHTCLIENT: SpecLightclient
 
 
 def _prepare_state(balances_fn: Callable[[Any], Sequence[int]], threshold_fn: Callable[[Any], int],
@@ -337,12 +346,16 @@ def with_phases(phases, other_phases=None):
                 phase_dir[PHASE0] = spec_phase0
             if PHASE1 in available_phases:
                 phase_dir[PHASE1] = spec_phase1
+            if LIGHTCLIENT in available_phases:
+                phase_dir[LIGHTCLIENT] = spec_lightclient
 
             # return is ignored whenever multiple phases are ran. If
             if PHASE0 in run_phases:
                 ret = fn(spec=spec_phase0, phases=phase_dir, *args, **kw)
             if PHASE1 in run_phases:
                 ret = fn(spec=spec_phase1, phases=phase_dir, *args, **kw)
+            if LIGHTCLIENT in run_phases:
+                ret = fn(spec=spec_lightclient, phases=phase_dir, *args, **kw)
             return ret
         return wrapper
     return decorator

--- a/tests/core/pyspec/eth2spec/test/context.py
+++ b/tests/core/pyspec/eth2spec/test/context.py
@@ -2,7 +2,7 @@ import pytest
 
 from eth2spec.phase0 import spec as spec_phase0
 from eth2spec.phase1 import spec as spec_phase1
-from eth2spec.lightclient import spec as spec_lightclient
+from eth2spec.lightclient_patch import spec as spec_lightclient_patch
 from eth2spec.utils import bls
 
 from .exceptions import SkippedTest
@@ -20,7 +20,7 @@ from importlib import reload
 def reload_specs():
     reload(spec_phase0)
     reload(spec_phase1)
-    reload(spec_lightclient)
+    reload(spec_lightclient_patch)
 
 
 # Some of the Spec module functionality is exposed here to deal with phase-specific changes.
@@ -30,9 +30,9 @@ ConfigName = NewType("ConfigName", str)
 
 PHASE0 = SpecForkName('phase0')
 PHASE1 = SpecForkName('phase1')
-LIGHTCLIENT = SpecForkName('lightclient')
+LIGHTCLIENT_PATCH = SpecForkName('lightclient_patch')
 
-ALL_PHASES = (PHASE0, PHASE1, LIGHTCLIENT)
+ALL_PHASES = (PHASE0, PHASE1, LIGHTCLIENT_PATCH)
 
 MAINNET = ConfigName('mainnet')
 MINIMAL = ConfigName('minimal')
@@ -63,7 +63,7 @@ class SpecLightclient(Spec):
 class SpecForks(TypedDict, total=False):
     PHASE0: SpecPhase0
     PHASE1: SpecPhase1
-    LIGHTCLIENT: SpecLightclient
+    LIGHTCLIENT_PATCH: SpecLightclient
 
 
 def _prepare_state(balances_fn: Callable[[Any], Sequence[int]], threshold_fn: Callable[[Any], int],
@@ -346,16 +346,16 @@ def with_phases(phases, other_phases=None):
                 phase_dir[PHASE0] = spec_phase0
             if PHASE1 in available_phases:
                 phase_dir[PHASE1] = spec_phase1
-            if LIGHTCLIENT in available_phases:
-                phase_dir[LIGHTCLIENT] = spec_lightclient
+            if LIGHTCLIENT_PATCH in available_phases:
+                phase_dir[LIGHTCLIENT_PATCH] = spec_lightclient_patch
 
             # return is ignored whenever multiple phases are ran. If
             if PHASE0 in run_phases:
                 ret = fn(spec=spec_phase0, phases=phase_dir, *args, **kw)
             if PHASE1 in run_phases:
                 ret = fn(spec=spec_phase1, phases=phase_dir, *args, **kw)
-            if LIGHTCLIENT in run_phases:
-                ret = fn(spec=spec_lightclient, phases=phase_dir, *args, **kw)
+            if LIGHTCLIENT_PATCH in run_phases:
+                ret = fn(spec=spec_lightclient_patch, phases=phase_dir, *args, **kw)
             return ret
         return wrapper
     return decorator

--- a/tests/core/pyspec/eth2spec/test/context.py
+++ b/tests/core/pyspec/eth2spec/test/context.py
@@ -79,6 +79,8 @@ def _prepare_state(balances_fn: Callable[[Any], Sequence[int]], threshold_fn: Ca
         # TODO: instead of upgrading a test phase0 genesis state we can also write a phase1 state helper.
         # Decide based on performance/consistency results later.
         state = phases[PHASE1].upgrade_to_phase1(state)
+    elif spec.fork == LIGHTCLIENT_PATCH:  # not generalizing this just yet, unclear final spec fork/patch order.
+        state = phases[LIGHTCLIENT_PATCH].upgrade_to_lightclient_patch(state)
 
     return state
 

--- a/tests/core/pyspec/eth2spec/test/context.py
+++ b/tests/core/pyspec/eth2spec/test/context.py
@@ -51,8 +51,7 @@ class SpecPhase0(Spec):
 
 
 class SpecPhase1(Spec):
-    def upgrade_to_phase1(self, state: spec_phase0.BeaconState) -> spec_phase1.BeaconState:
-        ...
+    ...
 
 
 class SpecLightclient(Spec):

--- a/tests/core/pyspec/eth2spec/test/helpers/block.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/block.py
@@ -1,3 +1,4 @@
+from eth2spec.test.context import LIGHTCLIENT
 from eth2spec.test.helpers.keys import privkeys
 from eth2spec.utils import bls
 from eth2spec.utils.bls import only_with_bls
@@ -89,6 +90,10 @@ def build_empty_block(spec, state, slot=None):
     empty_block.proposer_index = spec.get_beacon_proposer_index(state)
     empty_block.body.eth1_data.deposit_count = state.eth1_deposit_index
     empty_block.parent_root = parent_block_root
+
+    if spec.fork == LIGHTCLIENT:
+        empty_block.body.sync_committee_signature = spec.G2_INFINITY_POINT_SIG
+
     apply_randao_reveal(spec, state, empty_block)
     return empty_block
 

--- a/tests/core/pyspec/eth2spec/test/helpers/block.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/block.py
@@ -92,7 +92,7 @@ def build_empty_block(spec, state, slot=None):
     empty_block.parent_root = parent_block_root
 
     if spec.fork == LIGHTCLIENT:
-        empty_block.body.sync_committee_signature = spec.G2_INFINITY_POINT_SIG
+        empty_block.sync_committee_signature = spec.G2_INFINITY_POINT_SIG
 
     apply_randao_reveal(spec, state, empty_block)
     return empty_block

--- a/tests/core/pyspec/eth2spec/test/helpers/block.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/block.py
@@ -1,4 +1,4 @@
-from eth2spec.test.context import LIGHTCLIENT
+from eth2spec.test.context import LIGHTCLIENT_PATCH
 from eth2spec.test.helpers.keys import privkeys
 from eth2spec.utils import bls
 from eth2spec.utils.bls import only_with_bls
@@ -91,7 +91,7 @@ def build_empty_block(spec, state, slot=None):
     empty_block.body.eth1_data.deposit_count = state.eth1_deposit_index
     empty_block.parent_root = parent_block_root
 
-    if spec.fork == LIGHTCLIENT:
+    if spec.fork == LIGHTCLIENT_PATCH:
         empty_block.sync_committee_signature = spec.G2_INFINITY_POINT_SIG
 
     apply_randao_reveal(spec, state, empty_block)

--- a/tests/core/pyspec/eth2spec/test/helpers/block.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/block.py
@@ -92,7 +92,7 @@ def build_empty_block(spec, state, slot=None):
     empty_block.parent_root = parent_block_root
 
     if spec.fork == LIGHTCLIENT_PATCH:
-        empty_block.sync_committee_signature = spec.G2_INFINITY_POINT_SIG
+        empty_block.sync_committee_signature = spec.G2_POINT_AT_INFINITY
 
     apply_randao_reveal(spec, state, empty_block)
     return empty_block

--- a/tests/core/pyspec/eth2spec/test/helpers/block.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/block.py
@@ -92,7 +92,7 @@ def build_empty_block(spec, state, slot=None):
     empty_block.parent_root = parent_block_root
 
     if spec.fork == LIGHTCLIENT_PATCH:
-        empty_block.sync_committee_signature = spec.G2_POINT_AT_INFINITY
+        empty_block.body.sync_committee_signature = spec.G2_POINT_AT_INFINITY
 
     apply_randao_reveal(spec, state, empty_block)
     return empty_block

--- a/tests/core/pyspec/eth2spec/test/helpers/rewards.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/rewards.py
@@ -2,6 +2,7 @@ from random import Random
 from lru import LRU
 
 from eth2spec.phase0 import spec as spec_phase0
+from eth2spec.test.context import LIGHTCLIENT
 from eth2spec.test.helpers.attestations import cached_prepare_state_with_attestations
 from eth2spec.test.helpers.deposits import mock_deposit
 from eth2spec.test.helpers.state import next_epoch
@@ -159,8 +160,12 @@ def run_get_inactivity_penalty_deltas(spec, state):
             continue
 
         if spec.is_in_inactivity_leak(state):
+            if spec.fork == LIGHTCLIENT:
+                cancel_base_rewards_per_epoch = spec.BASE_REWARDS_PER_EPOCH - 1
+            else:
+                cancel_base_rewards_per_epoch = spec.BASE_REWARDS_PER_EPOCH
             base_reward = spec.get_base_reward(state, index)
-            base_penalty = spec.BASE_REWARDS_PER_EPOCH * base_reward - spec.get_proposer_reward(state, index)
+            base_penalty = cancel_base_rewards_per_epoch * base_reward - spec.get_proposer_reward(state, index)
             if not has_enough_for_reward(spec, state, index):
                 assert penalties[index] == 0
             elif index in matching_attesting_indices:

--- a/tests/core/pyspec/eth2spec/test/helpers/rewards.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/rewards.py
@@ -2,7 +2,7 @@ from random import Random
 from lru import LRU
 
 from eth2spec.phase0 import spec as spec_phase0
-from eth2spec.test.context import LIGHTCLIENT
+from eth2spec.test.context import LIGHTCLIENT_PATCH
 from eth2spec.test.helpers.attestations import cached_prepare_state_with_attestations
 from eth2spec.test.helpers.deposits import mock_deposit
 from eth2spec.test.helpers.state import next_epoch
@@ -160,7 +160,7 @@ def run_get_inactivity_penalty_deltas(spec, state):
             continue
 
         if spec.is_in_inactivity_leak(state):
-            if spec.fork == LIGHTCLIENT:
+            if spec.fork == LIGHTCLIENT_PATCH:
                 cancel_base_rewards_per_epoch = spec.BASE_REWARDS_PER_EPOCH - 1
             else:
                 cancel_base_rewards_per_epoch = spec.BASE_REWARDS_PER_EPOCH

--- a/tests/core/pyspec/eth2spec/test/phase0/epoch_processing/test_process_rewards_and_penalties.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/epoch_processing/test_process_rewards_and_penalties.py
@@ -1,5 +1,5 @@
 from eth2spec.test.context import (
-    LIGHTCLIENT,
+    LIGHTCLIENT_PATCH,
     spec_state_test, spec_test,
     with_all_phases, single_phase,
     with_phases, PHASE0,
@@ -163,7 +163,7 @@ def run_with_participation(spec, state, participation_fn):
 
     pre_state = state.copy()
 
-    if spec.fork == LIGHTCLIENT:
+    if spec.fork == LIGHTCLIENT_PATCH:
         sync_committee_indices = spec.get_sync_committee_indices(state, spec.get_current_epoch(state))
 
     yield from run_process_rewards_and_penalties(spec, state)
@@ -177,7 +177,7 @@ def run_with_participation(spec, state, participation_fn):
             if index in proposer_indices and index in participated:
                 assert state.balances[index] > pre_state.balances[index]
             elif index in attesting_indices:
-                if spec.fork == LIGHTCLIENT and index in sync_committee_indices:
+                if spec.fork == LIGHTCLIENT_PATCH and index in sync_committee_indices:
                     # The sync committee reward has not been canceled, so the sync committee participants still earn it
                     assert state.balances[index] >= pre_state.balances[index]
                 else:

--- a/tests/core/pyspec/eth2spec/test/phase0/epoch_processing/test_process_rewards_and_penalties.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/epoch_processing/test_process_rewards_and_penalties.py
@@ -1,4 +1,5 @@
 from eth2spec.test.context import (
+    LIGHTCLIENT,
     spec_state_test, spec_test,
     with_all_phases, single_phase,
     with_phases, PHASE0,
@@ -162,6 +163,9 @@ def run_with_participation(spec, state, participation_fn):
 
     pre_state = state.copy()
 
+    if spec.fork == LIGHTCLIENT:
+        sync_committee_indices = spec.get_sync_committee_indices(state, spec.get_current_epoch(state))
+
     yield from run_process_rewards_and_penalties(spec, state)
 
     attesting_indices = spec.get_unslashed_attesting_indices(state, attestations)
@@ -172,9 +176,13 @@ def run_with_participation(spec, state, participation_fn):
             # Proposers can still make money during a leak
             if index in proposer_indices and index in participated:
                 assert state.balances[index] > pre_state.balances[index]
-            # If not proposer but participated optimally, should have exactly neutral balance
             elif index in attesting_indices:
-                assert state.balances[index] == pre_state.balances[index]
+                if spec.fork == LIGHTCLIENT and index in sync_committee_indices:
+                    # The sync committee reward has not been canceled, so the sync committee participants still earn it
+                    assert state.balances[index] >= pre_state.balances[index]
+                else:
+                    # If not proposer but participated optimally, should have exactly neutral balance
+                    assert state.balances[index] == pre_state.balances[index]
             else:
                 assert state.balances[index] < pre_state.balances[index]
         else:

--- a/tests/core/pyspec/eth2spec/test/phase0/unittests/fork_choice/test_on_attestation.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/unittests/fork_choice/test_on_attestation.py
@@ -1,4 +1,4 @@
-from eth2spec.test.context import PHASE0, with_all_phases, spec_state_test
+from eth2spec.test.context import PHASE0, PHASE1, LIGHTCLIENT, with_all_phases, spec_state_test
 from eth2spec.test.helpers.block import build_empty_block_for_next_slot
 from eth2spec.test.helpers.attestations import get_valid_attestation, sign_attestation
 from eth2spec.test.helpers.state import transition_to, state_transition_and_sign_block, next_epoch, next_slot
@@ -18,12 +18,12 @@ def run_on_attestation(spec, state, store, attestation, valid=True):
     spec.on_attestation(store, attestation)
 
     sample_index = indexed_attestation.attesting_indices[0]
-    if spec.fork == PHASE0:
+    if spec.fork in (PHASE0, LIGHTCLIENT):
         latest_message = spec.LatestMessage(
             epoch=attestation.data.target.epoch,
             root=attestation.data.beacon_block_root,
         )
-    else:
+    elif spec.fork == PHASE1:
         latest_message = spec.LatestMessage(
             epoch=attestation.data.target.epoch,
             root=attestation.data.beacon_block_root,

--- a/tests/core/pyspec/eth2spec/test/phase0/unittests/fork_choice/test_on_attestation.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/unittests/fork_choice/test_on_attestation.py
@@ -1,4 +1,4 @@
-from eth2spec.test.context import PHASE0, PHASE1, LIGHTCLIENT, with_all_phases, spec_state_test
+from eth2spec.test.context import PHASE0, PHASE1, LIGHTCLIENT_PATCH, with_all_phases, spec_state_test
 from eth2spec.test.helpers.block import build_empty_block_for_next_slot
 from eth2spec.test.helpers.attestations import get_valid_attestation, sign_attestation
 from eth2spec.test.helpers.state import transition_to, state_transition_and_sign_block, next_epoch, next_slot
@@ -18,7 +18,7 @@ def run_on_attestation(spec, state, store, attestation, valid=True):
     spec.on_attestation(store, attestation)
 
     sample_index = indexed_attestation.attesting_indices[0]
-    if spec.fork in (PHASE0, LIGHTCLIENT):
+    if spec.fork in (PHASE0, LIGHTCLIENT_PATCH):
         latest_message = spec.LatestMessage(
             epoch=attestation.data.target.epoch,
             root=attestation.data.beacon_block_root,

--- a/tests/core/pyspec/eth2spec/test/phase1/block_processing/test_process_attestation.py
+++ b/tests/core/pyspec/eth2spec/test/phase1/block_processing/test_process_attestation.py
@@ -1,5 +1,6 @@
 from eth2spec.test.context import (
     PHASE0,
+    LIGHTCLIENT,
     with_all_phases_except,
     spec_state_test,
     always_bls,
@@ -12,7 +13,7 @@ from eth2spec.test.helpers.attestations import (
 )
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @always_bls
 def test_on_time_success(spec, state):
@@ -23,7 +24,7 @@ def test_on_time_success(spec, state):
     yield from run_attestation_processing(spec, state, attestation)
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @always_bls
 def test_late_success(spec, state):

--- a/tests/core/pyspec/eth2spec/test/phase1/block_processing/test_process_attestation.py
+++ b/tests/core/pyspec/eth2spec/test/phase1/block_processing/test_process_attestation.py
@@ -1,6 +1,6 @@
 from eth2spec.test.context import (
     PHASE0,
-    LIGHTCLIENT,
+    LIGHTCLIENT_PATCH,
     with_all_phases_except,
     spec_state_test,
     always_bls,
@@ -13,7 +13,7 @@ from eth2spec.test.helpers.attestations import (
 )
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @always_bls
 def test_on_time_success(spec, state):
@@ -24,7 +24,7 @@ def test_on_time_success(spec, state):
     yield from run_attestation_processing(spec, state, attestation)
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @always_bls
 def test_late_success(spec, state):

--- a/tests/core/pyspec/eth2spec/test/phase1/block_processing/test_process_chunk_challenge.py
+++ b/tests/core/pyspec/eth2spec/test/phase1/block_processing/test_process_chunk_challenge.py
@@ -9,6 +9,7 @@ from eth2spec.test.helpers.attestations import (
 from eth2spec.test.helpers.state import transition_to, transition_to_valid_shard_slot
 from eth2spec.test.context import (
     PHASE0,
+    LIGHTCLIENT,
     MINIMAL,
     expect_assertion_error,
     disable_process_reveal_deadlines,
@@ -68,7 +69,7 @@ def run_custody_chunk_response_processing(spec, state, custody_response, valid=T
     yield 'post', state
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @with_configs([MINIMAL], reason="too slow")
 @disable_process_reveal_deadlines
@@ -92,7 +93,7 @@ def test_challenge_appended(spec, state):
     yield from run_chunk_challenge_processing(spec, state, challenge)
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @disable_process_reveal_deadlines
 @with_configs([MINIMAL], reason="too slow")
@@ -118,7 +119,7 @@ def test_challenge_empty_element_replaced(spec, state):
     yield from run_chunk_challenge_processing(spec, state, challenge)
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @disable_process_reveal_deadlines
 @with_configs([MINIMAL], reason="too slow")
@@ -144,7 +145,7 @@ def test_duplicate_challenge(spec, state):
     yield from run_chunk_challenge_processing(spec, state, challenge, valid=False)
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @disable_process_reveal_deadlines
 @with_configs([MINIMAL], reason="too slow")
@@ -172,7 +173,7 @@ def test_second_challenge(spec, state):
     yield from run_chunk_challenge_processing(spec, state, challenge1)
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @disable_process_reveal_deadlines
 @with_configs([MINIMAL], reason="too slow")
@@ -197,7 +198,7 @@ def test_multiple_epochs_custody(spec, state):
     yield from run_chunk_challenge_processing(spec, state, challenge)
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @disable_process_reveal_deadlines
 @with_configs([MINIMAL], reason="too slow")
@@ -222,7 +223,7 @@ def test_many_epochs_custody(spec, state):
     yield from run_chunk_challenge_processing(spec, state, challenge)
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @disable_process_reveal_deadlines
 @with_configs([MINIMAL], reason="too slow")
@@ -243,7 +244,7 @@ def test_off_chain_attestation(spec, state):
     yield from run_chunk_challenge_processing(spec, state, challenge)
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @disable_process_reveal_deadlines
 @with_configs([MINIMAL], reason="too slow")
@@ -275,7 +276,7 @@ def test_custody_response(spec, state):
     yield from run_custody_chunk_response_processing(spec, state, custody_response)
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @disable_process_reveal_deadlines
 @with_configs([MINIMAL], reason="too slow")
@@ -306,7 +307,7 @@ def test_custody_response_chunk_index_2(spec, state):
     yield from run_custody_chunk_response_processing(spec, state, custody_response)
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @disable_process_reveal_deadlines
 @with_configs([MINIMAL], reason="too slow")
@@ -338,7 +339,7 @@ def test_custody_response_multiple_epochs(spec, state):
     yield from run_custody_chunk_response_processing(spec, state, custody_response)
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @disable_process_reveal_deadlines
 @with_configs([MINIMAL], reason="too slow")

--- a/tests/core/pyspec/eth2spec/test/phase1/block_processing/test_process_chunk_challenge.py
+++ b/tests/core/pyspec/eth2spec/test/phase1/block_processing/test_process_chunk_challenge.py
@@ -9,7 +9,7 @@ from eth2spec.test.helpers.attestations import (
 from eth2spec.test.helpers.state import transition_to, transition_to_valid_shard_slot
 from eth2spec.test.context import (
     PHASE0,
-    LIGHTCLIENT,
+    LIGHTCLIENT_PATCH,
     MINIMAL,
     expect_assertion_error,
     disable_process_reveal_deadlines,
@@ -69,7 +69,7 @@ def run_custody_chunk_response_processing(spec, state, custody_response, valid=T
     yield 'post', state
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @with_configs([MINIMAL], reason="too slow")
 @disable_process_reveal_deadlines
@@ -93,7 +93,7 @@ def test_challenge_appended(spec, state):
     yield from run_chunk_challenge_processing(spec, state, challenge)
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @disable_process_reveal_deadlines
 @with_configs([MINIMAL], reason="too slow")
@@ -119,7 +119,7 @@ def test_challenge_empty_element_replaced(spec, state):
     yield from run_chunk_challenge_processing(spec, state, challenge)
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @disable_process_reveal_deadlines
 @with_configs([MINIMAL], reason="too slow")
@@ -145,7 +145,7 @@ def test_duplicate_challenge(spec, state):
     yield from run_chunk_challenge_processing(spec, state, challenge, valid=False)
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @disable_process_reveal_deadlines
 @with_configs([MINIMAL], reason="too slow")
@@ -173,7 +173,7 @@ def test_second_challenge(spec, state):
     yield from run_chunk_challenge_processing(spec, state, challenge1)
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @disable_process_reveal_deadlines
 @with_configs([MINIMAL], reason="too slow")
@@ -198,7 +198,7 @@ def test_multiple_epochs_custody(spec, state):
     yield from run_chunk_challenge_processing(spec, state, challenge)
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @disable_process_reveal_deadlines
 @with_configs([MINIMAL], reason="too slow")
@@ -223,7 +223,7 @@ def test_many_epochs_custody(spec, state):
     yield from run_chunk_challenge_processing(spec, state, challenge)
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @disable_process_reveal_deadlines
 @with_configs([MINIMAL], reason="too slow")
@@ -244,7 +244,7 @@ def test_off_chain_attestation(spec, state):
     yield from run_chunk_challenge_processing(spec, state, challenge)
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @disable_process_reveal_deadlines
 @with_configs([MINIMAL], reason="too slow")
@@ -276,7 +276,7 @@ def test_custody_response(spec, state):
     yield from run_custody_chunk_response_processing(spec, state, custody_response)
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @disable_process_reveal_deadlines
 @with_configs([MINIMAL], reason="too slow")
@@ -307,7 +307,7 @@ def test_custody_response_chunk_index_2(spec, state):
     yield from run_custody_chunk_response_processing(spec, state, custody_response)
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @disable_process_reveal_deadlines
 @with_configs([MINIMAL], reason="too slow")
@@ -339,7 +339,7 @@ def test_custody_response_multiple_epochs(spec, state):
     yield from run_custody_chunk_response_processing(spec, state, custody_response)
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @disable_process_reveal_deadlines
 @with_configs([MINIMAL], reason="too slow")

--- a/tests/core/pyspec/eth2spec/test/phase1/block_processing/test_process_custody_key_reveal.py
+++ b/tests/core/pyspec/eth2spec/test/phase1/block_processing/test_process_custody_key_reveal.py
@@ -1,6 +1,7 @@
 from eth2spec.test.helpers.custody import get_valid_custody_key_reveal
 from eth2spec.test.context import (
     PHASE0,
+    LIGHTCLIENT,
     with_all_phases_except,
     spec_state_test,
     expect_assertion_error,
@@ -39,7 +40,7 @@ def run_custody_key_reveal_processing(spec, state, custody_key_reveal, valid=Tru
     yield 'post', state
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @always_bls
 def test_success(spec, state):
@@ -49,7 +50,7 @@ def test_success(spec, state):
     yield from run_custody_key_reveal_processing(spec, state, custody_key_reveal)
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @always_bls
 def test_reveal_too_early(spec, state):
@@ -58,7 +59,7 @@ def test_reveal_too_early(spec, state):
     yield from run_custody_key_reveal_processing(spec, state, custody_key_reveal, False)
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @always_bls
 def test_wrong_period(spec, state):
@@ -67,7 +68,7 @@ def test_wrong_period(spec, state):
     yield from run_custody_key_reveal_processing(spec, state, custody_key_reveal, False)
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @always_bls
 def test_late_reveal(spec, state):
@@ -77,7 +78,7 @@ def test_late_reveal(spec, state):
     yield from run_custody_key_reveal_processing(spec, state, custody_key_reveal)
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @always_bls
 def test_double_reveal(spec, state):

--- a/tests/core/pyspec/eth2spec/test/phase1/block_processing/test_process_custody_key_reveal.py
+++ b/tests/core/pyspec/eth2spec/test/phase1/block_processing/test_process_custody_key_reveal.py
@@ -1,7 +1,7 @@
 from eth2spec.test.helpers.custody import get_valid_custody_key_reveal
 from eth2spec.test.context import (
     PHASE0,
-    LIGHTCLIENT,
+    LIGHTCLIENT_PATCH,
     with_all_phases_except,
     spec_state_test,
     expect_assertion_error,
@@ -40,7 +40,7 @@ def run_custody_key_reveal_processing(spec, state, custody_key_reveal, valid=Tru
     yield 'post', state
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @always_bls
 def test_success(spec, state):
@@ -50,7 +50,7 @@ def test_success(spec, state):
     yield from run_custody_key_reveal_processing(spec, state, custody_key_reveal)
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @always_bls
 def test_reveal_too_early(spec, state):
@@ -59,7 +59,7 @@ def test_reveal_too_early(spec, state):
     yield from run_custody_key_reveal_processing(spec, state, custody_key_reveal, False)
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @always_bls
 def test_wrong_period(spec, state):
@@ -68,7 +68,7 @@ def test_wrong_period(spec, state):
     yield from run_custody_key_reveal_processing(spec, state, custody_key_reveal, False)
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @always_bls
 def test_late_reveal(spec, state):
@@ -78,7 +78,7 @@ def test_late_reveal(spec, state):
     yield from run_custody_key_reveal_processing(spec, state, custody_key_reveal)
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @always_bls
 def test_double_reveal(spec, state):

--- a/tests/core/pyspec/eth2spec/test/phase1/block_processing/test_process_custody_slashing.py
+++ b/tests/core/pyspec/eth2spec/test/phase1/block_processing/test_process_custody_slashing.py
@@ -11,6 +11,7 @@ from eth2spec.test.helpers.state import get_balance, transition_to
 from eth2spec.test.context import (
     PHASE0,
     MINIMAL,
+    LIGHTCLIENT,
     with_all_phases_except,
     spec_state_test,
     expect_assertion_error,
@@ -112,7 +113,7 @@ def run_standard_custody_slashing_test(spec,
     yield from run_custody_slashing_processing(spec, state, slashing, valid=valid, correct=correct)
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @disable_process_reveal_deadlines
 @with_configs([MINIMAL], reason="too slow")
@@ -120,7 +121,7 @@ def test_custody_slashing(spec, state):
     yield from run_standard_custody_slashing_test(spec, state)
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @disable_process_reveal_deadlines
 @with_configs([MINIMAL], reason="too slow")
@@ -128,7 +129,7 @@ def test_incorrect_custody_slashing(spec, state):
     yield from run_standard_custody_slashing_test(spec, state, correct=False)
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @disable_process_reveal_deadlines
 @with_configs([MINIMAL], reason="too slow")
@@ -136,7 +137,7 @@ def test_multiple_epochs_custody(spec, state):
     yield from run_standard_custody_slashing_test(spec, state, shard_lateness=spec.SLOTS_PER_EPOCH * 3)
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @disable_process_reveal_deadlines
 @with_configs([MINIMAL], reason="too slow")
@@ -144,7 +145,7 @@ def test_many_epochs_custody(spec, state):
     yield from run_standard_custody_slashing_test(spec, state, shard_lateness=spec.SLOTS_PER_EPOCH * 5)
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @disable_process_reveal_deadlines
 @with_configs([MINIMAL], reason="too slow")

--- a/tests/core/pyspec/eth2spec/test/phase1/block_processing/test_process_custody_slashing.py
+++ b/tests/core/pyspec/eth2spec/test/phase1/block_processing/test_process_custody_slashing.py
@@ -11,7 +11,7 @@ from eth2spec.test.helpers.state import get_balance, transition_to
 from eth2spec.test.context import (
     PHASE0,
     MINIMAL,
-    LIGHTCLIENT,
+    LIGHTCLIENT_PATCH,
     with_all_phases_except,
     spec_state_test,
     expect_assertion_error,
@@ -113,7 +113,7 @@ def run_standard_custody_slashing_test(spec,
     yield from run_custody_slashing_processing(spec, state, slashing, valid=valid, correct=correct)
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @disable_process_reveal_deadlines
 @with_configs([MINIMAL], reason="too slow")
@@ -121,7 +121,7 @@ def test_custody_slashing(spec, state):
     yield from run_standard_custody_slashing_test(spec, state)
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @disable_process_reveal_deadlines
 @with_configs([MINIMAL], reason="too slow")
@@ -129,7 +129,7 @@ def test_incorrect_custody_slashing(spec, state):
     yield from run_standard_custody_slashing_test(spec, state, correct=False)
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @disable_process_reveal_deadlines
 @with_configs([MINIMAL], reason="too slow")
@@ -137,7 +137,7 @@ def test_multiple_epochs_custody(spec, state):
     yield from run_standard_custody_slashing_test(spec, state, shard_lateness=spec.SLOTS_PER_EPOCH * 3)
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @disable_process_reveal_deadlines
 @with_configs([MINIMAL], reason="too slow")
@@ -145,7 +145,7 @@ def test_many_epochs_custody(spec, state):
     yield from run_standard_custody_slashing_test(spec, state, shard_lateness=spec.SLOTS_PER_EPOCH * 5)
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @disable_process_reveal_deadlines
 @with_configs([MINIMAL], reason="too slow")

--- a/tests/core/pyspec/eth2spec/test/phase1/block_processing/test_process_early_derived_secret_reveal.py
+++ b/tests/core/pyspec/eth2spec/test/phase1/block_processing/test_process_early_derived_secret_reveal.py
@@ -2,6 +2,7 @@ from eth2spec.test.helpers.custody import get_valid_early_derived_secret_reveal
 from eth2spec.test.helpers.state import next_epoch_via_block, get_balance
 from eth2spec.test.context import (
     PHASE0,
+    LIGHTCLIENT,
     with_all_phases_except,
     spec_state_test,
     expect_assertion_error,
@@ -41,7 +42,7 @@ def run_early_derived_secret_reveal_processing(spec, state, randao_key_reveal, v
     yield 'post', state
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @always_bls
 def test_success(spec, state):
@@ -50,7 +51,7 @@ def test_success(spec, state):
     yield from run_early_derived_secret_reveal_processing(spec, state, randao_key_reveal)
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @never_bls
 def test_reveal_from_current_epoch(spec, state):
@@ -59,7 +60,7 @@ def test_reveal_from_current_epoch(spec, state):
     yield from run_early_derived_secret_reveal_processing(spec, state, randao_key_reveal, False)
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @never_bls
 def test_reveal_from_past_epoch(spec, state):
@@ -69,7 +70,7 @@ def test_reveal_from_past_epoch(spec, state):
     yield from run_early_derived_secret_reveal_processing(spec, state, randao_key_reveal, False)
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @always_bls
 def test_reveal_with_custody_padding(spec, state):
@@ -81,7 +82,7 @@ def test_reveal_with_custody_padding(spec, state):
     yield from run_early_derived_secret_reveal_processing(spec, state, randao_key_reveal, True)
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @always_bls
 def test_reveal_with_custody_padding_minus_one(spec, state):
@@ -93,7 +94,7 @@ def test_reveal_with_custody_padding_minus_one(spec, state):
     yield from run_early_derived_secret_reveal_processing(spec, state, randao_key_reveal, True)
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @never_bls
 def test_double_reveal(spec, state):
@@ -114,7 +115,7 @@ def test_double_reveal(spec, state):
     yield from run_early_derived_secret_reveal_processing(spec, state, randao_key_reveal2, False)
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @never_bls
 def test_revealer_is_slashed(spec, state):
@@ -124,7 +125,7 @@ def test_revealer_is_slashed(spec, state):
     yield from run_early_derived_secret_reveal_processing(spec, state, randao_key_reveal, False)
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @never_bls
 def test_far_future_epoch(spec, state):

--- a/tests/core/pyspec/eth2spec/test/phase1/block_processing/test_process_early_derived_secret_reveal.py
+++ b/tests/core/pyspec/eth2spec/test/phase1/block_processing/test_process_early_derived_secret_reveal.py
@@ -2,7 +2,7 @@ from eth2spec.test.helpers.custody import get_valid_early_derived_secret_reveal
 from eth2spec.test.helpers.state import next_epoch_via_block, get_balance
 from eth2spec.test.context import (
     PHASE0,
-    LIGHTCLIENT,
+    LIGHTCLIENT_PATCH,
     with_all_phases_except,
     spec_state_test,
     expect_assertion_error,
@@ -42,7 +42,7 @@ def run_early_derived_secret_reveal_processing(spec, state, randao_key_reveal, v
     yield 'post', state
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @always_bls
 def test_success(spec, state):
@@ -51,7 +51,7 @@ def test_success(spec, state):
     yield from run_early_derived_secret_reveal_processing(spec, state, randao_key_reveal)
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @never_bls
 def test_reveal_from_current_epoch(spec, state):
@@ -60,7 +60,7 @@ def test_reveal_from_current_epoch(spec, state):
     yield from run_early_derived_secret_reveal_processing(spec, state, randao_key_reveal, False)
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @never_bls
 def test_reveal_from_past_epoch(spec, state):
@@ -70,7 +70,7 @@ def test_reveal_from_past_epoch(spec, state):
     yield from run_early_derived_secret_reveal_processing(spec, state, randao_key_reveal, False)
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @always_bls
 def test_reveal_with_custody_padding(spec, state):
@@ -82,7 +82,7 @@ def test_reveal_with_custody_padding(spec, state):
     yield from run_early_derived_secret_reveal_processing(spec, state, randao_key_reveal, True)
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @always_bls
 def test_reveal_with_custody_padding_minus_one(spec, state):
@@ -94,7 +94,7 @@ def test_reveal_with_custody_padding_minus_one(spec, state):
     yield from run_early_derived_secret_reveal_processing(spec, state, randao_key_reveal, True)
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @never_bls
 def test_double_reveal(spec, state):
@@ -115,7 +115,7 @@ def test_double_reveal(spec, state):
     yield from run_early_derived_secret_reveal_processing(spec, state, randao_key_reveal2, False)
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @never_bls
 def test_revealer_is_slashed(spec, state):
@@ -125,7 +125,7 @@ def test_revealer_is_slashed(spec, state):
     yield from run_early_derived_secret_reveal_processing(spec, state, randao_key_reveal, False)
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @never_bls
 def test_far_future_epoch(spec, state):

--- a/tests/core/pyspec/eth2spec/test/phase1/block_processing/test_process_shard_transition.py
+++ b/tests/core/pyspec/eth2spec/test/phase1/block_processing/test_process_shard_transition.py
@@ -1,5 +1,6 @@
 from eth2spec.test.context import (
     PHASE0,
+    LIGHTCLIENT,
     with_all_phases_except,
     only_full_crosslink,
     spec_state_test,
@@ -90,21 +91,21 @@ def run_successful_crosslink_tests(spec, state, target_len_offset_slot):
         assert bool(pending_attestation.crosslink_success) is True
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @only_full_crosslink
 def test_basic_crosslinks(spec, state):
     yield from run_successful_crosslink_tests(spec, state, target_len_offset_slot=1)
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @only_full_crosslink
 def test_multiple_offset_slots(spec, state):
     yield from run_successful_crosslink_tests(spec, state, target_len_offset_slot=2)
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @only_full_crosslink
 def test_no_winning_root(spec, state):
@@ -152,7 +153,7 @@ def test_no_winning_root(spec, state):
     assert state.shard_states == pre_shard_states
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @only_full_crosslink
 def test_wrong_shard_transition_root(spec, state):

--- a/tests/core/pyspec/eth2spec/test/phase1/block_processing/test_process_shard_transition.py
+++ b/tests/core/pyspec/eth2spec/test/phase1/block_processing/test_process_shard_transition.py
@@ -1,6 +1,6 @@
 from eth2spec.test.context import (
     PHASE0,
-    LIGHTCLIENT,
+    LIGHTCLIENT_PATCH,
     with_all_phases_except,
     only_full_crosslink,
     spec_state_test,
@@ -91,21 +91,21 @@ def run_successful_crosslink_tests(spec, state, target_len_offset_slot):
         assert bool(pending_attestation.crosslink_success) is True
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @only_full_crosslink
 def test_basic_crosslinks(spec, state):
     yield from run_successful_crosslink_tests(spec, state, target_len_offset_slot=1)
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @only_full_crosslink
 def test_multiple_offset_slots(spec, state):
     yield from run_successful_crosslink_tests(spec, state, target_len_offset_slot=2)
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @only_full_crosslink
 def test_no_winning_root(spec, state):
@@ -153,7 +153,7 @@ def test_no_winning_root(spec, state):
     assert state.shard_states == pre_shard_states
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @only_full_crosslink
 def test_wrong_shard_transition_root(spec, state):

--- a/tests/core/pyspec/eth2spec/test/phase1/epoch_processing/test_process_challenge_deadlines.py
+++ b/tests/core/pyspec/eth2spec/test/phase1/epoch_processing/test_process_challenge_deadlines.py
@@ -8,6 +8,7 @@ from eth2spec.test.helpers.attestations import (
 from eth2spec.test.helpers.state import transition_to, transition_to_valid_shard_slot
 from eth2spec.test.context import (
     PHASE0,
+    LIGHTCLIENT,
     MINIMAL,
     spec_state_test,
     with_all_phases_except,
@@ -25,7 +26,7 @@ def run_process_challenge_deadlines(spec, state):
     yield from run_epoch_processing_with(spec, state, 'process_challenge_deadlines')
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @with_configs([MINIMAL], reason="too slow")
 def test_validator_slashed_after_chunk_challenge(spec, state):

--- a/tests/core/pyspec/eth2spec/test/phase1/epoch_processing/test_process_challenge_deadlines.py
+++ b/tests/core/pyspec/eth2spec/test/phase1/epoch_processing/test_process_challenge_deadlines.py
@@ -8,7 +8,7 @@ from eth2spec.test.helpers.attestations import (
 from eth2spec.test.helpers.state import transition_to, transition_to_valid_shard_slot
 from eth2spec.test.context import (
     PHASE0,
-    LIGHTCLIENT,
+    LIGHTCLIENT_PATCH,
     MINIMAL,
     spec_state_test,
     with_all_phases_except,
@@ -26,7 +26,7 @@ def run_process_challenge_deadlines(spec, state):
     yield from run_epoch_processing_with(spec, state, 'process_challenge_deadlines')
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @with_configs([MINIMAL], reason="too slow")
 def test_validator_slashed_after_chunk_challenge(spec, state):

--- a/tests/core/pyspec/eth2spec/test/phase1/epoch_processing/test_process_custody_final_updates.py
+++ b/tests/core/pyspec/eth2spec/test/phase1/epoch_processing/test_process_custody_final_updates.py
@@ -1,5 +1,6 @@
 from eth2spec.test.context import (
     PHASE0,
+    LIGHTCLIENT,
 )
 from eth2spec.test.helpers.custody import (
     get_valid_chunk_challenge,
@@ -29,7 +30,7 @@ def run_process_custody_final_updates(spec, state):
     yield from run_epoch_processing_with(spec, state, 'process_custody_final_updates')
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 def test_validator_withdrawal_delay(spec, state):
     transition_to_valid_shard_slot(spec, state)
@@ -42,7 +43,7 @@ def test_validator_withdrawal_delay(spec, state):
     assert state.validators[0].withdrawable_epoch == spec.FAR_FUTURE_EPOCH
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 def test_validator_withdrawal_reenable_after_custody_reveal(spec, state):
     transition_to_valid_shard_slot(spec, state)
@@ -67,7 +68,7 @@ def test_validator_withdrawal_reenable_after_custody_reveal(spec, state):
     assert state.validators[0].withdrawable_epoch < spec.FAR_FUTURE_EPOCH
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 def test_validator_withdrawal_suspend_after_chunk_challenge(spec, state):
     transition_to_valid_shard_slot(spec, state)
@@ -116,7 +117,7 @@ def test_validator_withdrawal_suspend_after_chunk_challenge(spec, state):
     assert state.validators[validator_index].withdrawable_epoch == spec.FAR_FUTURE_EPOCH
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 def test_validator_withdrawal_resume_after_chunk_challenge_response(spec, state):
     transition_to_valid_shard_slot(spec, state)

--- a/tests/core/pyspec/eth2spec/test/phase1/epoch_processing/test_process_custody_final_updates.py
+++ b/tests/core/pyspec/eth2spec/test/phase1/epoch_processing/test_process_custody_final_updates.py
@@ -1,6 +1,6 @@
 from eth2spec.test.context import (
     PHASE0,
-    LIGHTCLIENT,
+    LIGHTCLIENT_PATCH,
 )
 from eth2spec.test.helpers.custody import (
     get_valid_chunk_challenge,
@@ -30,7 +30,7 @@ def run_process_custody_final_updates(spec, state):
     yield from run_epoch_processing_with(spec, state, 'process_custody_final_updates')
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 def test_validator_withdrawal_delay(spec, state):
     transition_to_valid_shard_slot(spec, state)
@@ -43,7 +43,7 @@ def test_validator_withdrawal_delay(spec, state):
     assert state.validators[0].withdrawable_epoch == spec.FAR_FUTURE_EPOCH
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 def test_validator_withdrawal_reenable_after_custody_reveal(spec, state):
     transition_to_valid_shard_slot(spec, state)
@@ -68,7 +68,7 @@ def test_validator_withdrawal_reenable_after_custody_reveal(spec, state):
     assert state.validators[0].withdrawable_epoch < spec.FAR_FUTURE_EPOCH
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 def test_validator_withdrawal_suspend_after_chunk_challenge(spec, state):
     transition_to_valid_shard_slot(spec, state)
@@ -117,7 +117,7 @@ def test_validator_withdrawal_suspend_after_chunk_challenge(spec, state):
     assert state.validators[validator_index].withdrawable_epoch == spec.FAR_FUTURE_EPOCH
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 def test_validator_withdrawal_resume_after_chunk_challenge_response(spec, state):
     transition_to_valid_shard_slot(spec, state)

--- a/tests/core/pyspec/eth2spec/test/phase1/epoch_processing/test_process_reveal_deadlines.py
+++ b/tests/core/pyspec/eth2spec/test/phase1/epoch_processing/test_process_reveal_deadlines.py
@@ -4,6 +4,7 @@ from eth2spec.test.helpers.custody import (
 from eth2spec.test.helpers.state import transition_to
 from eth2spec.test.context import (
     PHASE0,
+    LIGHTCLIENT,
     MINIMAL,
     with_all_phases_except,
     with_configs,
@@ -17,7 +18,7 @@ def run_process_challenge_deadlines(spec, state):
     yield from run_epoch_processing_with(spec, state, 'process_challenge_deadlines')
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @with_configs([MINIMAL], reason="too slow")
 def test_validator_slashed_after_reveal_deadline(spec, state):
@@ -37,7 +38,7 @@ def test_validator_slashed_after_reveal_deadline(spec, state):
     assert state.validators[0].slashed == 1
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @with_configs([MINIMAL], reason="too slow")
 def test_validator_not_slashed_after_reveal(spec, state):

--- a/tests/core/pyspec/eth2spec/test/phase1/epoch_processing/test_process_reveal_deadlines.py
+++ b/tests/core/pyspec/eth2spec/test/phase1/epoch_processing/test_process_reveal_deadlines.py
@@ -4,7 +4,7 @@ from eth2spec.test.helpers.custody import (
 from eth2spec.test.helpers.state import transition_to
 from eth2spec.test.context import (
     PHASE0,
-    LIGHTCLIENT,
+    LIGHTCLIENT_PATCH,
     MINIMAL,
     with_all_phases_except,
     with_configs,
@@ -18,7 +18,7 @@ def run_process_challenge_deadlines(spec, state):
     yield from run_epoch_processing_with(spec, state, 'process_challenge_deadlines')
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @with_configs([MINIMAL], reason="too slow")
 def test_validator_slashed_after_reveal_deadline(spec, state):
@@ -38,7 +38,7 @@ def test_validator_slashed_after_reveal_deadline(spec, state):
     assert state.validators[0].slashed == 1
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @with_configs([MINIMAL], reason="too slow")
 def test_validator_not_slashed_after_reveal(spec, state):

--- a/tests/core/pyspec/eth2spec/test/phase1/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/phase1/sanity/test_blocks.py
@@ -1,7 +1,9 @@
 from typing import Dict, Sequence
 
 from eth2spec.test.context import (
-    PHASE0, MINIMAL,
+    PHASE0,
+    LIGHTCLIENT,
+    MINIMAL,
     with_all_phases_except,
     spec_state_test,
     only_full_crosslink,
@@ -98,7 +100,7 @@ def run_beacon_block_with_shard_blocks(spec, state, target_len_offset_slot, comm
                 assert post_shard_state.gasprice > pre_gasprice
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @only_full_crosslink
 def test_process_beacon_block_with_normal_shard_transition(spec, state):
@@ -112,7 +114,7 @@ def test_process_beacon_block_with_normal_shard_transition(spec, state):
     yield from run_beacon_block_with_shard_blocks(spec, state, target_len_offset_slot, committee_index, shard)
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @only_full_crosslink
 def test_process_beacon_block_with_empty_proposal_transition(spec, state):
@@ -131,7 +133,7 @@ def test_process_beacon_block_with_empty_proposal_transition(spec, state):
 #
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @only_full_crosslink
 def test_with_shard_transition_with_custody_challenge_and_response(spec, state):
@@ -165,7 +167,7 @@ def test_with_shard_transition_with_custody_challenge_and_response(spec, state):
     yield from run_beacon_block(spec, state, block)
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @with_configs([MINIMAL])
 def test_custody_key_reveal(spec, state):
@@ -179,7 +181,7 @@ def test_custody_key_reveal(spec, state):
     yield from run_beacon_block(spec, state, block)
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 def test_early_derived_secret_reveal(spec, state):
     transition_to_valid_shard_slot(spec, state)
@@ -190,7 +192,7 @@ def test_early_derived_secret_reveal(spec, state):
     yield from run_beacon_block(spec, state, block)
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @only_full_crosslink
 def test_custody_slashing(spec, state):

--- a/tests/core/pyspec/eth2spec/test/phase1/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/phase1/sanity/test_blocks.py
@@ -2,7 +2,7 @@ from typing import Dict, Sequence
 
 from eth2spec.test.context import (
     PHASE0,
-    LIGHTCLIENT,
+    LIGHTCLIENT_PATCH,
     MINIMAL,
     with_all_phases_except,
     spec_state_test,
@@ -100,7 +100,7 @@ def run_beacon_block_with_shard_blocks(spec, state, target_len_offset_slot, comm
                 assert post_shard_state.gasprice > pre_gasprice
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @only_full_crosslink
 def test_process_beacon_block_with_normal_shard_transition(spec, state):
@@ -114,7 +114,7 @@ def test_process_beacon_block_with_normal_shard_transition(spec, state):
     yield from run_beacon_block_with_shard_blocks(spec, state, target_len_offset_slot, committee_index, shard)
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @only_full_crosslink
 def test_process_beacon_block_with_empty_proposal_transition(spec, state):
@@ -133,7 +133,7 @@ def test_process_beacon_block_with_empty_proposal_transition(spec, state):
 #
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @only_full_crosslink
 def test_with_shard_transition_with_custody_challenge_and_response(spec, state):
@@ -167,7 +167,7 @@ def test_with_shard_transition_with_custody_challenge_and_response(spec, state):
     yield from run_beacon_block(spec, state, block)
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @with_configs([MINIMAL])
 def test_custody_key_reveal(spec, state):
@@ -181,7 +181,7 @@ def test_custody_key_reveal(spec, state):
     yield from run_beacon_block(spec, state, block)
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 def test_early_derived_secret_reveal(spec, state):
     transition_to_valid_shard_slot(spec, state)
@@ -192,7 +192,7 @@ def test_early_derived_secret_reveal(spec, state):
     yield from run_beacon_block(spec, state, block)
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @only_full_crosslink
 def test_custody_slashing(spec, state):

--- a/tests/core/pyspec/eth2spec/test/phase1/sanity/test_shard_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/phase1/sanity/test_shard_blocks.py
@@ -1,5 +1,6 @@
 from eth2spec.test.context import (
     PHASE0,
+    LIGHTCLIENT,
     always_bls,
     expect_assertion_error,
     spec_state_test,
@@ -43,7 +44,7 @@ def run_shard_blocks(spec, shard_state, signed_shard_block, beacon_parent_state,
         shard_state.latest_block_root == pre_shard_state.latest_block_root
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @always_bls
 @only_full_crosslink
@@ -63,7 +64,7 @@ def test_valid_shard_block(spec, state):
 #
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @only_full_crosslink
 def test_invalid_shard_parent_root(spec, state):
@@ -79,7 +80,7 @@ def test_invalid_shard_parent_root(spec, state):
     yield from run_shard_blocks(spec, shard_state, signed_shard_block, beacon_state, valid=False)
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @only_full_crosslink
 def test_invalid_beacon_parent_root(spec, state):
@@ -94,7 +95,7 @@ def test_invalid_beacon_parent_root(spec, state):
     yield from run_shard_blocks(spec, shard_state, signed_shard_block, beacon_state, valid=False)
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @only_full_crosslink
 def test_invalid_slot(spec, state):
@@ -110,7 +111,7 @@ def test_invalid_slot(spec, state):
     yield from run_shard_blocks(spec, shard_state, signed_shard_block, beacon_state, valid=False)
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @only_full_crosslink
 def test_invalid_proposer_index(spec, state):
@@ -130,7 +131,7 @@ def test_invalid_proposer_index(spec, state):
     yield from run_shard_blocks(spec, shard_state, signed_shard_block, beacon_state, valid=False)
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @always_bls
 @only_full_crosslink
@@ -151,7 +152,7 @@ def test_out_of_bound_offset(spec, state):
     yield from run_shard_blocks(spec, shard_state, signed_shard_block, beacon_state, valid=False)
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @always_bls
 @only_full_crosslink
@@ -170,7 +171,7 @@ def test_invalid_offset(spec, state):
     yield from run_shard_blocks(spec, shard_state, signed_shard_block, beacon_state, valid=False)
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @always_bls
 @only_full_crosslink
@@ -189,7 +190,7 @@ def test_empty_block_body(spec, state):
 #
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @always_bls
 @only_full_crosslink
@@ -208,7 +209,7 @@ def test_invalid_signature(spec, state):
 #
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @always_bls
 @only_full_crosslink
@@ -225,7 +226,7 @@ def test_max_offset(spec, state):
     yield from run_shard_blocks(spec, shard_state, signed_shard_block, beacon_state)
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @always_bls
 @only_full_crosslink

--- a/tests/core/pyspec/eth2spec/test/phase1/sanity/test_shard_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/phase1/sanity/test_shard_blocks.py
@@ -1,6 +1,6 @@
 from eth2spec.test.context import (
     PHASE0,
-    LIGHTCLIENT,
+    LIGHTCLIENT_PATCH,
     always_bls,
     expect_assertion_error,
     spec_state_test,
@@ -44,7 +44,7 @@ def run_shard_blocks(spec, shard_state, signed_shard_block, beacon_parent_state,
         shard_state.latest_block_root == pre_shard_state.latest_block_root
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @always_bls
 @only_full_crosslink
@@ -64,7 +64,7 @@ def test_valid_shard_block(spec, state):
 #
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @only_full_crosslink
 def test_invalid_shard_parent_root(spec, state):
@@ -80,7 +80,7 @@ def test_invalid_shard_parent_root(spec, state):
     yield from run_shard_blocks(spec, shard_state, signed_shard_block, beacon_state, valid=False)
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @only_full_crosslink
 def test_invalid_beacon_parent_root(spec, state):
@@ -95,7 +95,7 @@ def test_invalid_beacon_parent_root(spec, state):
     yield from run_shard_blocks(spec, shard_state, signed_shard_block, beacon_state, valid=False)
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @only_full_crosslink
 def test_invalid_slot(spec, state):
@@ -111,7 +111,7 @@ def test_invalid_slot(spec, state):
     yield from run_shard_blocks(spec, shard_state, signed_shard_block, beacon_state, valid=False)
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @only_full_crosslink
 def test_invalid_proposer_index(spec, state):
@@ -131,7 +131,7 @@ def test_invalid_proposer_index(spec, state):
     yield from run_shard_blocks(spec, shard_state, signed_shard_block, beacon_state, valid=False)
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @always_bls
 @only_full_crosslink
@@ -152,7 +152,7 @@ def test_out_of_bound_offset(spec, state):
     yield from run_shard_blocks(spec, shard_state, signed_shard_block, beacon_state, valid=False)
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @always_bls
 @only_full_crosslink
@@ -171,7 +171,7 @@ def test_invalid_offset(spec, state):
     yield from run_shard_blocks(spec, shard_state, signed_shard_block, beacon_state, valid=False)
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @always_bls
 @only_full_crosslink
@@ -190,7 +190,7 @@ def test_empty_block_body(spec, state):
 #
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @always_bls
 @only_full_crosslink
@@ -209,7 +209,7 @@ def test_invalid_signature(spec, state):
 #
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @always_bls
 @only_full_crosslink
@@ -226,7 +226,7 @@ def test_max_offset(spec, state):
     yield from run_shard_blocks(spec, shard_state, signed_shard_block, beacon_state)
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @always_bls
 @only_full_crosslink

--- a/tests/core/pyspec/eth2spec/test/phase1/unittests/fork_choice/test_on_shard_block.py
+++ b/tests/core/pyspec/eth2spec/test/phase1/unittests/fork_choice/test_on_shard_block.py
@@ -1,6 +1,13 @@
 from eth2spec.utils.ssz.ssz_impl import hash_tree_root
 
-from eth2spec.test.context import PHASE0, spec_state_test, with_all_phases_except, never_bls, only_full_crosslink
+from eth2spec.test.context import (
+    PHASE0,
+    LIGHTCLIENT,
+    spec_state_test,
+    with_all_phases_except,
+    never_bls,
+    only_full_crosslink,
+)
 from eth2spec.test.helpers.attestations import get_valid_on_time_attestation
 from eth2spec.test.helpers.shard_block import (
     build_shard_block,
@@ -145,7 +152,7 @@ def create_and_apply_beacon_and_shard_blocks(spec, state, store, shard, shard_bl
     return has_shard_committee
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @never_bls  # Set to never_bls for testing `check_pending_shard_blocks`
 def test_basic(spec, state):
@@ -206,7 +213,7 @@ def create_simple_fork(spec, state, store, shard):
     return head_block, forking_block
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @only_full_crosslink
 def test_shard_simple_fork(spec, state):
@@ -231,7 +238,7 @@ def test_shard_simple_fork(spec, state):
     assert spec.get_shard_head(store, shard) == forking_block.message.hash_tree_root()
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 @only_full_crosslink
 def test_shard_latest_messages_for_different_shards(spec, state):

--- a/tests/core/pyspec/eth2spec/test/phase1/unittests/fork_choice/test_on_shard_block.py
+++ b/tests/core/pyspec/eth2spec/test/phase1/unittests/fork_choice/test_on_shard_block.py
@@ -2,7 +2,7 @@ from eth2spec.utils.ssz.ssz_impl import hash_tree_root
 
 from eth2spec.test.context import (
     PHASE0,
-    LIGHTCLIENT,
+    LIGHTCLIENT_PATCH,
     spec_state_test,
     with_all_phases_except,
     never_bls,
@@ -152,7 +152,7 @@ def create_and_apply_beacon_and_shard_blocks(spec, state, store, shard, shard_bl
     return has_shard_committee
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @never_bls  # Set to never_bls for testing `check_pending_shard_blocks`
 def test_basic(spec, state):
@@ -213,7 +213,7 @@ def create_simple_fork(spec, state, store, shard):
     return head_block, forking_block
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @only_full_crosslink
 def test_shard_simple_fork(spec, state):
@@ -238,7 +238,7 @@ def test_shard_simple_fork(spec, state):
     assert spec.get_shard_head(store, shard) == forking_block.message.hash_tree_root()
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 @only_full_crosslink
 def test_shard_latest_messages_for_different_shards(spec, state):

--- a/tests/core/pyspec/eth2spec/test/phase1/unittests/test_get_start_shard.py
+++ b/tests/core/pyspec/eth2spec/test/phase1/unittests/test_get_start_shard.py
@@ -1,12 +1,13 @@
 from eth2spec.test.context import (
     PHASE0,
+    LIGHTCLIENT,
     with_all_phases_except,
     spec_state_test,
 )
 from eth2spec.test.helpers.state import next_epoch
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 def test_get_committee_count_delta(spec, state):
     assert spec.get_committee_count_delta(state, 0, 0) == 0
@@ -23,7 +24,7 @@ def test_get_committee_count_delta(spec, state):
     )
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 def test_get_start_shard_current_epoch_start(spec, state):
     assert state.current_epoch_start_shard == 0
@@ -39,7 +40,7 @@ def test_get_start_shard_current_epoch_start(spec, state):
     assert start_shard == state.current_epoch_start_shard
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 def test_get_start_shard_next_slot(spec, state):
     next_epoch(spec, state)
@@ -57,7 +58,7 @@ def test_get_start_shard_next_slot(spec, state):
     assert start_shard == expected_start_shard
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 def test_get_start_shard_previous_slot(spec, state):
     next_epoch(spec, state)
@@ -76,7 +77,7 @@ def test_get_start_shard_previous_slot(spec, state):
     assert start_shard == expected_start_shard
 
 
-@with_all_phases_except([PHASE0])
+@with_all_phases_except([PHASE0, LIGHTCLIENT])
 @spec_state_test
 def test_get_start_shard_far_past_epoch(spec, state):
     initial_epoch = spec.get_current_epoch(state)

--- a/tests/core/pyspec/eth2spec/test/phase1/unittests/test_get_start_shard.py
+++ b/tests/core/pyspec/eth2spec/test/phase1/unittests/test_get_start_shard.py
@@ -1,13 +1,13 @@
 from eth2spec.test.context import (
     PHASE0,
-    LIGHTCLIENT,
+    LIGHTCLIENT_PATCH,
     with_all_phases_except,
     spec_state_test,
 )
 from eth2spec.test.helpers.state import next_epoch
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 def test_get_committee_count_delta(spec, state):
     assert spec.get_committee_count_delta(state, 0, 0) == 0
@@ -24,7 +24,7 @@ def test_get_committee_count_delta(spec, state):
     )
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 def test_get_start_shard_current_epoch_start(spec, state):
     assert state.current_epoch_start_shard == 0
@@ -40,7 +40,7 @@ def test_get_start_shard_current_epoch_start(spec, state):
     assert start_shard == state.current_epoch_start_shard
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 def test_get_start_shard_next_slot(spec, state):
     next_epoch(spec, state)
@@ -58,7 +58,7 @@ def test_get_start_shard_next_slot(spec, state):
     assert start_shard == expected_start_shard
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 def test_get_start_shard_previous_slot(spec, state):
     next_epoch(spec, state)
@@ -77,7 +77,7 @@ def test_get_start_shard_previous_slot(spec, state):
     assert start_shard == expected_start_shard
 
 
-@with_all_phases_except([PHASE0, LIGHTCLIENT])
+@with_all_phases_except([PHASE0, LIGHTCLIENT_PATCH])
 @spec_state_test
 def test_get_start_shard_far_past_epoch(spec, state):
     initial_epoch = spec.get_current_epoch(state)


### PR DESCRIPTION
Patch for #2130

### This PR
- [x] Bump remerkleable to 0.1.18 https://github.com/ethereum/eth2.0-specs/commit/ae86517813ef462a5f50e8668b8e32b7aacd3527 Thanks @protolambda!
- [x] Use *new* `optional_fast_aggregate_verify` https://github.com/ethereum/eth2.0-specs/commit/f0864b8e92639d35d83292cc18fb81774723f28f  /cc @JustinDrake 
- [x] Add `LIGHTCLIENT` fork to `test/context.py`
- [x] Make it pass the most phase0 tests except for the inactivity leak tests (see below)

### TODO in this PR:
- [x] Rename `LIGHTCLIENT` fork to another code name that is more like a "fork".  Does `LIGHTCLIENT_PATCH` work? /cc @djrtwo 

### TODOs in other PRs:
- [x] Fix inactivity leak issues (see https://github.com/ethereum/eth2.0-specs/pull/2130#discussion_r533518677 discussions)
    - failed tests
    ```
    FAILED eth2spec/test/phase0/epoch_processing/test_process_rewards_and_penalties.py::test_almost_empty_attestations_with_leak
    FAILED eth2spec/test/phase0/epoch_processing/test_process_rewards_and_penalties.py::test_random_fill_attestations_with_leak
    FAILED eth2spec/test/phase0/epoch_processing/test_process_rewards_and_penalties.py::test_almost_full_attestations_with_leak
    FAILED eth2spec/test/phase0/epoch_processing/test_process_rewards_and_penalties.py::test_full_attestation_participation_with_leak
    ```
- [ ] This PR disabled `sync-protocol.md` for now. Let's make it executable with other PRs.
- [ ] Add light client patch tests
