### PR TITLE
Fix existing tests on #2176 (accounting reform)

### DIFF
--- a/tests/core/pyspec/eth2spec/test/context.py
+++ b/tests/core/pyspec/eth2spec/test/context.py
@@ -390,3 +390,11 @@ def only_full_crosslink(fn):
             return None
         return fn(*args, spec=spec, state=state, **kw)
     return wrapper
+
+
+def is_post_lightclient_patch(spec):
+    if spec.fork in [PHASE0, PHASE1]:
+        # TODO: PHASE1 fork is temporarily parallel to LIGHTCLIENT_PATCH.
+        # Will make PHASE1 fork inherit LIGHTCLIENT_PATCH later.
+        return False
+    return True

--- a/tests/core/pyspec/eth2spec/test/helpers/attestations.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/attestations.py
@@ -323,7 +323,8 @@ def prepare_state_with_attestations(spec, state, participation_fn=None):
         next_slot(spec, state)
 
     assert state.slot == next_epoch_start_slot + spec.MIN_ATTESTATION_INCLUSION_DELAY
-    assert len(state.previous_epoch_attestations) == len(attestations)
+    if spec.fork != LIGHTCLIENT_PATCH:
+        assert len(state.previous_epoch_attestations) == len(attestations)
 
     return attestations
 

--- a/tests/core/pyspec/eth2spec/test/helpers/attestations.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/attestations.py
@@ -2,7 +2,7 @@ from lru import LRU
 
 from typing import List
 
-from eth2spec.test.context import expect_assertion_error, PHASE1, LIGHTCLIENT_PATCH
+from eth2spec.test.context import expect_assertion_error, PHASE1, is_post_lightclient_patch
 from eth2spec.test.helpers.state import state_transition_and_sign_block, next_epoch, next_slot
 from eth2spec.test.helpers.block import build_empty_block_for_next_slot
 from eth2spec.test.helpers.shard_transitions import get_shard_transition_of_committee
@@ -30,7 +30,7 @@ def run_attestation_processing(spec, state, attestation, valid=True):
         yield 'post', None
         return
 
-    if spec.fork != LIGHTCLIENT_PATCH:
+    if not is_post_lightclient_patch(spec):
         current_epoch_count = len(state.current_epoch_attestations)
         previous_epoch_count = len(state.previous_epoch_attestations)
 
@@ -38,7 +38,7 @@ def run_attestation_processing(spec, state, attestation, valid=True):
     spec.process_attestation(state, attestation)
 
     # Make sure the attestation has been processed
-    if spec.fork != LIGHTCLIENT_PATCH:
+    if not is_post_lightclient_patch(spec):
         if attestation.data.target.epoch == spec.get_current_epoch(state):
             assert len(state.current_epoch_attestations) == current_epoch_count + 1
         else:
@@ -323,7 +323,7 @@ def prepare_state_with_attestations(spec, state, participation_fn=None):
         next_slot(spec, state)
 
     assert state.slot == next_epoch_start_slot + spec.MIN_ATTESTATION_INCLUSION_DELAY
-    if spec.fork != LIGHTCLIENT_PATCH:
+    if not is_post_lightclient_patch(spec):
         assert len(state.previous_epoch_attestations) == len(attestations)
 
     return attestations

--- a/tests/core/pyspec/eth2spec/test/helpers/block.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/block.py
@@ -1,4 +1,4 @@
-from eth2spec.test.context import LIGHTCLIENT_PATCH
+from eth2spec.test.context import is_post_lightclient_patch
 from eth2spec.test.helpers.keys import privkeys
 from eth2spec.utils import bls
 from eth2spec.utils.bls import only_with_bls
@@ -91,7 +91,7 @@ def build_empty_block(spec, state, slot=None):
     empty_block.body.eth1_data.deposit_count = state.eth1_deposit_index
     empty_block.parent_root = parent_block_root
 
-    if spec.fork == LIGHTCLIENT_PATCH:
+    if is_post_lightclient_patch(spec):
         empty_block.body.sync_committee_signature = spec.G2_POINT_AT_INFINITY
 
     apply_randao_reveal(spec, state, empty_block)

--- a/tests/core/pyspec/eth2spec/test/helpers/rewards.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/rewards.py
@@ -6,7 +6,7 @@ from eth2spec.test.context import LIGHTCLIENT_PATCH
 from eth2spec.test.helpers.attestations import cached_prepare_state_with_attestations
 from eth2spec.test.helpers.deposits import mock_deposit
 from eth2spec.test.helpers.state import next_epoch
-from eth2spec.utils.ssz.ssz_typing import Container, uint64, List
+from eth2spec.utils.ssz.ssz_typing import Container, uint64, List, Bitvector
 
 
 class Deltas(Container):
