### PR TITLE
Simplify sync committee aggregates

### DIFF
--- a/configs/mainnet/altair.yaml
+++ b/configs/mainnet/altair.yaml
@@ -14,8 +14,6 @@ PROPORTIONAL_SLASHING_MULTIPLIER_ALTAIR: 2
 # ---------------------------------------------------------------
 # 2**10 (= 1,024)
 SYNC_COMMITTEE_SIZE: 1024
-# 2**6 (= 64)
-SYNC_PUBKEYS_PER_AGGREGATE: 64
 # 2**2 (= 4)
 INACTIVITY_SCORE_BIAS: 4
 

--- a/configs/minimal/altair.yaml
+++ b/configs/minimal/altair.yaml
@@ -14,8 +14,6 @@ PROPORTIONAL_SLASHING_MULTIPLIER_ALTAIR: 2
 # ---------------------------------------------------------------
 # [customized]
 SYNC_COMMITTEE_SIZE: 32
-# [customized]
-SYNC_PUBKEYS_PER_AGGREGATE: 16
 # 2**2 (= 4)
 INACTIVITY_SCORE_BIAS: 4
 

--- a/specs/altair/beacon-chain.md
+++ b/specs/altair/beacon-chain.md
@@ -302,6 +302,14 @@ def get_sync_committee_indices(state: BeaconState, epoch: Epoch) -> Sequence[Val
 def get_sync_committee(state: BeaconState, epoch: Epoch) -> SyncCommittee:
     """
     Return the sync committee for a given ``state`` and ``epoch``.
+
+    ``SyncCommittee`` contains an aggregate pubkey that enables
+    resource-constrained clients to save some computation when verifying
+    the sync committee's signature.
+
+    ``SyncCommittee`` can also contain duplicate pubkeys, when ``get_sync_committee_indices``
+    returns duplicate indices. Implementations must take care when handling
+    optimizations relating to aggregation and verification in the presence of duplicates.
     """
     indices = get_sync_committee_indices(state, epoch)
     pubkeys = [state.validators[index].pubkey for index in indices]

--- a/specs/altair/beacon-chain.md
+++ b/specs/altair/beacon-chain.md
@@ -409,7 +409,7 @@ def get_inactivity_penalty_deltas(state: BeaconState) -> Tuple[Sequence[Gwei], S
 
 #### Modified `slash_validator`
 
-*Note*: The function `slash_validator` is modified to use `MIN_SLASHING_PENALTY_QUOTIENT_ALTAIR` 
+*Note*: The function `slash_validator` is modified to use `MIN_SLASHING_PENALTY_QUOTIENT_ALTAIR`
 and use `PROPOSER_WEIGHT` when calculating the proposer reward.
 
 ```python

--- a/specs/altair/beacon-chain.md
+++ b/specs/altair/beacon-chain.md
@@ -119,7 +119,6 @@ This patch updates a few configuration values to move penalty parameters toward 
 | Name | Value |
 | - | - |
 | `SYNC_COMMITTEE_SIZE` | `uint64(2**10)` (= 1,024) |
-| `SYNC_PUBKEYS_PER_AGGREGATE` | `uint64(2**6)` (= 64) |
 | `INACTIVITY_SCORE_BIAS` | `uint64(4)` |
 
 ### Time parameters
@@ -212,7 +211,7 @@ class SyncAggregate(Container):
 ```python
 class SyncCommittee(Container):
     pubkeys: Vector[BLSPubkey, SYNC_COMMITTEE_SIZE]
-    pubkey_aggregates: Vector[BLSPubkey, SYNC_COMMITTEE_SIZE // SYNC_PUBKEYS_PER_AGGREGATE]
+    aggregate_pubkey: BLSPubkey
 ```
 
 ## Helper functions
@@ -306,9 +305,8 @@ def get_sync_committee(state: BeaconState, epoch: Epoch) -> SyncCommittee:
     """
     indices = get_sync_committee_indices(state, epoch)
     pubkeys = [state.validators[index].pubkey for index in indices]
-    partition = [pubkeys[i:i + SYNC_PUBKEYS_PER_AGGREGATE] for i in range(0, len(pubkeys), SYNC_PUBKEYS_PER_AGGREGATE)]
-    pubkey_aggregates = [bls.AggregatePKs(preaggregate) for preaggregate in partition]
-    return SyncCommittee(pubkeys=pubkeys, pubkey_aggregates=pubkey_aggregates)
+    aggregate_pubkey = bls.AggregatePKs(pubkeys)
+    return SyncCommittee(pubkeys=pubkeys, aggregate_pubkey=aggregate_pubkey)
 ```
 
 #### `get_base_reward_per_increment`


### PR DESCRIPTION
The current Altair spec provides multiple partitions of the full sync committee with the idea being that light clients could follow some subset of their choosing to enable a trade-off between security and performance.

However, to efficiently implement this feature the `BeaconBlock` definition in Altair needs to support a distinct (aggregate) signature for each partition stored in the `BeaconState`. And currently we only have one such signature.

To reconcile this discrepancy, we can either add multiple signatures to the `BeaconBlock` (along w/ the corresponding increase in consensus complexity) or we can omit the in-protocol aggregation. This PR presents the latter solution and I'd argue it is a better trade-off at this point in time given the relative maturity of Altair client implementations.