### PR TITLE
Update note about changes to slash_validator

### DIFF
--- a/specs/altair/beacon-chain.md
+++ b/specs/altair/beacon-chain.md
@@ -391,7 +391,8 @@ def get_inactivity_penalty_deltas(state: BeaconState) -> Tuple[Sequence[Gwei], S
 
 #### Modified `slash_validator`
 
-*Note*: The function `slash_validator` is modified to use `MIN_SLASHING_PENALTY_QUOTIENT_ALTAIR`.
+*Note*: The function `slash_validator` is modified to use `MIN_SLASHING_PENALTY_QUOTIENT_ALTAIR` 
+and use `PROPOSER_WEIGHT` when calculating the proposer reward.
 
 ```python
 def slash_validator(state: BeaconState,


### PR DESCRIPTION
1.1.0-alpha.3 updated the calculation for proposer rewards in `slash_validator`.  Include that change in the note explaining what changed.