### PR TITLE
[minor] Fix missing --cov-report

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ install_test:
 
 test: pyspec
 	. venv/bin/activate; cd $(PY_SPEC_DIR); \
-	python3 -m pytest -n 4 --disable-bls --cov=eth2spec.phase0.spec --cov=eth2spec.phase1.spec --cov=eth2spec.altair.spec -cov-report="html:$(COV_HTML_OUT)" --cov-branch eth2spec
+	python3 -m pytest -n 4 --disable-bls --cov=eth2spec.phase0.spec --cov=eth2spec.phase1.spec --cov=eth2spec.altair.spec --cov-report="html:$(COV_HTML_OUT)" --cov-branch eth2spec
 
 find_test: pyspec
 	. venv/bin/activate; cd $(PY_SPEC_DIR); \

--- a/setup.py
+++ b/setup.py
@@ -539,7 +539,6 @@ class PySpecCommand(Command):
                     specs/altair/fork.md
                     specs/altair/sync-protocol.md
                 """
-                # TODO: add specs/altair/sync-protocol.md back when the GeneralizedIndex helpers are included.
             else:
                 raise Exception('no markdown files specified, and spec fork "%s" is unknown', self.spec_fork)
 


### PR DESCRIPTION
1. The `--cov-report` flag was missed during #2141. (My bad!) Adding it back.
2. Remove outdated comment.