### PR TITLE
Fix is_within_weak_subjectivity_period() assertion

### DIFF
--- a/specs/phase0/weak-subjectivity.md
+++ b/specs/phase0/weak-subjectivity.md
@@ -120,7 +120,7 @@ The check can be implemented in the following way:
 ```python
 def is_within_weak_subjectivity_period(store: Store, ws_state: BeaconState, ws_checkpoint: Checkpoint) -> bool:
     # Clients may choose to validate the input state against the input Weak Subjectivity Checkpoint
-    assert ws_state.latest_block_header.state_root == ws_checkpoint.root
+    assert hash_tree_root(ws_state.latest_block_header) == ws_checkpoint.root
     assert compute_epoch_at_slot(ws_state.slot) == ws_checkpoint.epoch
 
     ws_period = compute_weak_subjectivity_period(ws_state)


### PR DESCRIPTION
Currently, [is_within_weak_subjectivity_period()](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase0/weak-subjectivity.md#is_within_weak_subjectivity_period) has the following assertion:
```python
assert ws_state.latest_block_header.state_root == ws_checkpoint.root
```
However, `ws_checkpoint.root` is a block root, so when asserting that provided `ws_state` has the matching root, the assertion should be changed to:
```python
assert hash_tree_root(ws_state.latest_block_header) == ws_checkpoint.root
```