### PR TITLE
patch test_filtered_block_tree test generator

### DIFF
--- a/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_get_head.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_get_head.py
@@ -211,7 +211,7 @@ def test_filtered_block_tree(spec, state):
     test_steps.append({
         'checks': {
             'head': get_formatted_head_output(spec, store),
-            'justified_checkpoint_root': encode_hex(store.justified_checkpoint.hash_tree_root()),
+            'justified_checkpoint_root': encode_hex(store.justified_checkpoint.root),
         }
     })
 


### PR DESCRIPTION
address #2269 

note, we could just yield with extraneous `checks` because there is no update but it also makes it a bit clearer to test writers what is being checked after adding all the blocks.

thanks  @ajsutton!