### PR TITLE
Enhance gen_runner error handler

### DIFF
--- a/tests/core/pyspec/eth2spec/gen_helpers/gen_base/gen_runner.py
+++ b/tests/core/pyspec/eth2spec/gen_helpers/gen_base/gen_runner.py
@@ -132,7 +132,7 @@ def run_generator(generator_name, test_providers: Iterable[TestProvider]):
                 / Path(test_case.runner_name) / Path(test_case.handler_name)
                 / Path(test_case.suite_name) / Path(test_case.case_name)
             )
-            if case_dir.exists():
+            if case_dir.exists() and not args.force:
                 # Check if the test vector was generated successfully.
                 meta_file = case_dir / 'meta.yaml'
                 # Check if meta file exists
@@ -141,7 +141,7 @@ def run_generator(generator_name, test_providers: Iterable[TestProvider]):
                     with meta_file.open('r') as f:
                         meta_dict = safe_load(f.read())
 
-                if 'release_version' in meta_dict and not args.force:
+                if 'release_version' in meta_dict and meta_dict['release_version'] == str(version('eth2spec')):
                     # If release_version is in meta.yaml, the test was generated successfully.
                     print(f'Skipping already existing test: {case_dir}')
                     continue
@@ -149,7 +149,7 @@ def run_generator(generator_name, test_providers: Iterable[TestProvider]):
                 print(f'Warning, output directory {case_dir} already exist,'
                       f' old files are not deleted but will be overwritten when a new version is produced')
 
-                # Remove case_dir folder
+                # Remove the existing case_dir folder
                 shutil.rmtree(case_dir)
 
             print(f'Generating test: {case_dir}')

--- a/tests/core/pyspec/eth2spec/gen_helpers/gen_base/gen_runner.py
+++ b/tests/core/pyspec/eth2spec/gen_helpers/gen_base/gen_runner.py
@@ -16,7 +16,6 @@ from snappy import compress
 from eth2spec.test import context
 from eth2spec.test.exceptions import SkippedTest
 
-
 from .gen_typing import TestProvider
 
 
@@ -180,7 +179,7 @@ def run_generator(generator_name, test_providers: Iterable[TestProvider]):
                     continue
 
                 # If the test case was executed successfully, write release version to meta.yaml
-                if written_part > 0:
+                if written_part:
                     meta['release_version'] = str(version('eth2spec'))
 
                 # Once all meta data is collected (if any), write it to a meta data file.

--- a/tests/core/pyspec/eth2spec/test/altair/block_processing/test_process_sync_committee.py
+++ b/tests/core/pyspec/eth2spec/test/altair/block_processing/test_process_sync_committee.py
@@ -284,6 +284,7 @@ def test_invalid_signature_previous_committee(spec, state):
 @with_all_phases_except([PHASE0, PHASE1])
 @spec_state_test
 @always_bls
+@with_configs([MINIMAL], reason="too slow")
 def test_valid_signature_future_committee(spec, state):
     # NOTE: the `state` provided is at genesis and the process to select
     # sync committees currently returns the same committee for the first and second

