### PR TITLE
Fix uint64 overflow when computing ROOT_OF_UNITY

### DIFF
--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -108,7 +108,7 @@ The following values are (non-configurable) constants used throughout the specif
 | - | - |
 | `G1_SETUP` | Type `List[G1]`. The G1-side trusted setup `[G, G*s, G*s**2....]`; note that the first point is the generator. |
 | `G2_SETUP` | Type `List[G2]`. The G2-side trusted setup `[G, G*s, G*s**2....]` |
-| `ROOT_OF_UNITY` | `pow(PRIMITIVE_ROOT_OF_UNITY, (MODULUS - 1) // (MAX_SAMPLES_PER_BLOCK * POINTS_PER_SAMPLE), MODULUS)` |
+| `ROOT_OF_UNITY` | `pow(PRIMITIVE_ROOT_OF_UNITY, (MODULUS - 1) // int(MAX_SAMPLES_PER_BLOCK * POINTS_PER_SAMPLE), MODULUS)` |
 
 ### Gwei values
 


### PR DESCRIPTION
Computing `(MODULUS - 1) // (MAX_SAMPLES_PER_BLOCK * POINTS_PER_SAMPLE)` leads to `uint64` overflow
```
>>> (MODULUS - 1) // (MAX_SAMPLES_PER_BLOCK * POINTS_PER_SAMPLE)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/mnt/c/Users/ericsson/IdeaProjects/eth2.0-specs/venv/lib/python3.8/site-packages/remerkleable/basic.py", line 113, in __rfloordiv__
    return self.__class__(self.__class__.coerce_view(other).__floordiv__(self))
  File "/mnt/c/Users/ericsson/IdeaProjects/eth2.0-specs/venv/lib/python3.8/site-packages/remerkleable/basic.py", line 188, in coerce_view
    return cls(v)
  File "/mnt/c/Users/ericsson/IdeaProjects/eth2.0-specs/venv/lib/python3.8/site-packages/remerkleable/basic.py", line 80, in __new__
    raise ValueError(f"value out of bounds for {cls}")
ValueError: value out of bounds for <class 'remerkleable.basic.uint64'>
```

The problem is that `MAX_SAMPLES_PER_BLOCK * POINTS_PER_SAMPLE` has `uint64` type, which overrides `__rfloordiv__` operation, so that it returns `uint64`. Since `MODULUS` is a huge number, it leads to overflow.
One way to fix it is to convert `MAX_SAMPLES_PER_BLOCK * POINTS_PER_SAMPLE` to `int`