### PR TITLE
Modify merge is_transition_block for readability

### DIFF
--- a/specs/merge/beacon-chain.md
+++ b/specs/merge/beacon-chain.md
@@ -149,6 +149,7 @@ def is_transition_completed(state: BeaconState) -> bool:
 def is_transition_block(state: BeaconState, block_body: BeaconBlockBody) -> bool:
     if is_transition_completed(state):
         return False
+    
     return block_body.execution_payload != ExecutionPayload()
 ```
 

--- a/specs/merge/beacon-chain.md
+++ b/specs/merge/beacon-chain.md
@@ -147,7 +147,9 @@ def is_transition_completed(state: BeaconState) -> bool:
 
 ```python
 def is_transition_block(state: BeaconState, block_body: BeaconBlockBody) -> bool:
-    return not is_transition_completed(state) and block_body.execution_payload != ExecutionPayload()
+    if is_transition_completed(state):
+        return False
+    return block_body.execution_payload != ExecutionPayload()
 ```
 
 #### `compute_time_at_slot`


### PR DESCRIPTION
This is subjective, but I found the existing code to be a little hard to read. I don't think it's immediately clear to the non-Python-guru how the order of operations should work here.

Consider this example:

```python
>>> not True and False
False
>>> not (True and False)
True
``` 

I'm not particularly concerned about this PR getting merged, it just feels less like a trap this way IMO.