### PR TITLE
Fix: `upgrade_to_altair` should use `phase0.get_current_epoch`

### DIFF
--- a/specs/altair/fork.md
+++ b/specs/altair/fork.md
@@ -40,7 +40,7 @@ After `process_slots` of Phase 0 finishes, if `state.slot % SLOTS_PER_EPOCH == 0
 
 ```python
 def upgrade_to_altair(pre: phase0.BeaconState) -> BeaconState:
-    epoch = get_current_epoch(pre)
+    epoch = phase0.get_current_epoch(pre)
     post = BeaconState(
         # Versioning
         genesis_time=pre.genesis_time,


### PR DESCRIPTION
`altair.BeaconState` class is a new class in `altair`, which doesn't extend `phase0.BeaconState`.
That means `get_current_epoch` has different signatures in `phase0` and `altair`.
Thus `upgrade_to_altair` should use `phase0.get_current_epoch` for an instance of `phase0.BeaconState` to avoid typing rules violation.