### PR TITLE
Use stable sync committee indices when processing block rewards

### DIFF
--- a/specs/altair/beacon-chain.md
+++ b/specs/altair/beacon-chain.md
@@ -571,7 +571,11 @@ def process_sync_committee(state: BeaconState, aggregate: SyncAggregate) -> None
     proposer_reward = Gwei(participant_reward * PROPOSER_WEIGHT // (WEIGHT_DENOMINATOR - PROPOSER_WEIGHT))
 
     # Apply participant and proposer rewards
-    committee_indices = get_sync_committee_indices(state, get_current_epoch(state))
+    committee_indices = []
+    pubkeys = [v.pubkey for v in state.validators]
+    for pubkey in state.current_sync_committee.pubkeys:
+        index = pubkeys.index(pubkey)
+        committee_indices.append(ValidatorIndex(index))
     participant_indices = [index for index, bit in zip(committee_indices, aggregate.sync_committee_bits) if bit]
     for participant_index in participant_indices:
         increase_balance(state, participant_index, participant_reward)


### PR DESCRIPTION
Addresses a bug surfaced in #2392 thanks to @michaelsproul.

It is possible that the `effective_balance`s of the active validator set change enough _during_ a sync committee period so that the shuffling computed at the period boundary (`epoch % EPOCHS_PER_SYNC_COMMITTEE_PERIOD == 0`) changes.

This implies `get_sync_committee_indices` is not stable across a sync committee period and so should not be relied upon while computing the members of the sync committee throughout such a period. This function is currently used during the processing of sync committee per-block rewards so this PR uses the (fixed) sync committee set in the `BeaconState`, rather than computing on-demand for each block.