### PR TITLE
New application payload fields

### DIFF
--- a/specs/merge/beacon-chain.md
+++ b/specs/merge/beacon-chain.md
@@ -127,6 +127,7 @@ class ApplicationBlockHeader(Container):
     gas_used: uint64
     receipt_root: Bytes32
     logs_bloom: ByteVector[BYTES_PER_LOGS_BLOOM]
+    transactions_root: Root
 ```
 
 ## Helper functions
@@ -203,5 +204,6 @@ def process_application_payload(state: BeaconState, body: BeaconBlockBody) -> No
         gas_used=application_payload.gas_used,
         receipt_root=application_payload.receipt_root,
         logs_bloom=application_payload.logs_bloom,
+        transactions_root=hash_tree_root(application_payload.transactions),
     )
 ```

--- a/specs/merge/fork-choice.md
+++ b/specs/merge/fork-choice.md
@@ -77,7 +77,7 @@ def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
     # [New in Merge]
     if is_transition_block(pre_state, block.body):
         # Delay consideration of block until PoW block is processed by the PoW node
-        pow_block = get_pow_block(block.body.application_payload.block_hash)
+        pow_block = get_pow_block(block.body.application_payload.parent_hash)
         assert pow_block.is_processed
         assert is_valid_transition_block(pow_block)
 

--- a/specs/merge/validator.md
+++ b/specs/merge/validator.md
@@ -57,12 +57,12 @@ The body of this function is implementation dependent.
 def get_application_payload(state: BeaconState) -> ApplicationPayload:
     if not is_transition_completed(state):
         pow_block = get_pow_chain_head()
-        if pow_block.total_difficulty < TRANSITION_TOTAL_DIFFICULTY:
+        if not is_valid_transition_block(pow_block):
             # Pre-merge, empty payload
             return ApplicationPayload()
         else:
-            # Signify merge via last PoW block_hash and an otherwise empty payload
-            return ApplicationPayload(block_hash=pow_block.block_hash)
+            # Signify merge via producing on top of the last PoW block
+            return produce_application_payload(pow_block.block_hash)
 
     # Post-merge, normal payload
     application_parent_hash = state.application_block_hash

--- a/specs/merge/validator.md
+++ b/specs/merge/validator.md
@@ -66,5 +66,5 @@ def get_application_payload(state: BeaconState) -> ApplicationPayload:
 
     # Post-merge, normal payload
     application_parent_hash = state.application_block_hash
-    return produce_application_payload(state.application_block_hash)
+    return produce_application_payload(application_parent_hash)
 ```

--- a/specs/merge/validator.md
+++ b/specs/merge/validator.md
@@ -65,6 +65,6 @@ def get_application_payload(state: BeaconState) -> ApplicationPayload:
             return produce_application_payload(pow_block.block_hash)
 
     # Post-merge, normal payload
-    application_parent_hash = state.application_block_hash
+    application_parent_hash = state.latest_application_block_header.block_hash
     return produce_application_payload(application_parent_hash)
 ```


### PR DESCRIPTION
### What's done

Adds the following fields to the `ApplicationPayload`:
- `parent_hash: Bytes32`
- `number: uint64`

Adds `application_block_number` to the `BeaconState` and incorporates following rules that ensures the validity of the application block tree:
```python
assert body.application_payload.parent_hash == state.application_block_hash
assert body.application_payload.number == state.application_block_number + 1
```

It would also make sense to add `gas_limit/base_fee` to the state with corresponding validity rules once EIP-1559 is shipped.

### Rationale
The main reason of doing this is making structures and code forward compatible with stateless execution which implies that there is no application block tree that is maintained by the application-layer. It results in a following requirements on consensus-layer:
- provide all data required to re-assemble a block to the application-layer
- check validity conditions of the application block tree

A byproduct of adding `parent_hash` is the following simplification in the transition process. Instead of submitting an empty `ApplicationPayload` with `block_hash = last_pow_block.hash` to signify the transition block, proposer becomes eligible to propose full `ApplicationPayload` with `parent_hash` referring to the last PoW block. Aside of simplification it also have a small incentivising effect as proposer of the transition block gets transaction fees now.

The cost of this change is additional `40 bytes` in `BeaconBlockBody` structure.