--- a/tests/formats/README.md
+++ b/tests/formats/README.md
@@ -163,17 +163,19 @@ Common data is documented here:
 Some test-case formats share some common key-value pair patterns, and these are documented here:
 
 ```
-bls_setting: int     -- optional, can have 3 different values:
-                            0: (default, applies if key-value pair is absent). Free to choose either BLS ON or OFF.
-                                 Tests are generated with valid BLS data in this case,
-                                 but there is no change of outcome when running the test if BLS is ON or OFF.
-                            1: known as "BLS required" - if the test validity is strictly dependent on BLS being ON
-                            2: known as "BLS ignored"  - if the test validity is strictly dependent on BLS being OFF
-reveal_deadlines_setting:   -- optional, can have 2 different values:
-                            0: default, `process_reveal_deadlines` is ON.
-                            1: `process_reveal_deadlines` is OFF.
+release_version: string         -- required, the pyspec release version.
+bls_setting: int                -- optional, can have 3 different values:
+                                    0: (default, applies if key-value pair is absent). Free to choose either BLS ON or OFF.
+                                        Tests are generated with valid BLS data in this case,
+                                        but there is no change of outcome when running the test if BLS is ON or OFF.
+                                    1: known as "BLS required" - if the test validity is strictly dependent on BLS being ON
+                                    2: known as "BLS ignored"  - if the test validity is strictly dependent on BLS being OFF
+reveal_deadlines_setting: int   -- optional, can have 2 different values:
+                                    0: default, `process_reveal_deadlines` is ON.
+                                    1: `process_reveal_deadlines` is OFF.
+description: string             -- optional description of test case, purely for debugging purposes.
+                                   Tests should use the directory name of the test case as identifier, not the description.
 ```
-
 
 ## Config
 

--- a/tests/formats/bls/aggregate.md
+++ b/tests/formats/bls/aggregate.md
@@ -4,7 +4,13 @@ A BLS signature aggregation combines a series of signatures into a single signat
 
 ## Test case format
 
-The test data is declared in a `data.yaml` file:
+### `meta.yaml`
+
+```yaml
+release_version: string  -- required, the pyspec release version.
+```
+
+### `data.yaml`
 
 ```yaml
 input: List[BLS Signature] -- list of input BLS signatures

--- a/tests/formats/bls/aggregate_verify.md
+++ b/tests/formats/bls/aggregate_verify.md
@@ -4,7 +4,13 @@ Verify the signature against the given pubkeys and one messages.
 
 ## Test case format
 
-The test data is declared in a `data.yaml` file:
+### `meta.yaml`
+
+```yaml
+release_version: string  -- required, the pyspec release version.
+```
+
+### `data.yaml`
 
 ```yaml
 input:

--- a/tests/formats/bls/fast_aggregate_verify.md
+++ b/tests/formats/bls/fast_aggregate_verify.md
@@ -4,7 +4,13 @@ Verify the signature against the given pubkeys and one message.
 
 ## Test case format
 
-The test data is declared in a `data.yaml` file:
+### `meta.yaml`
+
+```yaml
+release_version: string  -- required, the pyspec release version.
+```
+
+### `data.yaml`
 
 ```yaml
 input:

--- a/tests/formats/bls/sign.md
+++ b/tests/formats/bls/sign.md
@@ -4,7 +4,13 @@ Message signing with BLS should produce a signature.
 
 ## Test case format
 
-The test data is declared in a `data.yaml` file:
+### `meta.yaml`
+
+```yaml
+release_version: string  -- required, the pyspec release version.
+```
+
+### `data.yaml`
 
 ```yaml
 input:

--- a/tests/formats/bls/verify.md
+++ b/tests/formats/bls/verify.md
@@ -4,7 +4,13 @@ Verify the signature against the given one pubkey and one message.
 
 ## Test case format
 
-The test data is declared in a `data.yaml` file:
+### `meta.yaml`
+
+```yaml
+release_version: string  -- required, the pyspec release version.
+```
+
+### `data.yaml`
 
 ```yaml
 input:

--- a/tests/formats/epoch_processing/README.md
+++ b/tests/formats/epoch_processing/README.md
@@ -10,9 +10,10 @@ Hence, the format is shared between each test-handler. (See test condition docum
 ### `meta.yaml`
 
 ```yaml
-description: string    -- Optional description of test case, purely for debugging purposes.
-                          Tests should use the directory name of the test case as identifier, not the description.
-bls_setting: int       -- see general test-format spec.
+release_version: string    -- required, the pyspec release version.
+description: string        -- Optional description of test case, purely for debugging purposes.
+                              Tests should use the directory name of the test case as identifier, not the description.
+bls_setting: int           -- see general test-format spec.
 ```
 
 ### `pre.ssz_snappy`

--- a/tests/formats/finality/README.md
+++ b/tests/formats/finality/README.md
@@ -9,9 +9,10 @@ The aim of the tests for the finality rules.
 ### `meta.yaml`
 
 ```yaml
