### PR TITLE
Fix `NEXT_SYNC_COMMITTEE_INDEX` (leftover of #2236)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -315,7 +315,7 @@ def get_generalized_index(ssz_class: Any, *path: Sequence[Union[int, SSZVariable
 # Will verify the value at the end of the spec
 ALTAIR_HARDCODED_SSZ_DEP_CONSTANTS = {
     'FINALIZED_ROOT_INDEX': 'GeneralizedIndex(105)',
-    'NEXT_SYNC_COMMITTEE_INDEX': 'GeneralizedIndex(54)',
+    'NEXT_SYNC_COMMITTEE_INDEX': 'GeneralizedIndex(55)',
 }
 
 


### PR DESCRIPTION
## Issue
#2236 changed the order of `BeaconState` fields. But `NEXT_SYNC_COMMITTEE_INDEX` is hardcoded in `setup.py` for pyspec generation procedure.

## How did I fix it
Update the hardcoded number as well.