### PR TITLE
Altair testing fork version fixes

### DIFF
--- a/configs/minimal/altair.yaml
+++ b/configs/minimal/altair.yaml
@@ -35,7 +35,8 @@ DOMAIN_SYNC_COMMITTEE: 0x07000000
 
 # Fork
 # ---------------------------------------------------------------
-ALTAIR_FORK_VERSION: 0x01000000
+# Highest byte set to 0x01 to avoid collisions with mainnet versioning
+ALTAIR_FORK_VERSION: 0x01000001
 # [customized]
 ALTAIR_FORK_SLOT: 0
 

--- a/tests/core/pyspec/eth2spec/test/context.py
+++ b/tests/core/pyspec/eth2spec/test/context.py
@@ -97,8 +97,7 @@ def with_custom_state(balances_fn: Callable[[Any], Sequence[int]],
 
         def entry(*args, spec: Spec, phases: SpecForks, **kw):
             # make a key for the state
-            # genesis fork version separates configs during test-generation runtime.
-            key = (spec.fork, spec.GENESIS_FORK_VERSION, spec.__file__, balances_fn, threshold_fn)
+            key = (spec.fork, spec.CONFIG_NAME, spec.__file__, balances_fn, threshold_fn)
             global _custom_state_cache_dict
             if key not in _custom_state_cache_dict:
                 state = _prepare_state(balances_fn, threshold_fn, spec, phases)

--- a/tests/core/pyspec/eth2spec/test/helpers/genesis.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/genesis.py
@@ -28,6 +28,11 @@ def create_genesis_state(spec, validator_balances, activation_threshold):
             deposit_count=len(validator_balances),
             block_hash=eth1_block_hash,
         ),
+        fork=spec.Fork(
+            previous_version=spec.GENESIS_FORK_VERSION,
+            current_version=spec.GENESIS_FORK_VERSION,
+            epoch=spec.GENESIS_EPOCH,
+        ),
         latest_block_header=spec.BeaconBlockHeader(body_root=spec.hash_tree_root(spec.BeaconBlockBody())),
         randao_mixes=[eth1_block_hash] * spec.EPOCHS_PER_HISTORICAL_VECTOR,
     )


### PR DESCRIPTION
- Update Altair config to avoid fork version collision with minimal test variant.
- Update test state caching: use the name instead of the digest, this is harder to get wrong, more obvious in debugging (the old code was ok, but had a look at this during debugging of below problem)
- Fix genesis state creator bug: minimal states were being created with zeroed fork data, equal to mainnet genesis fork version. It appears that state-based fork versioning was used everywhere in signing and verification, obfuscating the problem in test vectors. I found the bug after adding more fork-version/digest instrumentation for the Altair update of my Go-version of the spec.

Note: this will affect the (alpha) release of Altair test-vectors. All minimal-config beacon-state fork versions should get in sync with their configuration.
