### PR TITLE
Shard fees: `adjustment_quotient` to use `previous_epoch`

### DIFF
--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -714,11 +714,11 @@ def process_pending_headers(state: BeaconState) -> None:
 ```python
 def charge_confirmed_header_fees(state: BeaconState) -> None:
     new_gasprice = state.shard_gasprice
+    previous_epoch = get_previous_epoch(state)
     adjustment_quotient = (
-        get_active_shard_count(state, get_current_epoch(state))
+        get_active_shard_count(state, previous_epoch)
         * SLOTS_PER_EPOCH * GASPRICE_ADJUSTMENT_COEFFICIENT
     )
-    previous_epoch = get_previous_epoch(state)
     previous_epoch_start_slot = compute_start_slot_at_epoch(previous_epoch)
     for slot in range(previous_epoch_start_slot, previous_epoch_start_slot + SLOTS_PER_EPOCH):
         for shard_index in range(get_active_shard_count(state, previous_epoch)):


### PR DESCRIPTION
I think `adjustment_quotient`'s shard count should reference to previous epoch similar to accounting of header confirmation and fee calculation