-description: string    -- Optional. Description of test case, purely for debugging purposes.
-bls_setting: int       -- see general test-format spec.
-blocks_count: int      -- the number of blocks processed in this test.
+release_version: string    -- required, the pyspec release version.
+description: string        -- Optional. Description of test case, purely for debugging purposes.
+bls_setting: int           -- see general test-format spec.
+blocks_count: int          -- the number of blocks processed in this test.
 ```
 
 ### `pre.ssz_snappy`

--- a/tests/formats/fork_choice/README.md
+++ b/tests/formats/fork_choice/README.md
@@ -7,8 +7,9 @@ The aim of the fork choice tests is to provide test coverage of the various comp
 ### `meta.yaml`
 
 ```yaml
-description: string    -- Optional. Description of test case, purely for debugging purposes.
-bls_setting: int       -- see general test-format spec.
+release_version: string  -- required, the pyspec release version.
+description: string      -- Optional. Description of test case, purely for debugging purposes.
+bls_setting: int         -- see general test-format spec.
 ```
 
 ### `anchor_state.ssz_snappy`

--- a/tests/formats/forks/README.md
+++ b/tests/formats/forks/README.md
@@ -13,7 +13,9 @@ There is only one handler: `fork`. Each fork (after genesis) is handled with the
 A yaml file to signify which fork boundary is being tested.
 
 ```yaml
-fork: str    -- Fork being transitioned to
+release_version: string    -- required, the pyspec release version.
+description: string        -- Optional. Description of test case, purely for debugging purposes.
+fork: string               -- Fork being transitioned to
 ```
 
 #### Fork strings

--- a/tests/formats/genesis/initialization.md
+++ b/tests/formats/genesis/initialization.md
@@ -17,8 +17,9 @@ An integer. The timestamp of the block, in seconds.
 A yaml file to help read the deposit count:
 
 ```yaml
-description: string    -- Optional. Description of test case, purely for debugging purposes.
-deposits_count: int    -- Amount of deposits.
+release_version: string  -- required, the pyspec release version.
+description: string      -- Optional. Description of test case, purely for debugging purposes.
+deposits_count: int      -- Amount of deposits.
 ```
 
 ### `deposits_<index>.ssz_snappy`

--- a/tests/formats/genesis/validity.md
+++ b/tests/formats/genesis/validity.md
@@ -9,7 +9,8 @@ Tests if a genesis state is valid, i.e. if it counts as trigger to launch.
 A yaml file to help read the deposit count:
 
 ```yaml
-description: string    -- Optional. Description of test case, purely for debugging purposes.
+release_version: string  -- required, the pyspec release version.
+description: string      -- Optional. Description of test case, purely for debugging purposes.
 ```
 
 ### `genesis.ssz_snappy`

--- a/tests/formats/operations/README.md
+++ b/tests/formats/operations/README.md
@@ -7,9 +7,10 @@ The different kinds of operations ("transactions") are tested individually with 
 ### `meta.yaml`
 
 ```yaml
-description: string    -- Optional description of test case, purely for debugging purposes.
-                          Tests should use the directory name of the test case as identifier, not the description.
-bls_setting: int       -- see general test-format spec.
+release_version: string  -- required, the pyspec release version.
+description: string      -- Optional description of test case, purely for debugging purposes.
+                            Tests should use the directory name of the test case as identifier, not the description.
+bls_setting: int         -- see general test-format spec.
 ```
 
 ### `pre.ssz_snappy`

--- a/tests/formats/rewards/README.md
+++ b/tests/formats/rewards/README.md
@@ -16,8 +16,9 @@ class Deltas(Container):
 ### `meta.yaml`
 
 ```yaml
