### PR TITLE
Fix typing problems: convert to CommitteeIndex

### DIFF
--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -719,7 +719,8 @@ def charge_confirmed_header_fees(state: BeaconState) -> None:
     )
     previous_epoch_start_slot = compute_start_slot_at_epoch(get_previous_epoch(state))
     for slot in range(previous_epoch_start_slot, previous_epoch_start_slot + SLOTS_PER_EPOCH):
-        for shard in range(SHARD_COUNT):
+        for shard_index in range(SHARD_COUNT):
+            shard = Shard(shard_index)
             confirmed_candidates = [
                 c for c in state.previous_epoch_pending_shard_headers
                 if (c.slot, c.shard, c.confirmed) == (slot, shard, True)

--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -754,8 +754,8 @@ def reset_pending_headers(state: BeaconState) -> None:
     next_epoch_start_slot = compute_start_slot_at_epoch(next_epoch)
     for slot in range(next_epoch_start_slot, next_epoch_start_slot + SLOTS_PER_EPOCH):
         for index in range(get_committee_count_per_slot(state, next_epoch)):
-            shard = compute_shard_from_committee_index(state, slot, index)
-            committee_length = len(get_beacon_committee(state, slot, shard))
+            shard = compute_shard_from_committee_index(state, slot, CommitteeIndex(index))
+            committee_length = len(get_beacon_committee(state, slot, CommitteeIndex(shard)))
             state.current_epoch_pending_shard_headers.append(PendingShardHeader(
                 slot=slot,
                 shard=shard,

--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -671,7 +671,8 @@ def process_pending_headers(state: BeaconState) -> None:
     previous_epoch = get_previous_epoch(state)
     previous_epoch_start_slot = compute_start_slot_at_epoch(previous_epoch)
     for slot in range(previous_epoch_start_slot, previous_epoch_start_slot + SLOTS_PER_EPOCH):
-        for shard in range(get_active_shard_count(state, previous_epoch)):
+        for shard_index in range(get_active_shard_count(state, previous_epoch)):
+            shard = Shard(shard_index)
             # Pending headers for this (slot, shard) combo
             candidates = [
                 c for c in state.previous_epoch_pending_shard_headers
@@ -682,7 +683,7 @@ def process_pending_headers(state: BeaconState) -> None:
                 continue
 
             # The entire committee (and its balance)
-            full_committee = get_beacon_committee(state, slot, shard)
+            full_committee = get_beacon_committee(state, slot, CommitteeIndex(shard))
             # The set of voters who voted for each header (and their total balances)
             voting_sets = [
                 set(v for i, v in enumerate(full_committee) if c.votes[i])

--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -683,7 +683,8 @@ def process_pending_headers(state: BeaconState) -> None:
                 continue
 
             # The entire committee (and its balance)
-            full_committee = get_beacon_committee(state, slot, CommitteeIndex(shard))
+            index = compute_committee_index_from_shard(state, slot, shard)
+            full_committee = get_beacon_committee(state, slot, index)
             # The set of voters who voted for each header (and their total balances)
             voting_sets = [
                 set(v for i, v in enumerate(full_committee) if c.votes[i])

--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -756,8 +756,9 @@ def reset_pending_headers(state: BeaconState) -> None:
     next_epoch_start_slot = compute_start_slot_at_epoch(next_epoch)
     for slot in range(next_epoch_start_slot, next_epoch_start_slot + SLOTS_PER_EPOCH):
         for index in range(get_committee_count_per_slot(state, next_epoch)):
-            shard = compute_shard_from_committee_index(state, slot, CommitteeIndex(index))
-            committee_length = len(get_beacon_committee(state, slot, CommitteeIndex(shard)))
+            committee_index = CommitteeIndex(index)
+            shard = compute_shard_from_committee_index(state, slot, committee_index)
+            committee_length = len(get_beacon_committee(state, slot, committee_index))
             state.current_epoch_pending_shard_headers.append(PendingShardHeader(
                 slot=slot,
                 shard=shard,


### PR DESCRIPTION
`get_beacon_committee` and `compute_shard_from_committee_index` expect `CommitteeIndex` as their last parameter, however, other types, like `int` or `Shard` has been passed.

The PR contains a suggested fix, which just converts to `CommitteeIndex` (and additionally `shard_index` to `Shard` too), which shouldn't affect runtime behavior, just make type-checker happy.

However, the typing error may indicate there is a bug actually, i.e. it may be the case that `CommitteeIndex(shard)` is not an appropriate way to obtain a `CommitteeIndex` from `shard`. Actually, [process_shard_header](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/sharding/beacon-chain.md#process_shard_header) uses [compute_committee_index_from_shard](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/sharding/beacon-chain.md#compute_committee_index_from_shard) to obtain `CommitteeIndex` from a `shard`.

I don't have enough knowledge to disambiguate which is the correct way here.