@@ -38,29 +38,50 @@ def run_deltas(spec, state):
       - inactivity penalty deltas ('inactivity_penalty_deltas')
     """
     yield 'pre', state
+
+    if spec.fork == LIGHTCLIENT_PATCH:
+        def get_source_deltas(state):
+            return spec.get_flag_deltas(state, spec.TIMELY_SOURCE_FLAG, spec.TIMELY_SOURCE_NUMERATOR)
+
+        def get_head_deltas(state):
+            return spec.get_flag_deltas(state, spec.TIMELY_HEAD_FLAG, spec.TIMELY_HEAD_NUMERATOR)
+
+        def get_target_deltas(state):
+            return spec.get_flag_deltas(state, spec.TIMELY_TARGET_FLAG, spec.TIMELY_TARGET_NUMERATOR)
+
     yield from run_attestation_component_deltas(
         spec,
         state,
-        spec.get_source_deltas,
+        spec.get_source_deltas if spec.fork != LIGHTCLIENT_PATCH else get_source_deltas,
         spec.get_matching_source_attestations,
         'source_deltas',
     )
     yield from run_attestation_component_deltas(
         spec,
         state,
-        spec.get_target_deltas,
+        spec.get_target_deltas if spec.fork != LIGHTCLIENT_PATCH else get_target_deltas,
         spec.get_matching_target_attestations,
         'target_deltas',
     )
     yield from run_attestation_component_deltas(
         spec,
         state,
-        spec.get_head_deltas,
+        spec.get_head_deltas if spec.fork != LIGHTCLIENT_PATCH else get_head_deltas,
         spec.get_matching_head_attestations,
         'head_deltas',
     )
     yield from run_get_inclusion_delay_deltas(spec, state)
     yield from run_get_inactivity_penalty_deltas(spec, state)
+
+
+def deltas_name_to_flag(spec, deltas_name):
+    if 'source' in deltas_name:
+        return spec.TIMELY_SOURCE_FLAG
+    elif 'head' in deltas_name:
+        return spec.TIMELY_HEAD_FLAG
+    elif 'target' in deltas_name:
+        return spec.TIMELY_TARGET_FLAG
+    raise ValueError("Wrong deltas_name %s" % deltas_name)
 
 
 def run_attestation_component_deltas(spec, state, component_delta_fn, matching_att_fn, deltas_name):
@@ -72,8 +93,14 @@ def run_attestation_component_deltas(spec, state, component_delta_fn, matching_a
 
     yield deltas_name, Deltas(rewards=rewards, penalties=penalties)
 
-    matching_attestations = matching_att_fn(state, spec.get_previous_epoch(state))
-    matching_indices = spec.get_unslashed_attesting_indices(state, matching_attestations)
+    if spec.fork != LIGHTCLIENT_PATCH:
+        matching_attestations = matching_att_fn(state, spec.get_previous_epoch(state))
+        matching_indices = spec.get_unslashed_attesting_indices(state, matching_attestations)
+    else:
+        matching_indices = spec.get_unslashed_participating_indices(
+            state, deltas_name_to_flag(spec, deltas_name), spec.get_previous_epoch(state)
+        )
+
     eligible_indices = spec.get_eligible_validator_indices(state)
     for index in range(len(state.validators)):
         if index not in eligible_indices:
@@ -102,6 +129,12 @@ def run_get_inclusion_delay_deltas(spec, state):
     Run ``get_inclusion_delay_deltas``, yielding:
       - inclusion delay deltas ('inclusion_delay_deltas')
     """
+    if spec.fork == LIGHTCLIENT_PATCH:
+        # No inclusion_delay_deltas
+        yield 'inclusion_delay_deltas', Deltas(rewards=[0] * len(state.validators),
+                                               penalties=[0] * len(state.validators))
+        return
+
     rewards, penalties = spec.get_inclusion_delay_deltas(state)
 
     yield 'inclusion_delay_deltas', Deltas(rewards=rewards, penalties=penalties)
@@ -149,8 +182,14 @@ def run_get_inactivity_penalty_deltas(spec, state):
 
     yield 'inactivity_penalty_deltas', Deltas(rewards=rewards, penalties=penalties)
 
-    matching_attestations = spec.get_matching_target_attestations(state, spec.get_previous_epoch(state))
-    matching_attesting_indices = spec.get_unslashed_attesting_indices(state, matching_attestations)
+    if spec.fork != LIGHTCLIENT_PATCH:
+        matching_attestations = spec.get_matching_target_attestations(state, spec.get_previous_epoch(state))
+        matching_attesting_indices = spec.get_unslashed_attesting_indices(state, matching_attestations)
+    else:
+        matching_attesting_indices = spec.get_unslashed_participating_indices(
+            state, spec.TIMELY_TARGET_FLAG, spec.get_previous_epoch(state)
+        )
+        reward_numerator_sum = sum(numerator for (_, numerator) in spec.get_flags_and_numerators())
 
     eligible_indices = spec.get_eligible_validator_indices(state)
     for index in range(len(state.validators)):
@@ -160,12 +199,14 @@ def run_get_inactivity_penalty_deltas(spec, state):
             continue
 
         if spec.is_in_inactivity_leak(state):
-            if spec.fork == LIGHTCLIENT_PATCH:
-                cancel_base_rewards_per_epoch = spec.BASE_REWARDS_PER_EPOCH - 1
-            else:
+            # Compute base_penalty
+            if spec.fork != LIGHTCLIENT_PATCH:
                 cancel_base_rewards_per_epoch = spec.BASE_REWARDS_PER_EPOCH
