### PR TITLE
Global quotient penalties [isolated]

### DIFF
--- a/specs/lightclient/beacon-chain.md
+++ b/specs/lightclient/beacon-chain.md
@@ -30,6 +30,7 @@
     - [`get_sync_committee_indices`](#get_sync_committee_indices)
     - [`get_sync_committee`](#get_sync_committee)
     - [`get_base_reward`](#get_base_reward)
+    - [`get_base_reward_per_eth`](#get_base_reward_per_eth)
     - [`get_unslashed_participating_indices`](#get_unslashed_participating_indices)
     - [`get_flag_deltas`](#get_flag_deltas)
     - [New `get_inactivity_penalty_deltas`](#new-get_inactivity_penalty_deltas)

--- a/specs/phase1/light-client-sync.md
+++ b/specs/phase1/light-client-sync.md
@@ -24,7 +24,10 @@
 
 ## Introduction
 
-Ethereum 2.0 is designed to be light client friendly. This allows low-resource clients such as mobile phones to access Ethereum 2.0 with reasonable safety and liveness. It also facilitates the development of "bridges" to external blockchains. This document suggests a minimal light client design for the beacon chain.
+Ethereum 2.0 is designed to be light client friendly.
+This allows low-resource clients such as mobile phones to access Ethereum 2.0 with reasonable safety and liveness.
+It also facilitates the development of "bridges" to external blockchains.
+This document suggests a minimal light client design for the beacon chain.
 
 ## Custom types
 


### PR DESCRIPTION
Isolated penalties via a global quotient feature. 
Pulled out of #2159. Branch based on/dependent on account-reform (#2176)

---

Copied from #2150:

This PR changes the way that we process inactivity penalties (both in the "normal case" and in the "inactivity leak" case). Currently, we process such penalties by directly adjusting all active validators' balances, going through all validators in a loop at the end of each epoch. However, this poses the risk that even a chain with a very low level of participation (eg. 100 empty epochs followed by a single block) requires O(N) work per epoch, leading to a potential DoS vector via an attacker proposing many such chains.

This PR fixes this by moving all validator penalties into a single global quotient, `balance_denominator`, which starts at 10**9 gwei and increments from there. For example, if in some epoch, participating validators are to gain a reward of 0.02% and nonparticipating validators a penalty of 0.03%, the `balance_denominator` increases by 1.0003x, and participating validators are assigned a reward of 0.05%. If no one (or almost no one) is participating, then very little work needs to be done except for the single O(1) operation of adjusting the `balance_denominator`.

We make effective balances reflect the denominator as part of hysteresis: when the `balance_denominator` increases, the thresholds needed for a validator to be assigned a particular EB level change. For example, for an EB of 20 ETH, at the start (`balance_denominator == 1`), the hysteresis thresholds are 19.75 ETH to drop below and 21.25 ETH to go above 20 ETH. But when the `balance_denominator` increases by 1.0003x, those thresholds shift to 19.755925 ETH to drop below and 21.256375 ETH to go above. The buckets themselves shift.

When the `balance_denominator` goes above 2, we perform the extremely rare procedure of halving both the `balance_denominator` and everyone's balances (so the effective balances stay the same).

This approach is slightly different from #1340 in that balances are reconciled during hysteresis and not during the first block after a series of empty slots; this arguably increases efficiency for low-participation chains (and not just "nearly zero participation chains") further.
