### PR TITLE
Disable the deposit contract tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,15 +216,17 @@ workflows:
       - lint:
           requires:
             - test
-      - install_deposit_contract_web3_tester:
-          requires:
-            - checkout_specs
-      - test_deposit_contract_web3_tests:
-          requires:
-            - install_deposit_contract_web3_tester
+      # NOTE: Since phase 0 has been launched, we disabled the deposit contract tests. 
+      # - install_deposit_contract_web3_tester:
+      #     requires:
+      #       - checkout_specs
+      # - test_deposit_contract_web3_tests:
+      #     requires:
+      #       - install_deposit_contract_web3_tester
   build_and_test_deposit_contract:
     jobs:
       - build_deposit_contract
-      - test_deposit_contract:
-          requires:
-            - build_deposit_contract
+      # NOTE: Since phase 0 has been launched, we disabled the deposit contract tests.
+      # - test_deposit_contract:
+      #     requires:
+      #       - build_deposit_contract


### PR DESCRIPTION
- `test_deposit_contract` CI job took the most of our CI execution time.
- Since phase 0 has been launched, we can disable the deposit contract tests in CI now.
- Only keep the `build_deposit_contract` CI job to verify the bytecode correctness.

The codespell and doctoc errors are fixed in #2144. 
