### PR TITLE
Set tmp ALTAIR_FORK_SLOT to max value

### DIFF
--- a/configs/mainnet/altair.yaml
+++ b/configs/mainnet/altair.yaml
@@ -37,7 +37,7 @@ DOMAIN_SYNC_COMMITTEE: 0x07000000
 # ---------------------------------------------------------------
 ALTAIR_FORK_VERSION: 0x01000000
 # TBD
-ALTAIR_FORK_SLOT: 0
+ALTAIR_FORK_SLOT: 18446744073709551615
 
 
 # Sync protocol

--- a/configs/minimal/altair.yaml
+++ b/configs/minimal/altair.yaml
@@ -37,7 +37,7 @@ DOMAIN_SYNC_COMMITTEE: 0x07000000
 # ---------------------------------------------------------------
 ALTAIR_FORK_VERSION: 0x01000000
 # [customized]
-ALTAIR_FORK_SLOT: 0
+ALTAIR_FORK_SLOT: 18446744073709551615
 
 
 # Sync protocol

--- a/specs/altair/fork.md
+++ b/specs/altair/fork.md
@@ -26,7 +26,7 @@ Warning: this configuration is not definitive.
 | Name | Value |
 | - | - |
 | `ALTAIR_FORK_VERSION` | `Version('0x01000000')` |
-| `ALTAIR_FORK_SLOT` | `Slot(0)` **TBD** |
+| `ALTAIR_FORK_SLOT` | `Slot(18446744073709551615)` **TBD** |
 
 ## Fork to Altair
 


### PR DESCRIPTION
### Description
Suggesting we set the temporary `ALTAIR_FORK_SLOT` to its max value to lower the risk of accidentally enabling altair early. 