### PR TITLE
Use markdown parser for literate pyspec

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -471,7 +471,7 @@ def produce_execution_payload(parent_hash: Hash32, timestamp: uint64) -> Executi
 
 spec_builders = {
     builder.fork: builder
-    for builder in (AltairSpecBuilder, )
+    for builder in (Phase0SpecBuilder, AltairSpecBuilder, MergeSpecBuilder)
 }
 
 

--- a/specs/altair/p2p-interface.md
+++ b/specs/altair/p2p-interface.md
@@ -182,6 +182,8 @@ Request and Response remain unchanged. A `ForkDigest`-context is used to select 
 
 Per `context = compute_fork_digest(fork_version, genesis_validators_root)`:
 
+[0]: # (eth2spec: skip)
+
 | `fork_version`           | Chunk SSZ type             |
 | ------------------------ | -------------------------- |
 | `GENESIS_FORK_VERSION`   | `phase0.SignedBeaconBlock` |
@@ -194,6 +196,8 @@ Per `context = compute_fork_digest(fork_version, genesis_validators_root)`:
 Request and Response remain unchanged. A `ForkDigest`-context is used to select the fork namespace of the Response type.
 
 Per `context = compute_fork_digest(fork_version, genesis_validators_root)`:
+
+[1]: # (eth2spec: skip)
 
 | `fork_version`           | Chunk SSZ type             |
 | ------------------------ | -------------------------- |


### PR DESCRIPTION
# About

This PR suggests a refactoring of how we handle parsing the pyspec from the literate markdown files.

~This PR should serve as basis for discussion for now and should not be merged until this comment is updated otherwise.~

# Discussion

We currently have a hand-rolled parser that scans markdown files in the `/specs` tree and pulls out python code to build the pyspec. I ran into at least two situations in #2329 where I needed further flexibility in handling how the parser works so wrote this PR to refactor the implementation along with introducing a new feature to fix one of the aforementioned situations.

First, I'll motivate w/ these situations:

1. If you look at the code *before* this diff https://github.com/ethereum/eth2.0-specs/pull/2329/commits/4606920e25bc55be4d2a37243a5c757f649dff72, you will see the definition of the constant `SYNC_SUBCOMMITTEE_SIZE` in `p2p-interface.md` on line 89. The current parser only grabs functions or class definitions from "```python" blocks so I had to inline the constant into the function body. The existing way to handle this would require the creation of a "constants" table in the front matter of this document and that seems a little heavy just to define this one constant that exists only to facilitate computation, not something that is important to the spec or eth2 itself.

2. And the next issue arose when I made `p2p-interface.md` executable as it attempts to parse constants from any table it encounters. If you refer to that file currently, we have tables for tabular data but they do not hold spec constants so the spec build fails: https://app.circleci.com/pipelines/github/ethereum/eth2.0-specs/5565/workflows/87c8cc23-5cb0-4f3e-aad6-6a14025577c0/jobs/34587  There are a number of ways we could think to resolve this but a general one is simply an inline method to skip parsing of the next markdown element.

To address these problems, I've used a markdown parser to handle breaking up the spec files into textual elements and started using the python `ast` module to handle the parsing of python code. By using the markdown parser, I hope to make it easier to work over Markdown elements -- for example, parsing comments (and then using some convention to handling "skipping" tables, e.g. resolving (2)). And by beginning to use `ast`, hope to make it easier to deal with python code moving forward. Unfortunately, there is not a straightforward way to "dump" an `AST` object back to source code so stopped at a solution for (1) but this should lay the groundwork if we need it for some more pressing issue in the future.

~If we get general agreement on this PR/approach, then I can add a few more edits to deprecate the existing `get_spec` and clean up some of the attending code in `setup.py`.~
