### PR TITLE
Require gossip blocks to have a higher slot than thier parent

### DIFF
--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -313,6 +313,7 @@ The following validations MUST pass before forwarding the `signed_beacon_block` 
   (via both gossip and non-gossip sources)
   (a client MAY queue blocks for processing once the parent block is retrieved).
 - _[REJECT]_ The block's parent (defined by `block.parent_root`) passes validation.
+- _[REJECT]_ The block is from a higher slot than its parent.
 - _[REJECT]_ The current `finalized_checkpoint` is an ancestor of `block` -- i.e.
   `get_ancestor(store, block.parent_root, compute_start_slot_at_epoch(store.finalized_checkpoint.epoch))
   == store.finalized_checkpoint.root`


### PR DESCRIPTION
As discussed with/raised by @protolambda, don't allow propagation of gossip blocks which have a slot eq to or lower than their parent.

I understand that this check is likely to end up *implicitly* in client implementations, so it's sensible to have it made explicit.