### PR TITLE
[Sharding] Simplify and optimize get_start_shard()

### DIFF
--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -425,17 +425,15 @@ def get_start_shard(state: BeaconState, slot: Slot) -> Shard:
     """
     current_epoch_start_slot = compute_start_slot_at_epoch(get_current_epoch(state))
     shard = state.current_epoch_start_shard
+    committee_count = get_committee_count_per_slot(state, compute_epoch_at_slot(slot))
+    active_shard_count = get_active_shard_count(state, compute_epoch_at_slot(slot))
     if slot > current_epoch_start_slot:
         # Current epoch or the next epoch lookahead
         for _slot in range(current_epoch_start_slot, slot):
-            committee_count = get_committee_count_per_slot(state, compute_epoch_at_slot(Slot(_slot)))
-            active_shard_count = get_active_shard_count(state, compute_epoch_at_slot(Slot(_slot)))
             shard = (shard + committee_count) % active_shard_count
     elif slot < current_epoch_start_slot:
         # Previous epoch
         for _slot in list(range(slot, current_epoch_start_slot))[::-1]:
-            committee_count = get_committee_count_per_slot(state, compute_epoch_at_slot(Slot(_slot)))
-            active_shard_count = get_active_shard_count(state, compute_epoch_at_slot(Slot(_slot)))
             # Ensure positive
             shard = (shard + active_shard_count - committee_count) % active_shard_count
     return Shard(shard)

--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -424,19 +424,17 @@ def get_start_shard(state: BeaconState, slot: Slot) -> Shard:
     Return the start shard at ``slot``.
     """
     current_epoch_start_slot = compute_start_slot_at_epoch(get_current_epoch(state))
-    shard = state.current_epoch_start_shard
     committee_count = get_committee_count_per_slot(state, compute_epoch_at_slot(slot))
     active_shard_count = get_active_shard_count(state, compute_epoch_at_slot(slot))
-    if slot > current_epoch_start_slot:
+    if slot >= current_epoch_start_slot:
         # Current epoch or the next epoch lookahead
-        for _slot in range(current_epoch_start_slot, slot):
-            shard = (shard + committee_count) % active_shard_count
+        slots_diff = slot - current_epoch_start_slot
+        return (state.current_epoch_start_shard + slots_diff) % active_shard_count
     elif slot < current_epoch_start_slot:
         # Previous epoch
-        for _slot in list(range(slot, current_epoch_start_slot))[::-1]:
-            # Ensure positive
-            shard = (shard + active_shard_count - committee_count) % active_shard_count
-    return Shard(shard)
+        slots_diff = current_epoch_start_slot - slot
+        return (state.current_epoch_start_shard + (active_shard_count - committee_count) * slots_diff) 
+            % active_shard_count
 ```
 
 #### `compute_shard_from_committee_index`


### PR DESCRIPTION
- `committee_count` and `active_shard_count` are invariants in the loops as `compute_epoch_at_slot(_slot)` would always be equal to `compute_epoch_at_slot(slot)`
- replace with multiplication the loops which effectively do N `add by module` operations 

From my perspective the code looks a bit more clear and clean this way. 