### PR TITLE
Fix typo

### DIFF
--- a/specs/phase0/weak-subjectivity.md
+++ b/specs/phase0/weak-subjectivity.md
@@ -42,7 +42,7 @@ This document uses data structures, constants, functions, and terminology from
 
 ## Weak Subjectivity Checkpoint
 
-Any `Checkpoint` can used be a Weak Subjectivity Checkpoint.
+Any `Checkpoint` can be used as a Weak Subjectivity Checkpoint.
 These Weak Subjectivity Checkpoints are distributed by providers,
 downloaded by users and/or distributed as a part of clients, and used as input while syncing a client.
 

--- a/specs/phase0/weak-subjectivity.md
+++ b/specs/phase0/weak-subjectivity.md
@@ -42,7 +42,7 @@ This document uses data structures, constants, functions, and terminology from
 
 ## Weak Subjectivity Checkpoint
 
-Any `Checkpoint` can be used as a Weak Subjectivity Checkpoint.
+Any `Checkpoint` object can be used as a Weak Subjectivity Checkpoint.
 These Weak Subjectivity Checkpoints are distributed by providers,
 downloaded by users and/or distributed as a part of clients, and used as input while syncing a client.
 


### PR DESCRIPTION
Fixes typo: `can used be` -> `can be used as` in WS docs