-            base_reward = spec.get_base_reward(state, index)
-            base_penalty = cancel_base_rewards_per_epoch * base_reward - spec.get_proposer_reward(state, index)
+                base_reward = spec.get_base_reward(state, index)
+                base_penalty = cancel_base_rewards_per_epoch * base_reward - spec.get_proposer_reward(state, index)
+            else:
+                base_penalty = spec.get_base_reward(state, index) * reward_numerator_sum // spec.REWARD_DENOMINATOR
+
             if not has_enough_for_reward(spec, state, index):
                 assert penalties[index] == 0
             elif index in matching_attesting_indices:
@@ -267,8 +308,13 @@ def run_test_full_all_correct(spec, state):
 def run_test_full_but_partial_participation(spec, state, rng=Random(5522)):
     cached_prepare_state_with_attestations(spec, state)
 
-    for a in state.previous_epoch_attestations:
-        a.aggregation_bits = [rng.choice([True, False]) for _ in a.aggregation_bits]
+    if spec.fork != LIGHTCLIENT_PATCH:
+        for a in state.previous_epoch_attestations:
+            a.aggregation_bits = [rng.choice([True, False]) for _ in a.aggregation_bits]
+    else:
+        for index in range(len(state.validators)):
+            if rng.choice([True, False]):
+                state.previous_epoch_participation[index] = Bitvector[spec.PARTICIPATION_FLAGS_LENGTH]()
 
     yield from run_deltas(spec, state)
 
@@ -277,8 +323,12 @@ def run_test_partial(spec, state, fraction_filled):
     cached_prepare_state_with_attestations(spec, state)
 
     # Remove portion of attestations
-    num_attestations = int(len(state.previous_epoch_attestations) * fraction_filled)
-    state.previous_epoch_attestations = state.previous_epoch_attestations[:num_attestations]
+    if spec.fork != LIGHTCLIENT_PATCH:
+        num_attestations = int(len(state.previous_epoch_attestations) * fraction_filled)
+        state.previous_epoch_attestations = state.previous_epoch_attestations[:num_attestations]
+    else:
+        for index in range(int(len(state.validators) * fraction_filled)):
+            state.previous_epoch_participation[index] = Bitvector[spec.PARTICIPATION_FLAGS_LENGTH]()
 
     yield from run_deltas(spec, state)
 
@@ -333,13 +383,18 @@ def run_test_some_very_low_effective_balances_that_attested(spec, state):
 def run_test_some_very_low_effective_balances_that_did_not_attest(spec, state):
     cached_prepare_state_with_attestations(spec, state)
 
-    # Remove attestation
-    attestation = state.previous_epoch_attestations[0]
-    state.previous_epoch_attestations = state.previous_epoch_attestations[1:]
-    # Set removed indices effective balance to very low amount
-    indices = spec.get_unslashed_attesting_indices(state, [attestation])
-    for i, index in enumerate(indices):
-        state.validators[index].effective_balance = i
+    if spec.fork != LIGHTCLIENT_PATCH:
+        # Remove attestation
+        attestation = state.previous_epoch_attestations[0]
+        state.previous_epoch_attestations = state.previous_epoch_attestations[1:]
+        # Set removed indices effective balance to very low amount
+        indices = spec.get_unslashed_attesting_indices(state, [attestation])
+        for i, index in enumerate(indices):
+            state.validators[index].effective_balance = i
+    else:
+        index = 0
+        state.validators[index].effective_balance = 1
+        state.previous_epoch_participation[index] = Bitvector[spec.PARTICIPATION_FLAGS_LENGTH]()
 
     yield from run_deltas(spec, state)
 
@@ -447,16 +502,26 @@ def run_test_full_random(spec, state, rng=Random(8020)):
 
     cached_prepare_state_with_attestations(spec, state)
 
-    for pending_attestation in state.previous_epoch_attestations:
-        # ~1/3 have bad target
-        if rng.randint(0, 2) == 0:
-            pending_attestation.data.target.root = b'\x55' * 32
-        # ~1/3 have bad head
-        if rng.randint(0, 2) == 0:
-            pending_attestation.data.beacon_block_root = b'\x66' * 32
-        # ~50% participation
-        pending_attestation.aggregation_bits = [rng.choice([True, False]) for _ in pending_attestation.aggregation_bits]
-        # Random inclusion delay
-        pending_attestation.inclusion_delay = rng.randint(1, spec.SLOTS_PER_EPOCH)
+    if spec.fork != LIGHTCLIENT_PATCH:
+        for pending_attestation in state.previous_epoch_attestations:
+            # ~1/3 have bad target
+            if rng.randint(0, 2) == 0:
+                pending_attestation.data.target.root = b'\x55' * 32
+            # ~1/3 have bad head
+            if rng.randint(0, 2) == 0:
+                pending_attestation.data.beacon_block_root = b'\x66' * 32
+            # ~50% participation
+            pending_attestation.aggregation_bits = [rng.choice([True, False])
+                                                    for _ in pending_attestation.aggregation_bits]
+            # Random inclusion delay
+            pending_attestation.inclusion_delay = rng.randint(1, spec.SLOTS_PER_EPOCH)
+    else:
+        for index in range(len(state.validators)):
+            # ~1/3 have bad target
+            state.previous_epoch_participation[index][spec.TIMELY_TARGET_FLAG] = rng.randint(0, 2) != 0
+            # ~1/3 have bad head
+            state.previous_epoch_participation[index][spec.TIMELY_HEAD_FLAG] = rng.randint(0, 2) != 0
+            # ~50% participation
+            state.previous_epoch_participation[index][spec.TIMELY_SOURCE_FLAG] = rng.choice([True, False])
 
     yield from run_deltas(spec, state)

