### PR TITLE
[Sharding] Calc the right root with respect to (slot, shard) for an empty PendingShardHeader

### DIFF
--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -701,7 +701,7 @@ def process_pending_headers(state: BeaconState) -> None:
                 winning_index = voting_balances.index(max(voting_balances))
             else:
                 # If no votes, zero wins
-                winning_index = [c.commitment for c in candidates].index(DataCommitment())
+                winning_index = [c.root for c in candidates].index(Root())
             candidates[winning_index].confirmed = True
     for slot_index in range(SLOTS_PER_EPOCH):
         for shard in range(SHARD_COUNT):

--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -512,17 +512,22 @@ def update_pending_votes(state: BeaconState, attestation: Attestation) -> None:
         pending_headers = state.current_epoch_pending_shard_headers
     else:
         pending_headers = state.previous_epoch_pending_shard_headers
-    pending_header = None
-    for header in pending_headers:
-        if header.root == attestation.data.shard_header_root:
-            pending_header = header
-    assert pending_header is not None
-    assert pending_header.slot == attestation.data.slot
-    assert pending_header.shard == compute_shard_from_committee_index(
+    
+    attestation_shard = compute_shard_from_committee_index(
         state,
         attestation.data.slot,
         attestation.data.index,
     )
+    pending_header = None
+    for header in pending_headers:
+        if (
+            header.root == attestation.data.shard_header_root
+            and header.slot == attestation.data.slot
+            and header.shard == attestation_shard
+        ):
+            pending_header = header
+    assert pending_header is not None
+
     for i in range(len(pending_header.votes)):
         pending_header.votes[i] = pending_header.votes[i] or attestation.aggregation_bits[i]
 

--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -701,7 +701,7 @@ def process_pending_headers(state: BeaconState) -> None:
                 winning_index = voting_balances.index(max(voting_balances))
             else:
                 # If no votes, zero wins
-                winning_index = [c.root for c in candidates].index(Root())
+                winning_index = [c.commitment for c in candidates].index(DataCommitment())
             candidates[winning_index].confirmed = True
     for slot_index in range(SLOTS_PER_EPOCH):
         for shard in range(SHARD_COUNT):

--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -763,7 +763,7 @@ def reset_pending_headers(state: BeaconState) -> None:
                 slot=slot,
                 shard=shard,
                 commitment=DataCommitment(),
-                root=Root(),
+                root=hash_tree_root(ShardBlobHeader(slot = slot, shard = shard)),
                 votes=Bitlist[MAX_VALIDATORS_PER_COMMITTEE]([0] * committee_length),
                 confirmed=False,
             ))

--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -763,7 +763,7 @@ def reset_pending_headers(state: BeaconState) -> None:
                 slot=slot,
                 shard=shard,
                 commitment=DataCommitment(),
-                root=hash_tree_root(ShardBlobHeader(slot = slot, shard = shard)),
+                root=Root(),
                 votes=Bitlist[MAX_VALIDATORS_PER_COMMITTEE]([0] * committee_length),
                 confirmed=False,
             ))


### PR DESCRIPTION
While processing attestation we are searching for the `PendingShardHeader` in the state via it's `root`. 
So we should either 
- put the correct `root` (involving `slot, shard`) for an 'empty' header when populating `current_epoch_pending_shard_headers` 
- or stick with another search heuristics 

This PR resolves the issue via the first variant 