### PR TITLE
Refactor pyspec `context.py` by adding `typing.py` and `constants.py`

### DIFF
--- a/tests/core/pyspec/eth2spec/gen_helpers/gen_from_tests/gen.py
+++ b/tests/core/pyspec/eth2spec/gen_helpers/gen_from_tests/gen.py
@@ -4,7 +4,8 @@ from typing import Any, Callable, Dict, Iterable, Optional
 
 from eth2spec.config import config_util
 from eth2spec.utils import bls
-from eth2spec.test.context import ALL_CONFIGS, TESTGEN_FORKS, SpecForkName, ConfigName
+from eth2spec.test.helpers.constants import ALL_CONFIGS, TESTGEN_FORKS
+from eth2spec.test.helpers.typing import SpecForkName, ConfigName
 
 from eth2spec.gen_helpers.gen_base import gen_runner
 from eth2spec.gen_helpers.gen_base.gen_typing import TestCase, TestProvider

--- a/tests/core/pyspec/eth2spec/test/altair/block_processing/test_process_sync_committee.py
+++ b/tests/core/pyspec/eth2spec/test/altair/block_processing/test_process_sync_committee.py
@@ -8,12 +8,14 @@ from eth2spec.test.helpers.state import (
     state_transition_and_sign_block,
     transition_to,
 )
