### PR TITLE
Beacon Chain sub-tree filter on shard blobs

### DIFF
--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -38,6 +38,7 @@
     - [`compute_updated_gasprice`](#compute_updated_gasprice)
     - [`compute_committee_source_epoch`](#compute_committee_source_epoch)
   - [Beacon state accessors](#beacon-state-accessors)
+    - [`get_state_root_at_slot`](#get_state_root_at_slot)
     - [Updated `get_committee_count_per_slot`](#updated-get_committee_count_per_slot)
     - [`get_active_shard_count`](#get_active_shard_count)
     - [`get_shard_committee`](#get_shard_committee)
@@ -561,6 +562,8 @@ def update_pending_votes(state: BeaconState, attestation: Attestation) -> None:
 def process_shard_header(state: BeaconState,
                          signed_header: SignedShardBlobHeader) -> None:
     header = signed_header.message
+    # Verify the header is not 0, and not from the future.
+    assert Slot(0) < header.slot <= state.slot
     header_epoch = compute_epoch_at_slot(header.slot)
     # Verify that the header is within the processing time window
     assert header_epoch in [get_previous_epoch(state), get_current_epoch(state)]
@@ -568,7 +571,6 @@ def process_shard_header(state: BeaconState,
     assert header.shard < get_active_shard_count(state, header_epoch)
     # Verify that the state root matches,
     # to ensure the header will only be included in this specific beacon-chain sub-tree.
-    assert header.slot > 0
     assert header.parent_state_root == get_state_root_at_slot(state, header.slot-1)
     # Verify proposer
     assert header.proposer_index == get_shard_proposer_index(state, header.slot, header.shard)

--- a/specs/sharding/p2p-interface.md
+++ b/specs/sharding/p2p-interface.md
@@ -41,8 +41,8 @@ class ShardBlobBody(Container):
     degree_proof: BLSCommitment
     # The actual data. Should match the commitment and degree proof.
     data: List[BLSPoint, POINTS_PER_SAMPLE * MAX_SAMPLES_PER_BLOCK]
-    # State of the Beacon Chain, right before the slot processing of shard_blob.slot
-    parent_state_root: Root
+    # Latest block root of the Beacon Chain, before shard_blob.slot
+    beacon_block_root: Root
 ```
 
 The user MUST always verify the commitments in the `body` are valid for the `data` in the `body`.
@@ -99,7 +99,7 @@ The following validations MUST pass before forwarding the `signed_blob` (with in
 - _[REJECT]_ The `blob.body.data` MUST NOT contain any point `p >= MODULUS`. Although it is a `uint256`, not the full 256 bit range is valid.
 - _[REJECT]_ The proposer signature, `signed_blob.signature`, is valid with respect to the `proposer_index` pubkey.
 - _[REJECT]_ The blob is proposed by the expected `proposer_index` for the blob's slot
-  in the context of the current shuffling (defined by `blob.body.parent_state_root`/`slot`).
+  in the context of the current shuffling (defined by `blob.body.beacon_block_root`/`slot`).
   If the `proposer_index` cannot immediately be verified against the expected shuffling,
   the block MAY be queued for later processing while proposers for the blob's branch are calculated --
   in such a case _do not_ `REJECT`, instead `IGNORE` this message.
@@ -118,7 +118,7 @@ The following validations MUST pass before forwarding the `signed_shard_header` 
 - _[IGNORE]_ The header is the first header with valid signature received for the `(header.proposer_index, header.slot, header.shard)` combination.
 - _[REJECT]_ The proposer signature, `signed_shard_header.signature`, is valid with respect to the `proposer_index` pubkey.
 - _[REJECT]_ The header is proposed by the expected `proposer_index` for the block's slot
-  in the context of the current shuffling (defined by `header.body_summary.parent_state_root`/`slot`).
+  in the context of the current shuffling (defined by `header.body_summary.beacon_block_root`/`slot`).
   If the `proposer_index` cannot immediately be verified against the expected shuffling,
   the block MAY be queued for later processing while proposers for the block's branch are calculated --
   in such a case _do not_ `REJECT`, instead `IGNORE` this message.


### PR DESCRIPTION
Enforce state sub-tree in shard blob proposal to avoid inconsistent replays on reorg, and provide context for `proposer_index` computation.

Previously, a shard blob could be replayed on another chain that omits confirmed shard-headers, delaying ultimate confirmation to the chain as a whole. This makes L2 transaction confirmation logic much more difficult. Also, the `proposer_index` need to be validated in the p2p layer, but was missing the required context to do so during deep forks that would change shard proposer indices.

Note that unlike the old (pre DAS refactor) shard-transition style would enforce much more (too much), this just tries to strike a balance between the two.

Shard-headers can be included in any order, and late too. But they can always rely on a pinned state history relative to their proposal slot.

This PR targets the shard-blob PR which improves the sharding types, still in review. 

Edit: pinning state with `block_root, slot` combination instead of a `state_root` to make it clear how to process towards the point. This matches blocks and attestations, at the cost of a little complexity for a shard-data user (gap slots need to be accounted for, the `slot` part is essential). Ignore the old `shard_blob_stateroot` branch name.
