### PR TITLE
remove resourceunavailable for more discussion

### DIFF
--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -567,8 +567,6 @@ The response code can have one of the following values, encoded as a single unsi
   The response payload adheres to the `ErrorMessage` schema (described below).
 -  2: **ServerError** -- the responder encountered an error while processing the request.
   The response payload adheres to the `ErrorMessage` schema (described below).
--  3: **ResourceUnavailable** -- the responder does not have requested resource.
-  The response payload adheres to the `ErrorMessage` schema (described below).
 
 Clients MAY use response codes above `128` to indicate alternative, erroneous request-specific responses.
 


### PR DESCRIPTION
Based on conversations with @arnetheduck this error code is a bit ambiguous/under-specified for all of the req/resp message types. Specifically, we need to ensure that the MUSTs and SHOULDs of various calls are sufficient and safe given this new code.

We are going to pull this code out for the `v1.1.0-alpha.4` release today, open a separate issue, and work through these details *BY WEDNESDAY MAY 19* in preparation for spec freeze on Friday

Go to #2414 for discussion