### PR TITLE
Update variable name ALTAIR_INVAIANT_CHECKS to INVARIANT in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -329,7 +329,7 @@ ALTAIR_HARDCODED_SSZ_DEP_CONSTANTS = {
 }
 
 
-ALTAIR_INVAIANT_CHECKS = '''
+ALTAIR_INVARIANT_CHECKS = '''
 assert (
     TIMELY_HEAD_WEIGHT + TIMELY_SOURCE_WEIGHT + TIMELY_TARGET_WEIGHT + SYNC_REWARD_WEIGHT + PROPOSER_WEIGHT
 ) == WEIGHT_DENOMINATOR'''
@@ -414,7 +414,7 @@ def objects_to_spec(spec_object: SpecObject, imports: str, fork: str, ordered_cl
     if is_altair(fork):
         altair_ssz_dep_constants_verification = '\n'.join(map(lambda x: 'assert %s == %s' % (x, spec_object.ssz_dep_constants[x]), ALTAIR_HARDCODED_SSZ_DEP_CONSTANTS))
         spec += '\n\n\n' + altair_ssz_dep_constants_verification
-        spec += '\n' + ALTAIR_INVAIANT_CHECKS
+        spec += '\n' + ALTAIR_INVARIANT_CHECKS
 
     spec += '\n'
     return spec


### PR DESCRIPTION
Minor fix of variable naming in `setup.py`.

`ALTAIR_INVAIANT_CHECKS` - assumed `INVAIANT` should be `INVARIANT`.