### PR TITLE
Return non-duplicated sync committee subnets

### DIFF
--- a/specs/altair/validator.md
+++ b/specs/altair/validator.md
@@ -292,7 +292,7 @@ The validator broadcasts the assembled signature to the assigned subnet, the `sy
 The `subnet_id` is derived from the position in the sync committee such that the sync committee is divided into "subcommittees".
 `subnet_id` can be computed via `compute_subnets_for_sync_committee(state, validator_index)` where `state` is a `BeaconState` during the matching sync committee period.
 
-*Note*: This function returns multiple subnets if a given validator index is included multiple times in a given sync committee across multiple subcommittees.
+*Note*: This function returns multiple non-duplicated subnets if a given validator index is included multiple times in a given sync committee across multiple subcommittees.
 
 ```python
 def compute_subnets_for_sync_committee(state: BeaconState, validator_index: ValidatorIndex) -> Sequence[uint64]:
@@ -304,10 +304,10 @@ def compute_subnets_for_sync_committee(state: BeaconState, validator_index: Vali
 
     target_pubkey = state.validators[validator_index].pubkey
     sync_committee_indices = [index for index, pubkey in enumerate(sync_committee.pubkeys) if pubkey == target_pubkey]
-    return [
+    return set([
         uint64(index // (SYNC_COMMITTEE_SIZE // SYNC_COMMITTEE_SUBNET_COUNT))
         for index in sync_committee_indices
-    ]
+    ])
 ```
 
 *Note*: Subnet assignment does not change during the duration of a validator's assignment to a given sync committee.

--- a/specs/altair/validator.md
+++ b/specs/altair/validator.md
@@ -292,10 +292,10 @@ The validator broadcasts the assembled signature to the assigned subnet, the `sy
 The `subnet_id` is derived from the position in the sync committee such that the sync committee is divided into "subcommittees".
 `subnet_id` can be computed via `compute_subnets_for_sync_committee(state, validator_index)` where `state` is a `BeaconState` during the matching sync committee period.
 
-*Note*: This function returns multiple non-duplicated subnets if a given validator index is included multiple times in a given sync committee across multiple subcommittees.
+*Note*: This function returns multiple deduplicated subnets if a given validator index is included multiple times in a given sync committee across multiple subcommittees.
 
 ```python
-def compute_subnets_for_sync_committee(state: BeaconState, validator_index: ValidatorIndex) -> Sequence[uint64]:
+def compute_subnets_for_sync_committee(state: BeaconState, validator_index: ValidatorIndex) -> Set[uint64]:
     next_slot_epoch = compute_epoch_at_slot(Slot(state.slot + 1))
     if compute_sync_committee_period(get_current_epoch(state)) == compute_sync_committee_period(next_slot_epoch):
         sync_committee = state.current_sync_committee

--- a/tests/core/pyspec/eth2spec/test/altair/unittests/validator/test_validator.py
+++ b/tests/core/pyspec/eth2spec/test/altair/unittests/validator/test_validator.py
@@ -149,9 +149,10 @@ def _subnet_for_sync_committee_index(spec, i):
 
 
 def _get_expected_subnets_by_pubkey(sync_committee_members):
-    expected_subnets_by_pubkey = defaultdict(list)
+    # Build deduplicated set for each pubkey
+    expected_subnets_by_pubkey = defaultdict(set)
     for (subnet, pubkey) in sync_committee_members:
-        expected_subnets_by_pubkey[pubkey].append(subnet)
+        expected_subnets_by_pubkey[pubkey].add(subnet)
     return expected_subnets_by_pubkey
 
 


### PR DESCRIPTION
Return non duplicated subnets by applying `set` on the return

Example:
```python
BeaconState {
 Validators: {{0xA}, {0xB}, {0xC}}
 SyncCommittee: {{0xA}, {0xA}, {0xA}, {0xB}, {0xB}, {0xC}}
}
```
Assuming `SYNC_COMMITTEE_SIZE // SYNC_COMMITTEE_SUBNET_COUNT` is 1,  instead of returning `[0,0,0,1,1,2]`, it would just return `[0,1,2]`