--- a/tests/core/pyspec/eth2spec/test/helpers/rewards.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/rewards.py
@@ -2,7 +2,7 @@ from random import Random
 from lru import LRU
 
 from eth2spec.phase0 import spec as spec_phase0
-from eth2spec.test.context import LIGHTCLIENT_PATCH
+from eth2spec.test.context import is_post_lightclient_patch
 from eth2spec.test.helpers.attestations import cached_prepare_state_with_attestations
 from eth2spec.test.helpers.deposits import mock_deposit
 from eth2spec.test.helpers.state import next_epoch
@@ -39,7 +39,7 @@ def run_deltas(spec, state):
     """
     yield 'pre', state
 
-    if spec.fork == LIGHTCLIENT_PATCH:
+    if is_post_lightclient_patch(spec):
         def get_source_deltas(state):
             return spec.get_flag_deltas(state, spec.TIMELY_SOURCE_FLAG, spec.TIMELY_SOURCE_NUMERATOR)
 
@@ -52,21 +52,21 @@ def run_deltas(spec, state):
     yield from run_attestation_component_deltas(
         spec,
         state,
-        spec.get_source_deltas if spec.fork != LIGHTCLIENT_PATCH else get_source_deltas,
+        spec.get_source_deltas if not is_post_lightclient_patch(spec) else get_source_deltas,
         spec.get_matching_source_attestations,
         'source_deltas',
     )
     yield from run_attestation_component_deltas(
         spec,
         state,
-        spec.get_target_deltas if spec.fork != LIGHTCLIENT_PATCH else get_target_deltas,
+        spec.get_target_deltas if not is_post_lightclient_patch(spec) else get_target_deltas,
         spec.get_matching_target_attestations,
         'target_deltas',
     )
     yield from run_attestation_component_deltas(
         spec,
         state,
-        spec.get_head_deltas if spec.fork != LIGHTCLIENT_PATCH else get_head_deltas,
+        spec.get_head_deltas if not is_post_lightclient_patch(spec) else get_head_deltas,
         spec.get_matching_head_attestations,
         'head_deltas',
     )
@@ -93,7 +93,7 @@ def run_attestation_component_deltas(spec, state, component_delta_fn, matching_a
 
     yield deltas_name, Deltas(rewards=rewards, penalties=penalties)
 
-    if spec.fork != LIGHTCLIENT_PATCH:
+    if not is_post_lightclient_patch(spec):
         matching_attestations = matching_att_fn(state, spec.get_previous_epoch(state))
         matching_indices = spec.get_unslashed_attesting_indices(state, matching_attestations)
     else:
@@ -129,7 +129,7 @@ def run_get_inclusion_delay_deltas(spec, state):
     Run ``get_inclusion_delay_deltas``, yielding:
       - inclusion delay deltas ('inclusion_delay_deltas')
     """
-    if spec.fork == LIGHTCLIENT_PATCH:
+    if is_post_lightclient_patch(spec):
         # No inclusion_delay_deltas
         yield 'inclusion_delay_deltas', Deltas(rewards=[0] * len(state.validators),
                                                penalties=[0] * len(state.validators))
@@ -182,7 +182,7 @@ def run_get_inactivity_penalty_deltas(spec, state):
 
     yield 'inactivity_penalty_deltas', Deltas(rewards=rewards, penalties=penalties)
 
-    if spec.fork != LIGHTCLIENT_PATCH:
+    if not is_post_lightclient_patch(spec):
         matching_attestations = spec.get_matching_target_attestations(state, spec.get_previous_epoch(state))
         matching_attesting_indices = spec.get_unslashed_attesting_indices(state, matching_attestations)
     else:
@@ -200,7 +200,7 @@ def run_get_inactivity_penalty_deltas(spec, state):
 
         if spec.is_in_inactivity_leak(state):
             # Compute base_penalty
-            if spec.fork != LIGHTCLIENT_PATCH:
+            if not is_post_lightclient_patch(spec):
                 cancel_base_rewards_per_epoch = spec.BASE_REWARDS_PER_EPOCH
                 base_reward = spec.get_base_reward(state, index)
                 base_penalty = cancel_base_rewards_per_epoch * base_reward - spec.get_proposer_reward(state, index)