+from eth2spec.test.helpers.constants import (
+    PHASE0,
+    MAINNET, MINIMAL,
+)
 from eth2spec.test.helpers.sync_committee import (
     compute_aggregate_sync_committee_signature,
 )
 from eth2spec.test.context import (
-    PHASE0,
-    MAINNET, MINIMAL,
     expect_assertion_error,
     with_all_phases_except,
     with_configs,

--- a/tests/core/pyspec/eth2spec/test/altair/epoch_processing/test_process_sync_committee_updates.py
+++ b/tests/core/pyspec/eth2spec/test/altair/epoch_processing/test_process_sync_committee_updates.py
@@ -1,9 +1,11 @@
 from eth2spec.test.context import (
-    PHASE0,
-    MINIMAL,
     spec_state_test,
     with_all_phases_except,
     with_configs,
+)
+from eth2spec.test.helpers.constants import (
+    PHASE0,
+    MINIMAL,
 )
 from eth2spec.test.helpers.state import transition_to
 from eth2spec.test.helpers.epoch_processing import (

--- a/tests/core/pyspec/eth2spec/test/altair/fork/test_fork.py
+++ b/tests/core/pyspec/eth2spec/test/altair/fork/test_fork.py
@@ -1,6 +1,4 @@
 from eth2spec.test.context import (
-    PHASE0, ALTAIR,
-    MINIMAL,
     with_phases,
     with_custom_state,
     with_configs,
@@ -8,6 +6,10 @@ from eth2spec.test.context import (
     low_balances, misc_balances, large_validator_set,
 )
 from eth2spec.test.utils import with_meta_tags
+from eth2spec.test.helpers.constants import (
+    PHASE0, ALTAIR,
+    MINIMAL,
+)
 from eth2spec.test.helpers.state import (
     next_epoch,
     next_epoch_via_block,

--- a/tests/core/pyspec/eth2spec/test/altair/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/altair/sanity/test_blocks.py
@@ -11,8 +11,8 @@ from eth2spec.test.helpers.block import (
 from eth2spec.test.helpers.sync_committee import (
     compute_aggregate_sync_committee_signature,
 )
+from eth2spec.test.helpers.constants import PHASE0
 from eth2spec.test.context import (
-    PHASE0,
     with_all_phases_except,
     spec_state_test,
 )

--- a/tests/core/pyspec/eth2spec/test/altair/unittests/test_helpers.py
+++ b/tests/core/pyspec/eth2spec/test/altair/unittests/test_helpers.py
@@ -1,8 +1,8 @@
 from eth2spec.test.context import (
     spec_state_test,
     with_phases,
-    ALTAIR,
 )
+from eth2spec.test.helpers.constants import ALTAIR
 from eth2spec.test.helpers.merkle import build_proof
 
 

--- a/tests/core/pyspec/eth2spec/test/altair/unittests/test_sync_protocol.py
+++ b/tests/core/pyspec/eth2spec/test/altair/unittests/test_sync_protocol.py
@@ -1,6 +1,4 @@
 from eth2spec.test.context import (
-    ALTAIR,
-    MINIMAL,
     spec_state_test,
     with_configs,
     with_phases,
@@ -9,6 +7,10 @@ from eth2spec.test.helpers.attestations import next_epoch_with_attestations
 from eth2spec.test.helpers.block import (
     build_empty_block,
     build_empty_block_for_next_slot,
+)
+from eth2spec.test.helpers.constants import (
+    ALTAIR,
+    MINIMAL,
 )
 from eth2spec.test.helpers.state import (
     next_slots,

--- a/tests/core/pyspec/eth2spec/test/context.py
+++ b/tests/core/pyspec/eth2spec/test/context.py
@@ -6,11 +6,15 @@ from eth2spec.merge import spec as spec_merge
 from eth2spec.utils import bls
 
 from .exceptions import SkippedTest
+from .helpers.constants import (
+    PHASE0, ALTAIR, MERGE, SHARDING, CUSTODY_GAME, DAS,
+    ALL_PHASES,
+)
 from .helpers.genesis import create_genesis_state
 from .utils import vector_test, with_meta_tags
 
 from random import Random
-from typing import Any, Callable, NewType, Sequence, TypedDict, Protocol
+from typing import Any, Callable, Sequence, TypedDict, Protocol
 
 from lru import LRU
 
@@ -22,30 +26,6 @@ def reload_specs():
     reload(spec_altair)
     reload(spec_merge)
 
-
-# Some of the Spec module functionality is exposed here to deal with phase-specific changes.
-
-SpecForkName = NewType("SpecForkName", str)
-ConfigName = NewType("ConfigName", str)
-
-PHASE0 = SpecForkName('phase0')
-ALTAIR = SpecForkName('altair')
-
-# Experimental phases (not included in default "ALL_PHASES"):
-MERGE = SpecForkName('merge')
-SHARDING = SpecForkName('sharding')
-CUSTODY_GAME = SpecForkName('custody_game')
-DAS = SpecForkName('das')
-
-ALL_PHASES = (PHASE0, ALTAIR)
-
-MAINNET = ConfigName('mainnet')
-MINIMAL = ConfigName('minimal')
-
-ALL_CONFIGS = (MINIMAL, MAINNET)
-
-# The forks that output to the test vectors.
-TESTGEN_FORKS = (PHASE0, ALTAIR)
 
 # TODO: currently phases are defined as python modules.
 # It would be better if they would be more well-defined interfaces for stronger typing.

--- a/tests/core/pyspec/eth2spec/test/custody_game/block_processing/test_process_attestation.py
+++ b/tests/core/pyspec/eth2spec/test/custody_game/block_processing/test_process_attestation.py
@@ -1,9 +1,9 @@
 from eth2spec.test.context import (
-    CUSTODY_GAME,
     with_phases,
     spec_state_test,
     always_bls,
 )
+from eth2spec.test.helpers.constants import CUSTODY_GAME
 from eth2spec.test.helpers.state import transition_to
 from eth2spec.test.helpers.attestations import (
     run_attestation_processing,

--- a/tests/core/pyspec/eth2spec/test/custody_game/block_processing/test_process_chunk_challenge.py
+++ b/tests/core/pyspec/eth2spec/test/custody_game/block_processing/test_process_chunk_challenge.py
@@ -6,10 +6,12 @@ from eth2spec.test.helpers.custody import (
 from eth2spec.test.helpers.attestations import (
     get_valid_on_time_attestation,
 )
-from eth2spec.test.helpers.state import transition_to, transition_to_valid_shard_slot
-from eth2spec.test.context import (
+from eth2spec.test.helpers.constants import (
     CUSTODY_GAME,
     MINIMAL,
+)
+from eth2spec.test.helpers.state import transition_to, transition_to_valid_shard_slot
+from eth2spec.test.context import (
     expect_assertion_error,
     disable_process_reveal_deadlines,
     spec_state_test,

--- a/tests/core/pyspec/eth2spec/test/custody_game/block_processing/test_process_custody_key_reveal.py
+++ b/tests/core/pyspec/eth2spec/test/custody_game/block_processing/test_process_custody_key_reveal.py
@@ -1,6 +1,6 @@
+from eth2spec.test.helpers.constants import CUSTODY_GAME
 from eth2spec.test.helpers.custody import get_valid_custody_key_reveal
 from eth2spec.test.context import (
-    CUSTODY_GAME,
     with_phases,
     spec_state_test,
     expect_assertion_error,

--- a/tests/core/pyspec/eth2spec/test/custody_game/block_processing/test_process_custody_slashing.py
+++ b/tests/core/pyspec/eth2spec/test/custody_game/block_processing/test_process_custody_slashing.py
@@ -5,12 +5,14 @@ from eth2spec.test.helpers.custody import (
 from eth2spec.test.helpers.attestations import (
     get_valid_on_time_attestation,
 )
+from eth2spec.test.helpers.constants import (
+    CUSTODY_GAME,
+    MINIMAL,
+)
 from eth2spec.test.helpers.keys import privkeys
 from eth2spec.utils.ssz.ssz_typing import ByteList
 from eth2spec.test.helpers.state import get_balance, transition_to
 from eth2spec.test.context import (
-    MINIMAL,
-    CUSTODY_GAME,
     with_phases,
     spec_state_test,
     expect_assertion_error,

--- a/tests/core/pyspec/eth2spec/test/custody_game/block_processing/test_process_early_derived_secret_reveal.py
+++ b/tests/core/pyspec/eth2spec/test/custody_game/block_processing/test_process_early_derived_secret_reveal.py
@@ -1,7 +1,7 @@
+from eth2spec.test.helpers.constants import CUSTODY_GAME
 from eth2spec.test.helpers.custody import get_valid_early_derived_secret_reveal
 from eth2spec.test.helpers.state import next_epoch_via_block, get_balance
 from eth2spec.test.context import (
-    CUSTODY_GAME,
     with_phases,
     spec_state_test,
     expect_assertion_error,

--- a/tests/core/pyspec/eth2spec/test/custody_game/epoch_processing/test_process_challenge_deadlines.py
+++ b/tests/core/pyspec/eth2spec/test/custody_game/epoch_processing/test_process_challenge_deadlines.py
@@ -7,13 +7,15 @@ from eth2spec.test.helpers.attestations import (
 )
 from eth2spec.test.helpers.state import transition_to, transition_to_valid_shard_slot
 from eth2spec.test.context import (
-    CUSTODY_GAME,
-    MINIMAL,
     spec_state_test,
     with_phases,
     with_configs,
 )
 from eth2spec.test.phase0.block_processing.test_process_attestation import run_attestation_processing
+from eth2spec.test.helpers.constants import (
+    CUSTODY_GAME,
+    MINIMAL,
+)
 from eth2spec.test.helpers.epoch_processing import run_epoch_processing_with
 
 from eth2spec.test.custody_game.block_processing.test_process_chunk_challenge import (

--- a/tests/core/pyspec/eth2spec/test/custody_game/epoch_processing/test_process_custody_final_updates.py
+++ b/tests/core/pyspec/eth2spec/test/custody_game/epoch_processing/test_process_custody_final_updates.py
@@ -1,4 +1,4 @@
-from eth2spec.test.context import (
+from eth2spec.test.helpers.constants import (
     CUSTODY_GAME,
 )
 from eth2spec.test.helpers.custody import (

--- a/tests/core/pyspec/eth2spec/test/custody_game/epoch_processing/test_process_reveal_deadlines.py
+++ b/tests/core/pyspec/eth2spec/test/custody_game/epoch_processing/test_process_reveal_deadlines.py
@@ -3,11 +3,13 @@ from eth2spec.test.helpers.custody import (
 )
 from eth2spec.test.helpers.state import transition_to
 from eth2spec.test.context import (
-    CUSTODY_GAME,
-    MINIMAL,
     with_phases,
     with_configs,
     spec_state_test,
+)
+from eth2spec.test.helpers.constants import (
+    CUSTODY_GAME,
+    MINIMAL,
 )
 from eth2spec.test.helpers.epoch_processing import run_epoch_processing_with
 from eth2spec.test.custody_game.block_processing.test_process_custody_key_reveal import (

--- a/tests/core/pyspec/eth2spec/test/custody_game/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/custody_game/sanity/test_blocks.py
@@ -1,14 +1,16 @@
 from typing import Dict, Sequence
 
 from eth2spec.test.context import (
-    CUSTODY_GAME,
-    MINIMAL,
     with_phases,
     spec_state_test,
     with_configs,
 )
 from eth2spec.test.helpers.attestations import get_valid_on_time_attestation
 from eth2spec.test.helpers.block import build_empty_block
+from eth2spec.test.helpers.constants import (
+    CUSTODY_GAME,
+    MINIMAL,
+)
 from eth2spec.test.helpers.custody import (
     get_custody_slashable_test_vector,
     get_valid_chunk_challenge,

--- a/tests/core/pyspec/eth2spec/test/helpers/constants.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/constants.py
@@ -1,0 +1,29 @@
+from .typing import SpecForkName, ConfigName
+
+
+#
+# SpecForkName
+#
+# Some of the Spec module functionality is exposed here to deal with phase-specific changes.
+PHASE0 = SpecForkName('phase0')
+ALTAIR = SpecForkName('altair')
+
+# Experimental phases (not included in default "ALL_PHASES"):
+MERGE = SpecForkName('merge')
+SHARDING = SpecForkName('sharding')
+CUSTODY_GAME = SpecForkName('custody_game')
+DAS = SpecForkName('das')
+
+# The forks that pytest runs with.
+ALL_PHASES = (PHASE0, ALTAIR)
+# The forks that output to the test vectors.
+TESTGEN_FORKS = (PHASE0, ALTAIR)
+
+
+#
+# Config
+#
+MAINNET = ConfigName('mainnet')
+MINIMAL = ConfigName('minimal')
+
+ALL_CONFIGS = (MINIMAL, MAINNET)

--- a/tests/core/pyspec/eth2spec/test/helpers/typing.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/typing.py
@@ -1,0 +1,4 @@
+from typing import NewType
+
+SpecForkName = NewType("SpecForkName", str)
+ConfigName = NewType("ConfigName", str)

--- a/tests/core/pyspec/eth2spec/test/phase0/epoch_processing/test_process_participation_record_updates.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/epoch_processing/test_process_participation_record_updates.py
@@ -1,4 +1,5 @@
-from eth2spec.test.context import PHASE0, spec_state_test, with_phases
+from eth2spec.test.context import spec_state_test, with_phases
+from eth2spec.test.helpers.constants import PHASE0
 from eth2spec.test.helpers.epoch_processing import (
     run_epoch_processing_with
 )

--- a/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_get_head.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/fork_choice/test_get_head.py
@@ -1,7 +1,6 @@
 from eth_utils import encode_hex
 
 from eth2spec.test.context import (
-    MINIMAL,
     is_post_altair,
     spec_state_test,
     with_all_phases,
@@ -9,6 +8,7 @@ from eth2spec.test.context import (
 )
 from eth2spec.test.helpers.attestations import get_valid_attestation, next_epoch_with_attestations
 from eth2spec.test.helpers.block import build_empty_block_for_next_slot
+from eth2spec.test.helpers.constants import MINIMAL
 from eth2spec.test.helpers.fork_choice import (
     tick_and_run_on_attestation,
     tick_and_run_on_block,

--- a/tests/core/pyspec/eth2spec/test/phase0/genesis/test_initialization.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/genesis/test_initialization.py
@@ -1,11 +1,11 @@
 from eth2spec.test.context import (
-    MINIMAL,
     is_post_altair,
     single_phase,
     spec_test,
     with_configs,
     with_all_phases,
 )
+from eth2spec.test.helpers.constants import MINIMAL
 from eth2spec.test.helpers.deposits import (
     prepare_full_genesis_deposits,
     prepare_random_genesis_deposits,

--- a/tests/core/pyspec/eth2spec/test/phase0/genesis/test_validity.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/genesis/test_validity.py
@@ -1,11 +1,11 @@
 from eth2spec.test.context import (
-    MINIMAL,
     is_post_altair,
     spec_test,
     single_phase,
     with_configs,
     with_all_phases,
 )
+from eth2spec.test.helpers.constants import MINIMAL
 from eth2spec.test.helpers.deposits import (
     prepare_full_genesis_deposits,
 )

--- a/tests/core/pyspec/eth2spec/test/phase0/rewards/test_basic.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/rewards/test_basic.py
@@ -1,4 +1,5 @@
-from eth2spec.test.context import PHASE0, with_all_phases, with_phases, spec_state_test
+from eth2spec.test.context import with_all_phases, with_phases, spec_state_test
+from eth2spec.test.helpers.constants import PHASE0
 import eth2spec.test.helpers.rewards as rewards_helpers
 
 

--- a/tests/core/pyspec/eth2spec/test/phase0/rewards/test_leak.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/rewards/test_leak.py
@@ -1,4 +1,5 @@
-from eth2spec.test.context import PHASE0, with_all_phases, with_phases, spec_state_test
+from eth2spec.test.context import with_all_phases, with_phases, spec_state_test
+from eth2spec.test.helpers.constants import PHASE0
 from eth2spec.test.helpers.rewards import leaking
 import eth2spec.test.helpers.rewards as rewards_helpers
 

--- a/tests/core/pyspec/eth2spec/test/phase0/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/sanity/test_blocks.py
@@ -24,9 +24,8 @@ from eth2spec.test.helpers.multi_operations import (
     run_slash_and_exit,
     run_test_full_random_operations,
 )
-
+from eth2spec.test.helpers.constants import PHASE0, MINIMAL
 from eth2spec.test.context import (
-    PHASE0, MINIMAL,
     spec_test, spec_state_test, dump_skipping_message,
     with_phases, with_all_phases, single_phase,
     expect_assertion_error, always_bls,

--- a/tests/core/pyspec/eth2spec/test/phase0/unittests/fork_choice/test_on_attestation.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/unittests/fork_choice/test_on_attestation.py
@@ -1,6 +1,7 @@
-from eth2spec.test.context import PHASE0, ALTAIR, with_all_phases, spec_state_test
+from eth2spec.test.context import with_all_phases, spec_state_test
 from eth2spec.test.helpers.block import build_empty_block_for_next_slot
 from eth2spec.test.helpers.attestations import get_valid_attestation, sign_attestation
+from eth2spec.test.helpers.constants import PHASE0, ALTAIR
 from eth2spec.test.helpers.state import transition_to, state_transition_and_sign_block, next_epoch, next_slot
 from eth2spec.test.helpers.fork_choice import get_genesis_forkchoice_store
 

--- a/tests/core/pyspec/eth2spec/test/phase0/unittests/validator/test_validator_unittest.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/unittests/validator/test_validator_unittest.py
@@ -1,8 +1,8 @@
 from eth2spec.test.context import (
     spec_state_test,
     always_bls, with_phases, with_all_phases,
-    PHASE0,
 )
+from eth2spec.test.helpers.constants import PHASE0
 from eth2spec.test.helpers.attestations import build_attestation_data, get_valid_attestation
 from eth2spec.test.helpers.block import build_empty_block
 from eth2spec.test.helpers.deposits import prepare_state_and_deposit

--- a/tests/core/pyspec/eth2spec/test/sharding/unittests/test_get_start_shard.py
+++ b/tests/core/pyspec/eth2spec/test/sharding/unittests/test_get_start_shard.py
@@ -1,8 +1,8 @@
 from eth2spec.test.context import (
-    SHARDING,
     with_phases,
     spec_state_test,
 )
+from eth2spec.test.helpers.constants import SHARDING
 from eth2spec.test.helpers.state import next_epoch
 
 

--- a/tests/generators/README.md
+++ b/tests/generators/README.md
@@ -164,7 +164,7 @@ Another example, to generate tests from pytests:
 ```python
 from eth2spec.phase0 import spec as spec_phase0
 from eth2spec.altair import spec as spec_altair
-from eth2spec.test.context import PHASE0, ALTAIR
+from eth2spec.test.helpers.constants import PHASE0, ALTAIR
 
 from eth2spec.gen_helpers.gen_from_tests.gen import run_state_test_generators
 

--- a/tests/generators/bls/main.py
+++ b/tests/generators/bls/main.py
@@ -12,7 +12,7 @@ from eth_utils import (
 import milagro_bls_binding as milagro_bls
 
 from eth2spec.utils import bls
-from eth2spec.test.context import PHASE0
+from eth2spec.test.helpers.constants import PHASE0
 from eth2spec.gen_helpers.gen_base import gen_runner, gen_typing
 
 

--- a/tests/generators/epoch_processing/main.py
+++ b/tests/generators/epoch_processing/main.py
@@ -1,7 +1,7 @@
 from eth2spec.gen_helpers.gen_from_tests.gen import run_state_test_generators
 from eth2spec.phase0 import spec as spec_phase0
 from eth2spec.altair import spec as spec_altair
-from eth2spec.test.context import PHASE0, ALTAIR
+from eth2spec.test.helpers.constants import PHASE0, ALTAIR
 
 
 specs = (spec_phase0, spec_altair)

--- a/tests/generators/finality/main.py
+++ b/tests/generators/finality/main.py
@@ -1,7 +1,7 @@
 from eth2spec.gen_helpers.gen_from_tests.gen import run_state_test_generators
 from eth2spec.phase0 import spec as spec_phase0
 from eth2spec.altair import spec as spec_altair
-from eth2spec.test.context import PHASE0, ALTAIR
+from eth2spec.test.helpers.constants import PHASE0, ALTAIR
 
 
 specs = (spec_phase0, spec_altair)

--- a/tests/generators/fork_choice/main.py
+++ b/tests/generators/fork_choice/main.py
@@ -1,7 +1,7 @@
 from eth2spec.gen_helpers.gen_from_tests.gen import run_state_test_generators
 from eth2spec.phase0 import spec as spec_phase0
 from eth2spec.altair import spec as spec_altair
-from eth2spec.test.context import PHASE0, ALTAIR
+from eth2spec.test.helpers.constants import PHASE0, ALTAIR
 
 
 specs = (spec_phase0, spec_altair)

--- a/tests/generators/forks/main.py
+++ b/tests/generators/forks/main.py
@@ -1,7 +1,7 @@
 from importlib import reload
 from typing import Iterable
 
-from eth2spec.test.context import PHASE0, ALTAIR, MINIMAL, MAINNET
+from eth2spec.test.helpers.constants import PHASE0, ALTAIR, MINIMAL, MAINNET
 from eth2spec.config import config_util
 from eth2spec.test.altair.fork import test_fork as test_altair_forks
 from eth2spec.phase0 import spec as spec_phase0

--- a/tests/generators/genesis/main.py
+++ b/tests/generators/genesis/main.py
@@ -1,7 +1,7 @@
 from eth2spec.gen_helpers.gen_from_tests.gen import run_state_test_generators
 from eth2spec.phase0 import spec as spec_phase0
 from eth2spec.altair import spec as spec_altair
-from eth2spec.test.context import PHASE0, ALTAIR
+from eth2spec.test.helpers.constants import PHASE0, ALTAIR
 
 
 specs = (spec_phase0, spec_altair)

--- a/tests/generators/operations/main.py
+++ b/tests/generators/operations/main.py
@@ -1,7 +1,7 @@
 from eth2spec.gen_helpers.gen_from_tests.gen import run_state_test_generators
 from eth2spec.phase0 import spec as spec_phase0
 from eth2spec.altair import spec as spec_altair
-from eth2spec.test.context import PHASE0, ALTAIR
+from eth2spec.test.helpers.constants import PHASE0, ALTAIR
 
 
 specs = (spec_phase0, spec_altair)

--- a/tests/generators/rewards/main.py
+++ b/tests/generators/rewards/main.py
@@ -1,7 +1,7 @@
 from eth2spec.gen_helpers.gen_from_tests.gen import run_state_test_generators
 from eth2spec.phase0 import spec as spec_phase0
 from eth2spec.altair import spec as spec_altair
-from eth2spec.test.context import PHASE0, ALTAIR
+from eth2spec.test.helpers.constants import PHASE0, ALTAIR
 
 
 specs = (spec_phase0, spec_altair)

--- a/tests/generators/sanity/main.py
+++ b/tests/generators/sanity/main.py
@@ -1,6 +1,6 @@
 from eth2spec.phase0 import spec as spec_phase0
 from eth2spec.altair import spec as spec_altair
-from eth2spec.test.context import PHASE0, ALTAIR
+from eth2spec.test.helpers.constants import PHASE0, ALTAIR
 
 from eth2spec.gen_helpers.gen_from_tests.gen import run_state_test_generators
 

--- a/tests/generators/shuffling/main.py
+++ b/tests/generators/shuffling/main.py
@@ -6,7 +6,7 @@ from eth2spec.gen_helpers.gen_base import gen_runner, gen_typing
 
 from eth2spec.config import config_util
 from eth2spec.phase0 import spec as spec
-from eth2spec.test.context import PHASE0
+from eth2spec.test.helpers.constants import PHASE0
 
 
 def shuffling_case_fn(seed, count):

--- a/tests/generators/ssz_generic/main.py
+++ b/tests/generators/ssz_generic/main.py
@@ -6,7 +6,7 @@ import ssz_bitvector
 import ssz_boolean
 import ssz_uints
 import ssz_container
-from eth2spec.test.context import PHASE0
+from eth2spec.test.helpers.constants import PHASE0
 
 
 def create_provider(handler_name: str, suite_name: str, case_maker) -> gen_typing.TestProvider:

--- a/tests/generators/ssz_static/main.py
+++ b/tests/generators/ssz_static/main.py
@@ -9,7 +9,7 @@ from eth2spec.debug import random_value, encode
 from eth2spec.config import config_util
 from eth2spec.phase0 import spec as spec_phase0
 from eth2spec.altair import spec as spec_altair
-from eth2spec.test.context import ALTAIR, TESTGEN_FORKS, MINIMAL, MAINNET
+from eth2spec.test.helpers.constants import ALTAIR, TESTGEN_FORKS, MINIMAL, MAINNET
 from eth2spec.utils.ssz.ssz_typing import Container
 from eth2spec.utils.ssz.ssz_impl import (
     hash_tree_root,


### PR DESCRIPTION
## Issue
In #2323
1. Spec fork names (`PHASE0`, `ALTAIR`) is defined in `eth2spec.test.context`
2. `eth2spec.test.helpers.genesis.create_genesis_state` function is called by `eth2spec.test.context._prepare_state` function
3. I wanted to use spec fork names in `eth2spec.test.helpers.genesis`... but due to (1) and (@), it would introduce a dependency issue.

## Proposed solution
- Move pyspec custom types to `eth2spec.test.helpers.typing`
- Move pyspec constants to `eth2spec.test.helpers.constants`

Then the forks names and config names can be accessed anywhere.
