### PR TITLE
Penalties by global quotient proposal

### DIFF
--- a/specs/accounting_reform/beacon-chain.md
+++ b/specs/accounting_reform/beacon-chain.md
@@ -49,12 +49,6 @@ The numerators add up to 7/8, leaving the remaining 1/8 for proposer rewards and
 | - | - |
 | `FLAGS_AND_NUMERATORS` | `((FLAG_TARGET, TARGET_NUMERATOR), (FLAG_TIMELY, TIMELY_NUMERATOR), (FLAG_HEAD_AND_VERY_TIMELY, HEAD_AND_VERY_TIMELY_NUMERATOR))` |
 
-### Misc
-
-| Name | Value |
-| - | - |
-| `BASE_BALANCE_DENOMINATOR` | `10**9` |
-
 ## Containers
 
 ### Modified containers


### PR DESCRIPTION
This PR changes the way that we process inactivity penalties (both in the "normal case" and in the "inactivity leak" case). Currently, we process such penalties by directly adjusting all active validators' balances, going through all validators in a loop at the end of each epoch. However, this poses the risk that even a chain with a very low level of participation (eg. 100 empty epochs followed by a single block) requires O(N) work per epoch, leading to a potential DoS vector via an attacker proposing many such chains.

This PR fixes this by moving all validator penalties into a single global quotient, `balance_denominator`, which starts at 10**9 gwei and increments from there. For example, if in some epoch, participating validators are to gain a reward of 0.02% and nonparticipating validators a penalty of 0.03%, the `balance_denominator` increases by 1.0003x, and participating validators are assigned a reward of 0.05%. If no one (or almost no one) is participating, then very little work needs to be done except for the single O(1) operation of adjusting the `balance_denominator`.

We make effective balances reflect the denominator as part of hysteresis: when the `balance_denominator` increases, the thresholds needed for a validator to be assigned a particular EB level change. For example, for an EB of 20 ETH, at the start (`balance_denominator == 1`), the hysteresis thresholds are 19.75 ETH to drop below and 21.25 ETH to go above 20 ETH. But when the `balance_denominator` increases by 1.0003x, those thresholds shift to 19.755925 ETH to drop below and 21.256375 ETH to go above. The buckets themselves shift.

When the `balance_denominator` goes above 2, we perform the extremely rare procedure of halving both the `balance_denominator` and everyone's balances (so the effective balances stay the same).

This approach is slightly different from #1340 in that balances are reconciled during hysteresis and not during the first block after a series of empty slots; this arguably increases efficiency for low-participation chains (and not just "nearly zero participation chains") further.