### PR TITLE
Adjust sync committee size and duration

### DIFF
--- a/configs/mainnet/altair.yaml
+++ b/configs/mainnet/altair.yaml
@@ -12,8 +12,8 @@ PROPORTIONAL_SLASHING_MULTIPLIER_ALTAIR: 2
 
 # Misc
 # ---------------------------------------------------------------
-# 2**10 (= 1,024)
-SYNC_COMMITTEE_SIZE: 1024
+# 2**9 (= 512)
+SYNC_COMMITTEE_SIZE: 512
 # 2**6 (= 64)
 SYNC_PUBKEYS_PER_AGGREGATE: 64
 # 2**2 (= 4)
@@ -22,8 +22,8 @@ INACTIVITY_SCORE_BIAS: 4
 
 # Time parameters
 # ---------------------------------------------------------------
-# 2**8 (= 256)
-EPOCHS_PER_SYNC_COMMITTEE_PERIOD: 256
+# 2**9 (= 512)
+EPOCHS_PER_SYNC_COMMITTEE_PERIOD: 512
 
 
 # Signature domains

--- a/specs/altair/beacon-chain.md
+++ b/specs/altair/beacon-chain.md
@@ -126,7 +126,7 @@ This patch updates a few configuration values to move penalty parameters toward 
 
 | Name | Value | Unit | Duration |
 | - | - | :-: | :-: |
-| `EPOCHS_PER_SYNC_COMMITTEE_PERIOD` | `Epoch(2**9)` (= 512) | epochs | ~54 hours |
+| `EPOCHS_PER_SYNC_COMMITTEE_PERIOD` | `uint64(2**9)` (= 512) | epochs | ~54 hours |
 
 ### Domain types
 

--- a/specs/altair/beacon-chain.md
+++ b/specs/altair/beacon-chain.md
@@ -118,7 +118,7 @@ This patch updates a few configuration values to move penalty parameters toward 
 
 | Name | Value |
 | - | - |
-| `SYNC_COMMITTEE_SIZE` | `uint64(2**10)` (= 1,024) |
+| `SYNC_COMMITTEE_SIZE` | `uint64(2**9)` (= 512) |
 | `SYNC_PUBKEYS_PER_AGGREGATE` | `uint64(2**6)` (= 64) |
 | `INACTIVITY_SCORE_BIAS` | `uint64(4)` |
 
@@ -126,7 +126,7 @@ This patch updates a few configuration values to move penalty parameters toward 
 
 | Name | Value | Unit | Duration |
 | - | - | :-: | :-: |
-| `EPOCHS_PER_SYNC_COMMITTEE_PERIOD` | `Epoch(2**8)` (= 256) | epochs | ~27 hours |
+| `EPOCHS_PER_SYNC_COMMITTEE_PERIOD` | `Epoch(2**9)` (= 512) | epochs | ~54 hours |
 
 ### Domain types
 


### PR DESCRIPTION
If we merge #2370 then we will also want to tune the sync committee parameters to be friendly to light clients (including bridges, etc.) while still maintaining a floor for security.