-description: string    -- Optional description of test case, purely for debugging purposes.
-                          Tests should use the directory name of the test case as identifier, not the description.
+release_version: string  -- required, the pyspec release version.
+description: string      -- Optional description of test case, purely for debugging purposes.
+                            Tests should use the directory name of the test case as identifier, not the description.
 ```
 
 _Note_: No signature verification happens within rewards sub-functions. These

--- a/tests/formats/sanity/blocks.md
+++ b/tests/formats/sanity/blocks.md
@@ -7,6 +7,7 @@ Sanity tests to cover a series of one or more blocks being processed, aiming to 
 ### `meta.yaml`
 
 ```yaml
+release_version: string        -- required, the pyspec release version.
 description: string            -- Optional. Description of test case, purely for debugging purposes.
 bls_setting: int               -- see general test-format spec.
 reveal_deadlines_setting: int  -- see general test-format spec.

--- a/tests/formats/sanity/slots.md
+++ b/tests/formats/sanity/slots.md
@@ -7,8 +7,9 @@ Sanity tests to cover a series of one or more empty-slot transitions being proce
 ### `meta.yaml`
 
 ```yaml
-description: string    -- Optional. Description of test case, purely for debugging purposes.
-bls_setting: int       -- see general test-format spec.
+release_version: string  -- required, the pyspec release version.
+description: string      -- Optional. Description of test case, purely for debugging purposes.
+bls_setting: int         -- see general test-format spec.
 ```
 
 

--- a/tests/formats/shuffling/README.md
+++ b/tests/formats/shuffling/README.md
@@ -14,6 +14,13 @@ For implementers, possible test runners implementing testing can include:
 
 ## Test case format
 
+### `meta.yaml`
+
+```yaml
+release_version: string  -- required, the pyspec release version.
+description: string      -- Optional. Description of test case, purely for debugging purposes.
+```
+
 ### `mapping.yaml`
 
 ```yaml

--- a/tests/formats/ssz_generic/README.md
+++ b/tests/formats/ssz_generic/README.md
@@ -42,6 +42,7 @@ The expected roots are encoded into the metadata yaml:
 
 ```yaml
 root: Bytes32             -- Hash-tree-root of the object
+release_version: string   -- required, the pyspec release version.
 ```
 
 The `Bytes32` is encoded as a string, hexadecimal encoding, prefixed with `0x`.

--- a/tests/formats/ssz_static/core.md
+++ b/tests/formats/ssz_static/core.md
@@ -18,7 +18,13 @@ One can iterate over the handlers, and select the type based on the handler name
 Suites are then the same format, but each specialized in one randomization mode.
 Some randomization modes may only produce a single test case (e.g. the all-zeroes case).
 
-The output parts are: `roots.yaml`, `serialized.ssz_snappy`, `value.yaml`
+The output parts are: `meta.yaml`, `roots.yaml`, `serialized.ssz_snappy`, `value.yaml`
+
+### `meta.yaml`
+
+```yaml
+release_version: string  -- required, the pyspec release version.
+```
 
 ### `roots.yaml`
 


### PR DESCRIPTION
### Issue

It was hard to check if all test vectors have been generated successfully.

### How did I improve it
1. Output error log to `<output_dir>/testgen_error_log.txt`.
2. Add `release_version: str` to `meta.yaml`. Two purposes:
	1. To indicate which spec release version it is.
	2. This field is added only if the test vectors have been generated successfully. So when we run testgen *again*, even if the folder exists, we should *not* skip it if `release_version` is *not* in `meta.yaml`.

---

* Disable mainnet config `test_valid_signature_future_committee`
	* It was really slow for me to transition `2 * spec.EPOCHS_PER_SYNC_COMMITTEE_PERIOD` epochs. @djrtwo does it work well on your end?
