### PR TITLE
Apply new terminology to the merge spec

### DIFF
--- a/specs/merge/beacon-chain.md
+++ b/specs/merge/beacon-chain.md
@@ -185,11 +185,7 @@ def process_execution_payload(state: BeaconState, body: BeaconBlockBody) -> None
 
     execution_payload = body.execution_payload
 
-    if not is_transition_completed(state):
-        assert execution_payload == ExecutionPayload()
-        return
-
-    if not is_transition_block(state, body):
+    if is_transition_completed(state):
         assert execution_payload.parent_hash == state.latest_execution_payload_header.block_hash
         assert execution_payload.number == state.latest_execution_payload_header.number + 1
 

--- a/specs/merge/beacon-chain.md
+++ b/specs/merge/beacon-chain.md
@@ -183,6 +183,10 @@ def process_execution_payload(state: BeaconState, body: BeaconBlockBody) -> None
     Note: This function is designed to be able to be run in parallel with the other `process_block` sub-functions
     """
 
+    # Pre-merge, skip processing
+    if not is_transition_completed(state) and not is_transition_block(state, body):
+        return
+
     execution_payload = body.execution_payload
 
     if is_transition_completed(state):

--- a/specs/merge/fork-choice.md
+++ b/specs/merge/fork-choice.md
@@ -77,7 +77,7 @@ def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
     # [New in Merge]
     if is_transition_block(pre_state, block.body):
         # Delay consideration of block until PoW block is processed by the PoW node
-        pow_block = get_pow_block(block.body.application_payload.parent_hash)
+        pow_block = get_pow_block(block.body.execution_payload.parent_hash)
         assert pow_block.is_processed
         assert is_valid_transition_block(pow_block)
 

--- a/specs/merge/validator.md
+++ b/specs/merge/validator.md
@@ -15,9 +15,9 @@
 - [Beacon chain responsibilities](#beacon-chain-responsibilities)
   - [Block proposal](#block-proposal)
     - [Constructing the `BeaconBlockBody`](#constructing-the-beaconblockbody)
-      - [Application Payload](#application-payload)
+      - [Execution Payload](#execution-payload)
         - [`get_pow_chain_head`](#get_pow_chain_head)
-        - [`produce_application_payload`](#produce_application_payload)
+        - [`produce_execution_payload`](#produce_execution_payload)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- /TOC -->
@@ -34,37 +34,37 @@ All terminology, constants, functions, and protocol mechanics defined in the upd
 
 ## Beacon chain responsibilities
 
-All validator responsibilities remain unchanged other than those noted below. Namely, the transition block handling and the addition of `ApplicationPayload`.
+All validator responsibilities remain unchanged other than those noted below. Namely, the transition block handling and the addition of `ExecutionPayload`.
 
 ### Block proposal
 
 #### Constructing the `BeaconBlockBody`
 
-##### Application Payload
+##### Execution Payload
 
 ###### `get_pow_chain_head`
 
 Let `get_pow_chain_head() -> PowBlock` be the function that returns the head of the PoW chain. The body of the function is implementation specific.
 
-###### `produce_application_payload`
+###### `produce_execution_payload`
 
-Let `produce_application_payload(parent_hash: Bytes32) -> ApplicationPayload` be the function that produces new instance of application payload.
+Let `produce_execution_payload(parent_hash: Bytes32) -> ExecutionPayload` be the function that produces new instance of execution payload.
 The body of this function is implementation dependent.
 
-* Set `block.body.application_payload = get_application_payload(state)` where:
+* Set `block.body.execution_payload = get_execution_payload(state)` where:
 
 ```python
-def get_application_payload(state: BeaconState) -> ApplicationPayload:
+def get_execution_payload(state: BeaconState) -> ExecutionPayload:
     if not is_transition_completed(state):
         pow_block = get_pow_chain_head()
         if not is_valid_transition_block(pow_block):
             # Pre-merge, empty payload
-            return ApplicationPayload()
+            return ExecutionPayload()
         else:
             # Signify merge via producing on top of the last PoW block
-            return produce_application_payload(pow_block.block_hash)
+            return produce_execution_payload(pow_block.block_hash)
 
     # Post-merge, normal payload
-    application_parent_hash = state.latest_application_block_header.block_hash
-    return produce_application_payload(application_parent_hash)
+    execution_parent_hash = state.latest_execution_payload_header.block_hash
+    return produce_execution_payload(execution_parent_hash)
 ```


### PR DESCRIPTION
Updates the spec according to the new terminology. 

There is a decision to rename `application-layer` to `execution-layer` to avoid potential confusion with the layer where smart contracts and apps built around them are living.

There is an essay utilising new terms to give an idea of how they should be used
- https://hackmd.io/@n0ble/the-merge-terminology

**UPD**

In addition, it renames `ExecutionBlockHeader` to `ExecutionPayloadHeader` to emphasize the difference between the payload header and pre-merge PoW `BlockHeader`.