### PR TITLE
Refactor sync committee rewards to use helper

### DIFF
--- a/specs/lightclient/beacon-chain.md
+++ b/specs/lightclient/beacon-chain.md
@@ -197,10 +197,11 @@ def process_sync_committee(state: BeaconState, body: BeaconBlockBody) -> None:
     active_validator_count = uint64(len(get_active_validator_indices(state, get_current_epoch(state))))
     for participant_index in participant_indices:
         base_reward = get_base_reward(state, participant_index)
-        max_participant_reward = base_reward - base_reward // PROPOSER_REWARD_QUOTIENT
+        proposer_reward = get_proposer_reward(state, participant_index)
+        max_participant_reward = base_reward - proposer_reward
         reward = Gwei(max_participant_reward * active_validator_count // len(committee_indices) // SLOTS_PER_EPOCH)
         increase_balance(state, participant_index, reward)
-        proposer_reward += base_reward // PROPOSER_REWARD_QUOTIENT
+        proposer_reward += proposer_reward
 
     # Reward beacon proposer
     increase_balance(state, get_beacon_proposer_index(state), proposer_reward)


### PR DESCRIPTION
This change is functionally equivalent but uses the helper we already have for proposer rewards.

The argument for this change is better encapsulation of the reward which makes it easier in general to reason about properties of the spec ("are the attestation proposer rewards and the sync committee proposer rewards equivalent?") and a single point of maintenance in the event that rewards get refactored in the future (which makes refactoring safer overall).