@@ -308,7 +308,7 @@ def run_test_full_all_correct(spec, state):
 def run_test_full_but_partial_participation(spec, state, rng=Random(5522)):
     cached_prepare_state_with_attestations(spec, state)
 
-    if spec.fork != LIGHTCLIENT_PATCH:
+    if not is_post_lightclient_patch(spec):
         for a in state.previous_epoch_attestations:
             a.aggregation_bits = [rng.choice([True, False]) for _ in a.aggregation_bits]
     else:
@@ -323,7 +323,7 @@ def run_test_partial(spec, state, fraction_filled):
     cached_prepare_state_with_attestations(spec, state)
 
     # Remove portion of attestations
-    if spec.fork != LIGHTCLIENT_PATCH:
+    if not is_post_lightclient_patch(spec):
         num_attestations = int(len(state.previous_epoch_attestations) * fraction_filled)
         state.previous_epoch_attestations = state.previous_epoch_attestations[:num_attestations]
     else:
@@ -383,7 +383,7 @@ def run_test_some_very_low_effective_balances_that_attested(spec, state):
 def run_test_some_very_low_effective_balances_that_did_not_attest(spec, state):
     cached_prepare_state_with_attestations(spec, state)
 
-    if spec.fork != LIGHTCLIENT_PATCH:
+    if not is_post_lightclient_patch(spec):
         # Remove attestation
         attestation = state.previous_epoch_attestations[0]
         state.previous_epoch_attestations = state.previous_epoch_attestations[1:]
@@ -502,7 +502,7 @@ def run_test_full_random(spec, state, rng=Random(8020)):
 
     cached_prepare_state_with_attestations(spec, state)
 
-    if spec.fork != LIGHTCLIENT_PATCH:
+    if not is_post_lightclient_patch(spec):
         for pending_attestation in state.previous_epoch_attestations:
             # ~1/3 have bad target
             if rng.randint(0, 2) == 0:

--- a/tests/core/pyspec/eth2spec/test/phase0/epoch_processing/test_process_justification_and_finalization.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/epoch_processing/test_process_justification_and_finalization.py
@@ -1,4 +1,4 @@
-from eth2spec.test.context import spec_state_test, with_all_phases
+from eth2spec.test.context import LIGHTCLIENT_PATCH, spec_state_test, with_all_phases
 from eth2spec.test.phase0.epoch_processing.run_epoch_process_base import (
     run_epoch_processing_with
 )
