### PR TITLE
bump setup.py to `dev` version's dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -516,13 +516,13 @@ setup(
     url="https://github.com/ethereum/eth2.0-specs",
     include_package_data=False,
     package_data={'configs': ['*.yaml'],
-                 
+
                   'specs': ['**/*.md'],
                   'eth2spec': ['VERSION.txt']},
     package_dir={
         "eth2spec": "tests/core/pyspec/eth2spec",
         "configs": "configs",
-        "specs": "specs"
+        "specs": "specs",
     },
     packages=find_packages(where='tests/core/pyspec') + ['configs', 'specs'],
     py_modules=["eth2spec"],
@@ -536,10 +536,10 @@ setup(
         "eth-utils>=1.3.0,<2",
         "eth-typing>=2.1.0,<3.0.0",
         "pycryptodome==3.9.4",
-        "py_ecc==5.0.0",
-        "milagro_bls_binding==1.5.0",
+        "py_ecc==5.1.0",
+        "milagro_bls_binding==1.6.3",
         "dataclasses==0.6",
-        "remerkleable==0.1.17",
+        "remerkleable==0.1.18",
         "ruamel.yaml==0.16.5",
         "lru-dict==1.1.6"
     ]


### PR DESCRIPTION
apparently, you are doing releases on a branch called `master` which does not reflect the updates - here: to python dependencies - applied in `dev`.

installing `eth2spec==1.0.1` fails due to unmatched dependencies. 

```
❯ pip install eth2spec==1.0.1
WARNING: Value for scheme.headers does not match. Please report this to <https://github.com/pypa/pip/issues/9617>
distutils: /usr/include/python3.9/UNKNOWN
sysconfig: /usr/include/python3.9
WARNING: Additional context:
user = False
home = None
root = None
prefix = None
Defaulting to user installation because normal site-packages is not writeable
Collecting eth2spec==1.0.1
  Downloading eth2spec-1.0.1-py3-none-any.whl (264 kB)
     |████████████████████████████████| 264 kB 3.8 MB/s 
Requirement already satisfied: eth-typing<3.0.0,>=2.1.0 in /home/user/.local/lib/python3.9/site-packages (from eth2spec==1.0.1) (2.2.2)
Requirement already satisfied: eth-utils<2,>=1.3.0 in /home/user/.local/lib/python3.9/site-packages (from eth2spec==1.0.1) (1.10.0)
ERROR: Could not find a version that satisfies the requirement milagro-bls-binding==1.5.0 (from eth2spec) (from versions: 0.1.4, 0.4.0, 1.0.0, 1.0.1, 1.6.2, 1.6.3)
ERROR: No matching distribution found for milagro-bls-binding==1.5.0
```

The changeset below only bumps the deps from `dev` to `master`, hopefully the next release will fix this 🙉 
