### PR TITLE
Bugfix in sync committee proposer rewards

### DIFF
--- a/specs/lightclient/beacon-chain.md
+++ b/specs/lightclient/beacon-chain.md
@@ -193,7 +193,7 @@ def process_sync_committee(state: BeaconState, body: BeaconBlockBody) -> None:
     assert eth2_fast_aggregate_verify(participant_pubkeys, signing_root, body.sync_committee_signature)
 
     # Reward sync committee participants
-    proposer_reward = Gwei(0)
+    total_proposer_reward = Gwei(0)
     active_validator_count = uint64(len(get_active_validator_indices(state, get_current_epoch(state))))
     for participant_index in participant_indices:
         base_reward = get_base_reward(state, participant_index)
@@ -201,10 +201,10 @@ def process_sync_committee(state: BeaconState, body: BeaconBlockBody) -> None:
         max_participant_reward = base_reward - proposer_reward
         reward = Gwei(max_participant_reward * active_validator_count // len(committee_indices) // SLOTS_PER_EPOCH)
         increase_balance(state, participant_index, reward)
-        proposer_reward += proposer_reward
+        total_proposer_reward += proposer_reward
 
     # Reward beacon proposer
-    increase_balance(state, get_beacon_proposer_index(state), proposer_reward)
+    increase_balance(state, get_beacon_proposer_index(state), total_proposer_reward)
 ```
 
 ### Epoch processing


### PR DESCRIPTION
The variable used to accumulate proposer rewards across the sync committee processing was shadowed by the per-participant proposer reward.

This means the total proposer reward would simply be twice the output of `get_proposer_reward` for the last participant in the sync committee.

I believe we want to sum all contributions to the proposer reward across sync committee participants which is what this PR does.