@@ -16,12 +16,20 @@ def add_mock_attestations(spec, state, epoch, source, target, sufficient_support
     previous_epoch = spec.get_previous_epoch(state)
     current_epoch = spec.get_current_epoch(state)
 
-    if current_epoch == epoch:
-        attestations = state.current_epoch_attestations
-    elif previous_epoch == epoch:
-        attestations = state.previous_epoch_attestations
+    if spec.fork != LIGHTCLIENT_PATCH:
+        if current_epoch == epoch:
+            attestations = state.current_epoch_attestations
+        elif previous_epoch == epoch:
+            attestations = state.previous_epoch_attestations
+        else:
+            raise Exception(f"cannot include attestations in epoch ${epoch} from epoch ${current_epoch}")
     else:
-        raise Exception(f"cannot include attestations in epoch ${epoch} from epoch ${current_epoch}")
+        if current_epoch == epoch:
+            epoch_participation = state.current_epoch_participation
+        elif previous_epoch == epoch:
+            epoch_participation = state.previous_epoch_participation
+        else:
+            raise Exception(f"cannot include attestations in epoch ${epoch} from epoch ${current_epoch}")
 
     total_balance = spec.get_total_active_balance(state)
     remaining_balance = int(total_balance * 2 // 3)  # can become negative
@@ -52,19 +60,28 @@ def add_mock_attestations(spec, state, epoch, source, target, sufficient_support
                 for i in range(max(len(committee) // 5, 1)):
                     aggregation_bits[i] = 0
 
-            attestations.append(spec.PendingAttestation(
-                aggregation_bits=aggregation_bits,
-                data=spec.AttestationData(
-                    slot=slot,
-                    beacon_block_root=b'\xff' * 32,  # irrelevant to testing
-                    source=source,
-                    target=target,
-                    index=index,
-                ),
-                inclusion_delay=1,
-            ))
-            if messed_up_target:
-                attestations[len(attestations) - 1].data.target.root = b'\x99' * 32
+            # Update state
+            if spec.fork != LIGHTCLIENT_PATCH:
+                attestations.append(spec.PendingAttestation(
+                    aggregation_bits=aggregation_bits,
+                    data=spec.AttestationData(
+                        slot=slot,
+                        beacon_block_root=b'\xff' * 32,  # irrelevant to testing
+                        source=source,
+                        target=target,
+                        index=index,
+                    ),
+                    inclusion_delay=1,
+                ))
+                if messed_up_target:
+                    attestations[len(attestations) - 1].data.target.root = b'\x99' * 32
+            else:
+                for i, index in enumerate(committee):
+                    if aggregation_bits[i]:
+                        epoch_participation[index][spec.TIMELY_HEAD_FLAG] = True
+                        epoch_participation[index][spec.TIMELY_SOURCE_FLAG] = True
+                        if not messed_up_target:
+                            epoch_participation[index][spec.TIMELY_TARGET_FLAG] = True
 
 
 def get_checkpoints(spec, epoch):

--- a/tests/core/pyspec/eth2spec/test/phase0/epoch_processing/test_process_justification_and_finalization.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/epoch_processing/test_process_justification_and_finalization.py
@@ -1,4 +1,4 @@
-from eth2spec.test.context import LIGHTCLIENT_PATCH, spec_state_test, with_all_phases
+from eth2spec.test.context import is_post_lightclient_patch, spec_state_test, with_all_phases
 from eth2spec.test.phase0.epoch_processing.run_epoch_process_base import (
     run_epoch_processing_with
 )
@@ -16,7 +16,7 @@ def add_mock_attestations(spec, state, epoch, source, target, sufficient_support
     previous_epoch = spec.get_previous_epoch(state)
     current_epoch = spec.get_current_epoch(state)
 
-    if spec.fork != LIGHTCLIENT_PATCH:
+    if not is_post_lightclient_patch(spec):
         if current_epoch == epoch:
             attestations = state.current_epoch_attestations
         elif previous_epoch == epoch:
@@ -61,7 +61,7 @@ def add_mock_attestations(spec, state, epoch, source, target, sufficient_support
                     aggregation_bits[i] = 0
 
             # Update state
-            if spec.fork != LIGHTCLIENT_PATCH:
+            if not is_post_lightclient_patch(spec):
                 attestations.append(spec.PendingAttestation(
                     aggregation_bits=aggregation_bits,
                     data=spec.AttestationData(

--- a/tests/core/pyspec/eth2spec/test/phase0/epoch_processing/test_process_rewards_and_penalties.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/epoch_processing/test_process_rewards_and_penalties.py
@@ -2,7 +2,7 @@ from eth2spec.test.context import (
     LIGHTCLIENT_PATCH,
     spec_state_test, spec_test,
     with_all_phases, single_phase,
-    with_phases, PHASE0,
+    with_phases, PHASE0, PHASE1,
     with_custom_state,
     zero_activation_threshold,
     misc_balances, low_single_balance,
@@ -66,7 +66,7 @@ def test_genesis_epoch_full_attestations_no_rewards(spec, state):
         assert state.balances[index] == pre_state.balances[index]
 
 
-@with_all_phases
+@with_phases([PHASE0, PHASE1])
 @spec_state_test
 def test_full_attestations_random_incorrect_fields(spec, state):
     attestations = prepare_state_with_attestations(spec, state)
@@ -159,7 +159,8 @@ def run_with_participation(spec, state, participation_fn):
         return att_participants
 
     attestations = prepare_state_with_attestations(spec, state, participation_fn=participation_tracker)
-    proposer_indices = [a.proposer_index for a in state.previous_epoch_attestations]
+    if spec.fork != LIGHTCLIENT_PATCH:
+        proposer_indices = [a.proposer_index for a in state.previous_epoch_attestations]
 
     pre_state = state.copy()
 
@@ -173,8 +174,8 @@ def run_with_participation(spec, state, participation_fn):
 
     for index in range(len(pre_state.validators)):
         if spec.is_in_inactivity_leak(state):
-            # Proposers can still make money during a leak
-            if index in proposer_indices and index in participated:
+            # Proposers can still make money during a leak before LIGHTCLIENT_PATCH
+            if spec.fork != LIGHTCLIENT_PATCH and index in proposer_indices and index in participated:
                 assert state.balances[index] > pre_state.balances[index]
             elif index in attesting_indices:
                 if spec.fork == LIGHTCLIENT_PATCH and index in sync_committee_indices:
@@ -428,7 +429,8 @@ def test_attestations_some_slashed(spec, state):
     for i in range(spec.MIN_PER_EPOCH_CHURN_LIMIT):
         spec.slash_validator(state, attesting_indices_before_slashings[i])
 
-    assert len(state.previous_epoch_attestations) == len(attestations)
+    if spec.fork != LIGHTCLIENT_PATCH:
+        assert len(state.previous_epoch_attestations) == len(attestations)
 
     pre_state = state.copy()
 

--- a/tests/core/pyspec/eth2spec/test/phase0/rewards/test_basic.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/rewards/test_basic.py
@@ -1,4 +1,4 @@
-from eth2spec.test.context import with_all_phases, spec_state_test
+from eth2spec.test.context import PHASE0, PHASE1, with_all_phases, with_phases, spec_state_test
 import eth2spec.test.helpers.rewards as rewards_helpers
 
 
@@ -32,7 +32,7 @@ def test_full_but_partial_participation(spec, state):
     yield from rewards_helpers.run_test_full_but_partial_participation(spec, state)
 
 
-@with_all_phases
+@with_phases([PHASE0, PHASE1])
 @spec_state_test
 def test_one_attestation_one_correct(spec, state):
     yield from rewards_helpers.run_test_one_attestation_one_correct(spec, state)
@@ -75,7 +75,7 @@ def test_some_very_low_effective_balances_that_did_not_attest(spec, state):
 #
 
 
-@with_all_phases
+@with_phases([PHASE0, PHASE1])
 @spec_state_test
 def test_full_half_correct_target_incorrect_head(spec, state):
     yield from rewards_helpers.run_test_full_fraction_incorrect(
@@ -86,7 +86,7 @@ def test_full_half_correct_target_incorrect_head(spec, state):
     )
 
 
-@with_all_phases
+@with_phases([PHASE0, PHASE1])
 @spec_state_test
 def test_full_correct_target_incorrect_head(spec, state):
     yield from rewards_helpers.run_test_full_fraction_incorrect(
@@ -97,7 +97,7 @@ def test_full_correct_target_incorrect_head(spec, state):
     )
 
 
-@with_all_phases
+@with_phases([PHASE0, PHASE1])
 @spec_state_test
 def test_full_half_incorrect_target_incorrect_head(spec, state):
     yield from rewards_helpers.run_test_full_fraction_incorrect(
@@ -108,7 +108,7 @@ def test_full_half_incorrect_target_incorrect_head(spec, state):
     )
 
 
-@with_all_phases
+@with_phases([PHASE0, PHASE1])
 @spec_state_test
 def test_full_half_incorrect_target_correct_head(spec, state):
     yield from rewards_helpers.run_test_full_fraction_incorrect(
@@ -119,31 +119,31 @@ def test_full_half_incorrect_target_correct_head(spec, state):
     )
 
 
-@with_all_phases
+@with_phases([PHASE0, PHASE1])
 @spec_state_test
 def test_full_delay_one_slot(spec, state):
     yield from rewards_helpers.run_test_full_delay_one_slot(spec, state)
 
 
-@with_all_phases
+@with_phases([PHASE0, PHASE1])
 @spec_state_test
 def test_full_delay_max_slots(spec, state):
     yield from rewards_helpers.run_test_full_delay_max_slots(spec, state)
 
 
-@with_all_phases
+@with_phases([PHASE0, PHASE1])
 @spec_state_test
 def test_full_mixed_delay(spec, state):
     yield from rewards_helpers.run_test_full_mixed_delay(spec, state)
 
 
-@with_all_phases
+@with_phases([PHASE0, PHASE1])
 @spec_state_test
 def test_proposer_not_in_attestations(spec, state):
     yield from rewards_helpers.run_test_proposer_not_in_attestations(spec, state)
 
 
-@with_all_phases
+@with_phases([PHASE0, PHASE1])
 @spec_state_test
 def test_duplicate_attestations_at_later_slots(spec, state):
     yield from rewards_helpers.run_test_duplicate_attestations_at_later_slots(spec, state)

--- a/tests/core/pyspec/eth2spec/test/phase0/rewards/test_leak.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/rewards/test_leak.py
@@ -1,4 +1,4 @@
-from eth2spec.test.context import with_all_phases, spec_state_test
+from eth2spec.test.context import PHASE0, PHASE1, with_all_phases, with_phases, spec_state_test
 from eth2spec.test.helpers.rewards import leaking
 import eth2spec.test.helpers.rewards as rewards_helpers
 
@@ -38,7 +38,7 @@ def test_full_but_partial_participation_leak(spec, state):
     yield from rewards_helpers.run_test_full_but_partial_participation(spec, state)
 
 
-@with_all_phases
+@with_phases([PHASE0, PHASE1])
 @spec_state_test
 @leaking()
 def test_one_attestation_one_correct_leak(spec, state):
@@ -87,7 +87,7 @@ def test_some_very_low_effective_balances_that_did_not_attest_leak(spec, state):
 #
 
 
-@with_all_phases
+@with_phases([PHASE0, PHASE1])
 @spec_state_test
 @leaking()
 def test_full_half_correct_target_incorrect_head_leak(spec, state):
@@ -99,7 +99,7 @@ def test_full_half_correct_target_incorrect_head_leak(spec, state):
     )
 
 
-@with_all_phases
+@with_phases([PHASE0, PHASE1])
 @spec_state_test
 @leaking()
 def test_full_correct_target_incorrect_head_leak(spec, state):
@@ -111,7 +111,7 @@ def test_full_correct_target_incorrect_head_leak(spec, state):
     )
 
 
-@with_all_phases
+@with_phases([PHASE0, PHASE1])
 @spec_state_test
 @leaking()
 def test_full_half_incorrect_target_incorrect_head_leak(spec, state):
@@ -123,7 +123,7 @@ def test_full_half_incorrect_target_incorrect_head_leak(spec, state):
     )
 
 
-@with_all_phases
+@with_phases([PHASE0, PHASE1])
 @spec_state_test
 @leaking()
 def test_full_half_incorrect_target_correct_head_leak(spec, state):

--- a/tests/core/pyspec/eth2spec/test/phase0/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/sanity/test_blocks.py
@@ -27,7 +27,7 @@ from eth2spec.test.helpers.multi_operations import (
 )
 
 from eth2spec.test.context import (
-    PHASE0, PHASE1, MINIMAL,
+    PHASE0, PHASE1, LIGHTCLIENT_PATCH, MINIMAL,
     spec_test, spec_state_test, dump_skipping_message,
     with_phases, with_all_phases, single_phase,
     expect_assertion_error, always_bls,
@@ -780,15 +780,19 @@ def test_attestation(spec, state):
         spec, state, shard_transition=shard_transition, index=index, signed=True, on_time=True
     )
 
+    if spec.fork != LIGHTCLIENT_PATCH:
+        pre_current_attestations_len = len(state.current_epoch_attestations)
+
     # Add to state via block transition
-    pre_current_attestations_len = len(state.current_epoch_attestations)
     attestation_block.body.attestations.append(attestation)
     signed_attestation_block = state_transition_and_sign_block(spec, state, attestation_block)
 
-    assert len(state.current_epoch_attestations) == pre_current_attestations_len + 1
-
-    # Epoch transition should move to previous_epoch_attestations
-    pre_current_attestations_root = spec.hash_tree_root(state.current_epoch_attestations)
+    if spec.fork != LIGHTCLIENT_PATCH:
+        assert len(state.current_epoch_attestations) == pre_current_attestations_len + 1
+        # Epoch transition should move to previous_epoch_attestations
+        pre_current_attestations_root = spec.hash_tree_root(state.current_epoch_attestations)
+    else:
+        pre_current_epoch_participation_root = spec.hash_tree_root(state.current_epoch_participation)
 
     epoch_block = build_empty_block(spec, state, state.slot + spec.SLOTS_PER_EPOCH)
     signed_epoch_block = state_transition_and_sign_block(spec, state, epoch_block)
@@ -796,8 +800,13 @@ def test_attestation(spec, state):
     yield 'blocks', [signed_attestation_block, signed_epoch_block]
     yield 'post', state
 
-    assert len(state.current_epoch_attestations) == 0
-    assert spec.hash_tree_root(state.previous_epoch_attestations) == pre_current_attestations_root
+    if spec.fork != LIGHTCLIENT_PATCH:
+        assert len(state.current_epoch_attestations) == 0
+        assert spec.hash_tree_root(state.previous_epoch_attestations) == pre_current_attestations_root
+    else:
+        for index in range(len(state.validators)):
+            assert state.current_epoch_participation[index] == spec.Bitvector[spec.PARTICIPATION_FLAGS_LENGTH]()
+        assert spec.hash_tree_root(state.previous_epoch_participation) == pre_current_epoch_participation_root
 
 
 # In phase1 a committee is computed for SHARD_COMMITTEE_PERIOD slots ago,

--- a/tests/core/pyspec/eth2spec/test/phase0/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/sanity/test_blocks.py
@@ -27,7 +27,7 @@ from eth2spec.test.helpers.multi_operations import (
 )
 
 from eth2spec.test.context import (
-    PHASE0, PHASE1, LIGHTCLIENT_PATCH, MINIMAL,
+    PHASE0, PHASE1, MINIMAL,
     spec_test, spec_state_test, dump_skipping_message,
     with_phases, with_all_phases, single_phase,
     expect_assertion_error, always_bls,
@@ -35,6 +35,7 @@ from eth2spec.test.context import (
     with_configs,
     with_custom_state,
     large_validator_set,
+    is_post_lightclient_patch,
 )
 
 
@@ -780,14 +781,14 @@ def test_attestation(spec, state):
         spec, state, shard_transition=shard_transition, index=index, signed=True, on_time=True
     )
 
-    if spec.fork != LIGHTCLIENT_PATCH:
+    if not is_post_lightclient_patch(spec):
         pre_current_attestations_len = len(state.current_epoch_attestations)
 
     # Add to state via block transition
     attestation_block.body.attestations.append(attestation)
     signed_attestation_block = state_transition_and_sign_block(spec, state, attestation_block)
 
-    if spec.fork != LIGHTCLIENT_PATCH:
+    if not is_post_lightclient_patch(spec):
         assert len(state.current_epoch_attestations) == pre_current_attestations_len + 1
         # Epoch transition should move to previous_epoch_attestations
         pre_current_attestations_root = spec.hash_tree_root(state.current_epoch_attestations)
@@ -800,7 +801,7 @@ def test_attestation(spec, state):
     yield 'blocks', [signed_attestation_block, signed_epoch_block]
     yield 'post', state
 
-    if spec.fork != LIGHTCLIENT_PATCH:
+    if not is_post_lightclient_patch(spec):
         assert len(state.current_epoch_attestations) == 0
         assert spec.hash_tree_root(state.previous_epoch_attestations) == pre_current_attestations_root
     else:


### PR DESCRIPTION
Separating the tests (this PR) from the spec changes (#2176).

- The most significant change is that we no longer store `PendingAttestation`s in the `BeaconState`. i.e.,`previous_epoch_attestations` and `current_epoch_attestations` are replaced with `previous_epoch_participation` and `current_epoch_participation`.
- Therefore, the tests we generated with mocking `state.previous_epoch_attestations`/`state.current_epoch_attestations` don't work after #2176. I disabled some tests for this reason and fixed other tests case by case.