### PR TITLE
Altair tests - fix mixed up formats

### DIFF
--- a/tests/core/pyspec/eth2spec/test/phase0/genesis/test_initialization.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/genesis/test_initialization.py
@@ -16,6 +16,13 @@ def get_post_altair_description(spec):
     return f"Although it's not phase 0, we may use {spec.fork} spec to start testnets."
 
 
+def eth1_init_data(eth1_block_hash, eth1_timestamp):
+    yield 'eth1', {
+        'eth1_block_hash': '0x' + eth1_block_hash.hex(),
+        'eth1_timestamp': int(eth1_timestamp),
+    }
+
+
 @with_all_phases
 @spec_test
 @single_phase
@@ -35,8 +42,7 @@ def test_initialize_beacon_state_from_eth1(spec):
     eth1_block_hash = b'\x12' * 32
     eth1_timestamp = spec.MIN_GENESIS_TIME
 
-    yield 'eth1_block_hash', eth1_block_hash
-    yield 'eth1_timestamp', eth1_timestamp
+    yield from eth1_init_data(eth1_block_hash, eth1_timestamp)
     yield 'deposits', deposits
 
     # initialize beacon_state
@@ -79,8 +85,7 @@ def test_initialize_beacon_state_some_small_balances(spec):
     eth1_block_hash = b'\x12' * 32
     eth1_timestamp = spec.MIN_GENESIS_TIME
 
-    yield 'eth1_block_hash', eth1_block_hash
-    yield 'eth1_timestamp', eth1_timestamp
+    yield from eth1_init_data(eth1_block_hash, eth1_timestamp)
     yield 'deposits', deposits
 
     # initialize beacon_state
@@ -136,8 +141,7 @@ def test_initialize_beacon_state_one_topup_activation(spec):
     eth1_block_hash = b'\x13' * 32
     eth1_timestamp = spec.MIN_GENESIS_TIME
 
-    yield 'eth1_block_hash', eth1_block_hash
-    yield 'eth1_timestamp', eth1_timestamp
+    yield from eth1_init_data(eth1_block_hash, eth1_timestamp)
     yield 'deposits', deposits
 
     # initialize beacon_state
@@ -165,8 +169,7 @@ def test_initialize_beacon_state_random_invalid_genesis(spec):
     eth1_block_hash = b'\x14' * 32
     eth1_timestamp = spec.MIN_GENESIS_TIME + 1
 
-    yield 'eth1_block_hash', eth1_block_hash
-    yield 'eth1_timestamp', eth1_timestamp
+    yield from eth1_init_data(eth1_block_hash, eth1_timestamp)
     yield 'deposits', deposits
 
     # initialize beacon_state
@@ -205,8 +208,7 @@ def test_initialize_beacon_state_random_valid_genesis(spec):
     eth1_block_hash = b'\x15' * 32
     eth1_timestamp = spec.MIN_GENESIS_TIME + 2
 
-    yield 'eth1_block_hash', eth1_block_hash
-    yield 'eth1_timestamp', eth1_timestamp
+    yield from eth1_init_data(eth1_block_hash, eth1_timestamp)
     yield 'deposits', deposits
 
     # initialize beacon_state

--- a/tests/core/pyspec/eth2spec/test/phase0/sanity/test_slots.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/sanity/test_slots.py
@@ -10,7 +10,7 @@ def test_slots_1(spec, state):
     yield 'pre', state
 
     slots = 1
-    yield 'slots', slots
+    yield 'slots', int(slots)
     spec.process_slots(state, state.slot + slots)
 
     yield 'post', state
@@ -23,7 +23,7 @@ def test_slots_1(spec, state):
 def test_slots_2(spec, state):
     yield 'pre', state
     slots = 2
-    yield 'slots', slots
+    yield 'slots', int(slots)
     spec.process_slots(state, state.slot + slots)
     yield 'post', state
 
@@ -33,7 +33,7 @@ def test_slots_2(spec, state):
 def test_empty_epoch(spec, state):
     yield 'pre', state
     slots = spec.SLOTS_PER_EPOCH
-    yield 'slots', slots
+    yield 'slots', int(slots)
     spec.process_slots(state, state.slot + slots)
     yield 'post', state
 
@@ -43,7 +43,7 @@ def test_empty_epoch(spec, state):
 def test_double_empty_epoch(spec, state):
     yield 'pre', state
     slots = spec.SLOTS_PER_EPOCH * 2
-    yield 'slots', slots
+    yield 'slots', int(slots)
     spec.process_slots(state, state.slot + slots)
     yield 'post', state
 
@@ -55,6 +55,6 @@ def test_over_epoch_boundary(spec, state):
         spec.process_slots(state, state.slot + (spec.SLOTS_PER_EPOCH // 2))
     yield 'pre', state
     slots = spec.SLOTS_PER_EPOCH
-    yield 'slots', slots
+    yield 'slots', int(slots)
     spec.process_slots(state, state.slot + slots)
     yield 'post', state

--- a/tests/formats/genesis/initialization.md
+++ b/tests/formats/genesis/initialization.md
@@ -4,13 +4,13 @@ Tests the initialization of a genesis state based on Eth1 data.
 
 ## Test case format
 
-### `eth1_block_hash.ssz_snappy`
+### `eth1.yaml`
 
-An SSZ-snappy encoded root of the Eth1 block.
+```yaml
+eth1_block_hash: Bytes32  -- A `Bytes32` hex encoded, with prefix 0x. The root of the Eth1 block. E.g. "0x4242424242424242424242424242424242424242424242424242424242424242"
+eth1_timestamp: int       -- An integer. The timestamp of the block, in seconds.
+```
 
-### `eth1_timestamp.yaml`
-
-An integer. The timestamp of the block, in seconds.
 
 ### `meta.yaml`
 


### PR DESCRIPTION
- Output the `slots` param in `sanity/slots` as int, formatted in yaml file. In v1 release it used to output both ssz and yaml, and format the data in both formats. The test emitted mixed types, and caused either `slots.ssz_snappy` or `slots.yaml` to output, but not both.
- Output genesis eth1 init data as yaml dict. Similar story here, the yaml/ssz mix forced it to format, but that was lost. The timestamp was inadvertently outputted as `ssz_snappy` while the format says `yaml`. Compressing and encoding the block hash as ssz_snappy also does not help. This  PR combines them and formats it as yaml. Minor change in Eth2 client test runners.

