### PR TITLE
Merge cleanups and improvements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -313,11 +313,13 @@ def get_pow_chain_head() -> PowBlock:
     pass
 
 
-def execution_state_transition(execution_state: ExecutionState, execution_payload: ExecutionPayload) -> None:
+def execution_state_transition(execution_state_root: Bytes32,
+                               execution_payload: ExecutionPayload,
+                               timestamp: uint64) -> None:
     pass
 
 
-def produce_execution_payload(parent_hash: Bytes32) -> ExecutionPayload:
+def produce_execution_payload(parent_hash: Hash32, timestamp: uint64) -> ExecutionPayload:
     pass"""
 
 

--- a/setup.py
+++ b/setup.py
@@ -313,10 +313,8 @@ def get_pow_chain_head() -> PowBlock:
     pass
 
 
-def execution_state_transition(execution_state_root: Bytes32,
-                               execution_payload: ExecutionPayload,
-                               timestamp: uint64) -> None:
-    pass
+def verify_execution_state_transition(execution_payload: ExecutionPayload) -> bool:
+    return True
 
 
 def produce_execution_payload(parent_hash: Hash32, timestamp: uint64) -> ExecutionPayload:

--- a/specs/merge/beacon-chain.md
+++ b/specs/merge/beacon-chain.md
@@ -16,7 +16,7 @@
   - [Transition](#transition)
   - [Execution](#execution)
 - [Containers](#containers)
-  - [Updated containers](#updated-containers)
+  - [Modified containers](#modified-containers)
     - [`Eth1Data`](#eth1data)
   - [Extended containers](#extended-containers)
     - [`BeaconBlockBody`](#beaconblockbody)
@@ -31,7 +31,7 @@
     - [`compute_time_at_slot`](#compute_time_at_slot)
   - [Block processing](#block-processing)
     - [Execution payload processing](#execution-payload-processing)
-      - [`execution_state_transition`](#execution_state_transition)
+      - [`validate_execution_payload`](#validate_execution_payload)
       - [`process_execution_payload`](#process_execution_payload)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -187,12 +187,10 @@ def process_block(state: BeaconState, block: BeaconBlock) -> None:
 
 #### Execution payload processing
 
-##### `execution_state_transition`
+##### `validate_execution_payload`
 
-Let `execution_state_transition(execution_state_root: Bytes32, execution_payload: ExecutionPayload) -> None` be the transition function of Ethereum execution state. 
+Let `validate_execution_payload(execution_payload: ExecutionPayload) -> boolean` be the function checking whether given `ExecutionPayload` is valid or not.
 The body of the function is implementation dependent.
-
-*Note*: `execution_state_transition` must throw `AssertionError` if either the transition itself or one of the pre or post conditions has failed.
 
 ##### `process_execution_payload`
 
@@ -213,8 +211,7 @@ def process_execution_payload(state: BeaconState, body: BeaconBlockBody) -> None
 
     assert execution_payload.timestamp == compute_time_at_slot(state, state.slot)
 
-    execution_state_root = state.latest_execution_payload_header.state_root
-    execution_state_transition(execution_state_root, body.execution_payload)
+    assert validate_execution_payload(execution_payload)
 
     state.latest_execution_payload_header = ExecutionPayloadHeader(
         block_hash=execution_payload.block_hash,

--- a/specs/merge/beacon-chain.md
+++ b/specs/merge/beacon-chain.md
@@ -168,6 +168,8 @@ def is_transition_block(state: BeaconState, block_body: BeaconBlockBody) -> bool
 
 #### `compute_time_at_slot`
 
+*Note*: This function is unsafe with respect to overflows and underflows.
+
 ```python
 def compute_time_at_slot(state: BeaconState, slot: Slot) -> uint64:
     slots_since_genesis = slot - GENESIS_SLOT

--- a/specs/merge/beacon-chain.md
+++ b/specs/merge/beacon-chain.md
@@ -47,6 +47,7 @@ We define the following Python custom types for type hinting and readability:
 | Name | SSZ equivalent | Description |
 | - | - | - |
 | `OpaqueTransaction` | `ByteList[MAX_BYTES_PER_OPAQUE_TRANSACTION]` | a byte-list containing a single [typed transaction envelope](https://eips.ethereum.org/EIPS/eip-2718#opaque-byte-array-rather-than-an-rlp-array) structured as `TransactionType \|\| TransactionPayload` |
+| `Hash32` | `Bytes32` | a 256-bit hash |
 
 ## Constants
 
@@ -98,8 +99,8 @@ The execution payload included in a `BeaconBlockBody`.
 
 ```python
 class ExecutionPayload(Container):
-    block_hash: Bytes32  # Hash of execution block
-    parent_hash: Bytes32
+    block_hash: Hash32  # Hash of execution block
+    parent_hash: Hash32
     coinbase: Bytes20
     state_root: Bytes32
     number: uint64
@@ -118,8 +119,8 @@ The execution payload header included in a `BeaconState`.
 
 ```python
 class ExecutionPayloadHeader(Container):
-    block_hash: Bytes32  # Hash of execution block
-    parent_hash: Bytes32
+    block_hash: Hash32  # Hash of execution block
+    parent_hash: Hash32
     coinbase: Bytes20
     state_root: Bytes32
     number: uint64

--- a/specs/merge/beacon-chain.md
+++ b/specs/merge/beacon-chain.md
@@ -31,7 +31,7 @@
     - [`compute_time_at_slot`](#compute_time_at_slot)
   - [Block processing](#block-processing)
     - [Execution payload processing](#execution-payload-processing)
-      - [`validate_execution_payload`](#validate_execution_payload)
+      - [`verify_execution_state_transition`](#verify_execution_state_transition)
       - [`process_execution_payload`](#process_execution_payload)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -189,9 +189,9 @@ def process_block(state: BeaconState, block: BeaconBlock) -> None:
 
 #### Execution payload processing
 
-##### `validate_execution_payload`
+##### `verify_execution_state_transition`
 
-Let `validate_execution_payload(execution_payload: ExecutionPayload) -> bool` be the function checking whether given `ExecutionPayload` is valid or not.
+Let `verify_execution_state_transition(execution_payload: ExecutionPayload) -> bool` be the function that verifies given `ExecutionPayload` with respect to execution state transition.
 The body of the function is implementation dependent.
 
 ##### `process_execution_payload`
@@ -213,7 +213,7 @@ def process_execution_payload(state: BeaconState, body: BeaconBlockBody) -> None
 
     assert execution_payload.timestamp == compute_time_at_slot(state, state.slot)
 
-    assert validate_execution_payload(execution_payload)
+    assert verify_execution_state_transition(execution_payload)
 
     state.latest_execution_payload_header = ExecutionPayloadHeader(
         block_hash=execution_payload.block_hash,

--- a/specs/merge/beacon-chain.md
+++ b/specs/merge/beacon-chain.md
@@ -16,8 +16,6 @@
   - [Transition](#transition)
   - [Execution](#execution)
 - [Containers](#containers)
-  - [Modified containers](#modified-containers)
-    - [`Eth1Data`](#eth1data)
   - [Extended containers](#extended-containers)
     - [`BeaconBlockBody`](#beaconblockbody)
     - [`BeaconState`](#beaconstate)
@@ -49,7 +47,6 @@ We define the following Python custom types for type hinting and readability:
 | Name | SSZ equivalent | Description |
 | - | - | - |
 | `OpaqueTransaction` | `ByteList[MAX_BYTES_PER_OPAQUE_TRANSACTION]` | a byte-list containing a single [typed transaction envelope](https://eips.ethereum.org/EIPS/eip-2718#opaque-byte-array-rather-than-an-rlp-array) structured as `TransactionType \|\| TransactionPayload` |
-| `Hash32` | `Bytes32` | a 256-bit hash |
 
 ## Constants
 
@@ -68,19 +65,6 @@ We define the following Python custom types for type hinting and readability:
 | `BYTES_PER_LOGS_BLOOM` | `uint64(2**8)` (= 256) |
 
 ## Containers
-
-### Modified containers
-
-#### `Eth1Data`
-
-*Note*: The only modification is the type of `block_hash` field that is changed to `Hash32`.
-
-```python
-class Eth1Data(Container):
-    deposit_root: Root
-    deposit_count: uint64
-    block_hash: Hash32  # [Modified in Merge]
-```
 
 ### Extended containers
 

--- a/specs/merge/beacon-chain.md
+++ b/specs/merge/beacon-chain.md
@@ -29,7 +29,6 @@
     - [`compute_time_at_slot`](#compute_time_at_slot)
   - [Block processing](#block-processing)
     - [Execution payload processing](#execution-payload-processing)
-      - [`get_execution_state`](#get_execution_state)
       - [`execution_state_transition`](#execution_state_transition)
       - [`process_execution_payload`](#process_execution_payload)
 
@@ -171,16 +170,9 @@ def process_block(state: BeaconState, block: BeaconBlock) -> None:
 
 #### Execution payload processing
 
-##### `get_execution_state`
-
-*Note*: `ExecutionState` class is an abstract class representing Ethereum execution state.
-
-Let `get_execution_state(execution_state_root: Bytes32) -> ExecutionState`  be the function that given the root hash returns a copy of Ethereum execution state. 
-The body of the function is implementation dependent.
-
 ##### `execution_state_transition`
 
-Let `execution_state_transition(execution_state: ExecutionState, execution_payload: ExecutionPayload, timestamp: uint64) -> None` be the transition function of Ethereum execution state. 
+Let `execution_state_transition(execution_state_root: Bytes32, execution_payload: ExecutionPayload, timestamp: uint64) -> None` be the transition function of Ethereum execution state. 
 The body of the function is implementation dependent.
 
 *Note*: `execution_state_transition` must throw `AssertionError` if either the transition itself or one of the pre or post conditions has failed.
@@ -203,8 +195,8 @@ def process_execution_payload(state: BeaconState, body: BeaconBlockBody) -> None
         assert execution_payload.number == state.latest_execution_payload_header.number + 1
 
     timestamp = compute_time_at_slot(state, state.slot)
-    execution_state = get_execution_state(state.latest_execution_payload_header.state_root)
-    execution_state_transition(execution_state, body.execution_payload, timestamp)
+    execution_state_root = state.latest_execution_payload_header.state_root
+    execution_state_transition(execution_state_root, body.execution_payload, timestamp)
 
     state.latest_execution_payload_header = ExecutionPayloadHeader(
         block_hash=execution_payload.block_hash,

--- a/specs/merge/beacon-chain.md
+++ b/specs/merge/beacon-chain.md
@@ -155,14 +155,14 @@ class ExecutionPayloadHeader(Container):
 #### `is_transition_completed`
 
 ```python
-def is_transition_completed(state: BeaconState) -> boolean:
+def is_transition_completed(state: BeaconState) -> bool:
     return state.latest_execution_payload_header != ExecutionPayloadHeader()
 ```
 
 #### `is_transition_block`
 
 ```python
-def is_transition_block(state: BeaconState, block_body: BeaconBlockBody) -> boolean:
+def is_transition_block(state: BeaconState, block_body: BeaconBlockBody) -> bool:
     return not is_transition_completed(state) and block_body.execution_payload != ExecutionPayload()
 ```
 
@@ -191,7 +191,7 @@ def process_block(state: BeaconState, block: BeaconBlock) -> None:
 
 ##### `validate_execution_payload`
 
-Let `validate_execution_payload(execution_payload: ExecutionPayload) -> boolean` be the function checking whether given `ExecutionPayload` is valid or not.
+Let `validate_execution_payload(execution_payload: ExecutionPayload) -> bool` be the function checking whether given `ExecutionPayload` is valid or not.
 The body of the function is implementation dependent.
 
 ##### `process_execution_payload`

--- a/specs/merge/beacon-chain.md
+++ b/specs/merge/beacon-chain.md
@@ -16,6 +16,8 @@
   - [Transition](#transition)
   - [Execution](#execution)
 - [Containers](#containers)
+  - [Updated containers](#updated-containers)
+    - [`Eth1Data`](#eth1data)
   - [Extended containers](#extended-containers)
     - [`BeaconBlockBody`](#beaconblockbody)
     - [`BeaconState`](#beaconstate)
@@ -66,6 +68,19 @@ We define the following Python custom types for type hinting and readability:
 | `BYTES_PER_LOGS_BLOOM` | `uint64(2**8)` (= 256) |
 
 ## Containers
+
+### Modified containers
+
+#### `Eth1Data`
+
+*Note*: The only modification is the type of `block_hash` field that is changed to `Hash32`.
+
+```python
+class Eth1Data(Container):
+    deposit_root: Root
+    deposit_count: uint64
+    block_hash: Hash32  # [Modified in Merge]
+```
 
 ### Extended containers
 

--- a/specs/merge/fork-choice.md
+++ b/specs/merge/fork-choice.md
@@ -38,7 +38,7 @@ class PowBlock(Container):
 
 #### `get_pow_block`
 
-Let `get_pow_block(hash: Hash32) -> PowBlock` be the function that given the hash of the PoW block returns its data.
+Let `get_pow_block(block_hash: Hash32) -> PowBlock` be the function that given the hash of the PoW block returns its data.
 
 *Note*: The `eth_getBlockByHash` JSON-RPC method does not distinguish invalid blocks from blocks that haven't been processed yet. Either extending this existing method or implementing a new one is required.
 
@@ -113,4 +113,3 @@ def on_block(store: Store, signed_block: SignedBeaconBlock) -> None:
             if ancestor_at_finalized_slot != store.finalized_checkpoint.root:
                 store.justified_checkpoint = state.current_justified_checkpoint
 ```
-

--- a/specs/merge/fork-choice.md
+++ b/specs/merge/fork-choice.md
@@ -30,7 +30,7 @@ This is the modification of the fork choice according to the executable beacon c
 
 ```python
 class PowBlock(Container):
-    block_hash: Bytes32
+    block_hash: Hash32
     is_processed: boolean
     is_valid: boolean
     total_difficulty: uint256
@@ -38,7 +38,7 @@ class PowBlock(Container):
 
 #### `get_pow_block`
 
-Let `get_pow_block(hash: Bytes32) -> PowBlock` be the function that given the hash of the PoW block returns its data.
+Let `get_pow_block(hash: Hash32) -> PowBlock` be the function that given the hash of the PoW block returns its data.
 
 *Note*: The `eth_getBlockByHash` JSON-RPC method does not distinguish invalid blocks from blocks that haven't been processed yet. Either extending this existing method or implementing a new one is required.
 

--- a/specs/merge/fork-choice.md
+++ b/specs/merge/fork-choice.md
@@ -47,7 +47,7 @@ Let `get_pow_block(block_hash: Hash32) -> PowBlock` be the function that given t
 Used by fork-choice handler, `on_block`.
 
 ```python
-def is_valid_transition_block(block: PowBlock) -> boolean:
+def is_valid_transition_block(block: PowBlock) -> bool:
     is_total_difficulty_reached = block.total_difficulty >= TRANSITION_TOTAL_DIFFICULTY
     return block.is_valid and is_total_difficulty_reached
 ```

--- a/specs/merge/validator.md
+++ b/specs/merge/validator.md
@@ -48,7 +48,7 @@ Let `get_pow_chain_head() -> PowBlock` be the function that returns the head of 
 
 ###### `produce_execution_payload`
 
-Let `produce_execution_payload(parent_hash: Bytes32) -> ExecutionPayload` be the function that produces new instance of execution payload.
+Let `produce_execution_payload(parent_hash: Hash32) -> ExecutionPayload` be the function that produces new instance of execution payload.
 The body of this function is implementation dependent.
 
 * Set `block.body.execution_payload = get_execution_payload(state)` where:

--- a/specs/merge/validator.md
+++ b/specs/merge/validator.md
@@ -48,7 +48,7 @@ Let `get_pow_chain_head() -> PowBlock` be the function that returns the head of 
 
 ###### `produce_execution_payload`
 
-Let `produce_execution_payload(parent_hash: Hash32) -> ExecutionPayload` be the function that produces new instance of execution payload.
+Let `produce_execution_payload(parent_hash: Hash32, timestamp: uint64) -> ExecutionPayload` be the function that produces new instance of execution payload.
 The body of this function is implementation dependent.
 
 * Set `block.body.execution_payload = get_execution_payload(state)` where:
@@ -66,5 +66,6 @@ def get_execution_payload(state: BeaconState) -> ExecutionPayload:
 
     # Post-merge, normal payload
     execution_parent_hash = state.latest_execution_payload_header.block_hash
-    return produce_execution_payload(execution_parent_hash)
+    timestamp = compute_time_at_slot(state, state.slot)
+    return produce_execution_payload(execution_parent_hash, timestamp)
 ```

--- a/specs/merge/validator.md
+++ b/specs/merge/validator.md
@@ -62,7 +62,8 @@ def get_execution_payload(state: BeaconState) -> ExecutionPayload:
             return ExecutionPayload()
         else:
             # Signify merge via producing on top of the last PoW block
-            return produce_execution_payload(pow_block.block_hash)
+            timestamp = compute_time_at_slot(state, state.slot)
+            return produce_execution_payload(pow_block.block_hash, timestamp)
 
     # Post-merge, normal payload
     execution_parent_hash = state.latest_execution_payload_header.block_hash

--- a/specs/phase0/beacon-chain.md
+++ b/specs/phase0/beacon-chain.md
@@ -157,12 +157,14 @@ We define the following Python custom types for type hinting and readability:
 | `ValidatorIndex` | `uint64` | a validator registry index |
 | `Gwei` | `uint64` | an amount in Gwei |
 | `Root` | `Bytes32` | a Merkle root |
+| `Hash32` | `Bytes32` | a 256-bit hash |
 | `Version` | `Bytes4` | a fork version number |
 | `DomainType` | `Bytes4` | a domain type |
 | `ForkDigest` | `Bytes4` | a digest of the current fork data |
 | `Domain` | `Bytes32` | a signature domain |
 | `BLSPubkey` | `Bytes48` | a BLS12-381 public key |
 | `BLSSignature` | `Bytes96` | a BLS12-381 signature |
+
 
 ## Constants
 
@@ -374,7 +376,7 @@ class PendingAttestation(Container):
 class Eth1Data(Container):
     deposit_root: Root
     deposit_count: uint64
-    block_hash: Bytes32
+    block_hash: Hash32
 ```
 
 #### `HistoricalBatch`


### PR DESCRIPTION
This PR introduces the following changes:
- `Hash32` custom type. This type is used to denote data type of execution payload hashes (`block_hash`, `parent_hash`). Though, `ExecutionPayload.state_root` still has `Bytes32` type, it is preserved to distinguish MPT root hash from merkle roots used by the beacon chain.
- `execution_state` object is replaced with `execution_state_root` in `execution_state_transition` params list. In the composite client implementation an operation to retrieve `execution_state ` object to further pass it to the function does not make sense as state management is delegated to execution engine. This change makes the spec suitable for both types of clients.
- Adds explicit computation of execution block `timestamp` and passes it onto `execution_state_transition` and `produce_execution_payload` functions.