### PR TITLE
Clean up unnecessary function arguments in Altair validator guide

### DIFF
--- a/specs/altair/validator.md
+++ b/specs/altair/validator.md
@@ -220,8 +220,7 @@ Given a collection of the best seen `contributions` (with no repeating `subcommi
 the proposer processes them as follows:
 
 ```python
-def process_sync_committee_contributions(state: BeaconState, 
-                                         block: BeaconBlock, 
+def process_sync_committee_contributions(block: BeaconBlock, 
                                          contributions: Set[SyncCommitteeContribution]) -> None:
     sync_aggregate = SyncAggregate()
     signatures = []
@@ -310,7 +309,7 @@ Each slot some sync committee members in each subcommittee are selected to aggre
 
 ##### Aggregation selection
 
-A validator is selected to aggregate based on the computation in `is_sync_committee_aggregator` where `state` is a `BeaconState` as supplied to `get_sync_committee_selection_proof` and `signature` is the BLS signature returned by `get_sync_committee_selection_proof`. 
+A validator is selected to aggregate based on the computation in `is_sync_committee_aggregator` where `signature` is the BLS signature returned by `get_sync_committee_selection_proof`. 
 The signature function takes a `BeaconState` with the relevant sync committees for the queried `slot` (i.e. `state.slot` is within the span covered by the current or next sync committee period), the `subcommittee_index` equal to the `subnet_id`, and the `privkey` is the BLS private key associated with the validator.
 
 ```python
@@ -326,7 +325,7 @@ def get_sync_committee_selection_proof(state: BeaconState, slot: Slot,
 ```
 
 ```python
-def is_sync_committee_aggregator(state: BeaconState, signature: BLSSignature) -> bool:
+def is_sync_committee_aggregator(signature: BLSSignature) -> bool:
     modulo = max(1, SYNC_COMMITTEE_SIZE // SYNC_COMMITTEE_SUBNET_COUNT // TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE)
     return bytes_to_uint64(hash(signature)[0:8]) % modulo == 0
 ```


### PR DESCRIPTION
Some of the inputs to some functions in the Altair validator guide were required in earlier iterations of the aggregation scheme but are no longer required in the current version. This commit cleans up these functions.

Thanks for @barnabemonnot for pointing it out!