### PR TITLE
Clarify fork upgrade conditions for Altair

### DIFF
--- a/specs/altair/fork.md
+++ b/specs/altair/fork.md
@@ -40,9 +40,9 @@ Note that for the pure Altair networks, we don't apply `upgrade_to_altair` since
 
 If `state.slot % SLOTS_PER_EPOCH == 0` and `compute_epoch_at_slot(state.slot) == ALTAIR_FORK_EPOCH`, an irregular state change is made to upgrade to Altair.
 
-The upgrade occurs after the inner loop of `process_slots` that sets `state.slot` equal to `ALTAIR_FORK_EPOCH * SLOTS_PER_EPOCH` finishes.
+The upgrade occurs after the completion of the inner loop of `process_slots` that sets `state.slot` equal to `ALTAIR_FORK_EPOCH * SLOTS_PER_EPOCH`.
 Care must be taken when transitioning through the fork boundary as implementations will need a modified state transition function that deviates from the Phase 0 spec.
-In particular, the `state_transition` function defined in the Phase 0 spec will not expose the correct time to execute the upgrade in the presence of skipped slots at the fork boundary.
+In particular, the outer `state_transition` function defined in the Phase 0 spec will not expose the precise fork slot to execute the upgrade in the presence of skipped slots at the fork boundary. Instead the logic must be within `process_slots`.
 
 ```python
 def upgrade_to_altair(pre: phase0.BeaconState) -> BeaconState:

--- a/specs/altair/fork.md
+++ b/specs/altair/fork.md
@@ -38,7 +38,11 @@ Note that for the pure Altair networks, we don't apply `upgrade_to_altair` since
 
 ### Upgrading the state
 
-After `process_slots` of Phase 0 finishes, if `state.slot % SLOTS_PER_EPOCH == 0` and `compute_epoch_at_slot(state.slot) == ALTAIR_FORK_EPOCH`, an irregular state change is made to upgrade to Altair.
+If `state.slot % SLOTS_PER_EPOCH == 0` and `compute_epoch_at_slot(state.slot) == ALTAIR_FORK_EPOCH`, an irregular state change is made to upgrade to Altair.
+
+The upgrade occurs after the inner loop of `process_slots` that sets `state.slot` equal to `ALTAIR_FORK_EPOCH * SLOTS_PER_EPOCH` finishes.
+Care must be taken when transitioning through the fork boundary as implementations will need a modified state transition function that deviates from the Phase 0 spec.
+In particular, the `state_transition` function defined in the Phase 0 spec will not expose the correct time to execute the upgrade in the presence of skipped slots at the fork boundary.
 
 ```python
 def upgrade_to_altair(pre: phase0.BeaconState) -> BeaconState:


### PR DESCRIPTION
In lieu of handling the details of managing the forking conditions in Python code as we started exploring in #2391, this PR just adds some clarifying prose.

Supersedes #2391.