### PR TITLE
Bump codespell and doctoc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ jobs:
       - checkout
       - run:
           name: Check table of contents
-          command: sudo npm install -g doctoc && make check_toc
+          command: sudo npm install -g doctoc@2 && make check_toc
   codespell:
     docker:
       - image: circleci/python:3.8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
       - checkout
       - run:
           name: Check codespell
-          command: pip install codespell --user &&  make codespell
+          command: pip install 'codespell<3.0.0,>=2.0.0' --user &&  make codespell
   lint:
     docker:
       - image: circleci/python:3.8

--- a/.codespell-whitelist
+++ b/.codespell-whitelist
@@ -1,2 +1,3 @@
 uint
 byteorder
+ether

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -5,7 +5,6 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
 - [Introduction](#introduction)
 - [Notation](#notation)
 - [Custom types](#custom-types)

--- a/specs/phase0/deposit-contract.md
+++ b/specs/phase0/deposit-contract.md
@@ -5,7 +5,6 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
 - [Introduction](#introduction)
 - [Constants](#constants)
 - [Configuration](#configuration)

--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -5,7 +5,6 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
 - [Introduction](#introduction)
 - [Fork choice](#fork-choice)
   - [Configuration](#configuration)

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -14,7 +14,6 @@ It consists of four main sections:
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
 - [Network fundamentals](#network-fundamentals)
   - [Transport](#transport)
   - [Encryption and identification](#encryption-and-identification)

--- a/specs/phase0/validator.md
+++ b/specs/phase0/validator.md
@@ -8,7 +8,6 @@ This is an accompanying document to [Ethereum 2.0 Phase 0 -- The Beacon Chain](.
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
 - [Introduction](#introduction)
 - [Prerequisites](#prerequisites)
 - [Constants](#constants)

--- a/specs/phase0/weak-subjectivity.md
+++ b/specs/phase0/weak-subjectivity.md
@@ -6,7 +6,6 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
 - [Introduction](#introduction)
 - [Prerequisites](#prerequisites)
 - [Constants](#constants)

--- a/specs/phase1/beacon-chain.md
+++ b/specs/phase1/beacon-chain.md
@@ -7,7 +7,6 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
 - [Introduction](#introduction)
 - [Custom types](#custom-types)
 - [Configuration](#configuration)

--- a/specs/phase1/custody-game.md
+++ b/specs/phase1/custody-game.md
@@ -7,7 +7,6 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
 - [Introduction](#introduction)
 - [Constants](#constants)
   - [Misc](#misc)

--- a/specs/phase1/fork-choice.md
+++ b/specs/phase1/fork-choice.md
@@ -7,7 +7,6 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
 - [Introduction](#introduction)
   - [Updated data structures](#updated-data-structures)
     - [Extended `Store`](#extended-store)

--- a/specs/phase1/light-client-sync.md
+++ b/specs/phase1/light-client-sync.md
@@ -8,7 +8,6 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
 - [Introduction](#introduction)
 - [Custom types](#custom-types)
 - [Constants](#constants)

--- a/specs/phase1/phase1-fork.md
+++ b/specs/phase1/phase1-fork.md
@@ -7,7 +7,6 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
 - [Introduction](#introduction)
 - [Configuration](#configuration)
 - [Fork to Phase 1](#fork-to-phase-1)

--- a/specs/phase1/shard-fork-choice.md
+++ b/specs/phase1/shard-fork-choice.md
@@ -7,7 +7,6 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
 - [Introduction](#introduction)
 - [Fork choice](#fork-choice)
   - [Helpers](#helpers)

--- a/specs/phase1/shard-transition.md
+++ b/specs/phase1/shard-transition.md
@@ -7,7 +7,6 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
 - [Introduction](#introduction)
 - [Helper functions](#helper-functions)
   - [Shard block verification functions](#shard-block-verification-functions)

--- a/specs/phase1/validator.md
+++ b/specs/phase1/validator.md
@@ -8,7 +8,6 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
 - [Introduction](#introduction)
 - [Prerequisites](#prerequisites)
 - [Constants](#constants)

--- a/ssz/merkle-proofs.md
+++ b/ssz/merkle-proofs.md
@@ -7,7 +7,6 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
 - [Helper functions](#helper-functions)
 - [Generalized Merkle tree index](#generalized-merkle-tree-index)
 - [SSZ object to index](#ssz-object-to-index)

--- a/ssz/simple-serialize.md
+++ b/ssz/simple-serialize.md
@@ -5,7 +5,6 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
 - [Constants](#constants)
 - [Typing](#typing)
   - [Basic types](#basic-types)


### PR DESCRIPTION
- codespell v2.0.0 released on Nov 23rd
- doctoc v2.0.0 released on December 5th

Both are not backward-compatible.

This PR bumps the package versions and fixed the compatibility errors.

Fix the CI errors in #2143 