### PR TITLE
Align fork epoch with the start of `EPOCHS_PER_SYNC_COMMITTEE_PERIOD`

### DIFF
--- a/configs/mainnet/altair.yaml
+++ b/configs/mainnet/altair.yaml
@@ -37,8 +37,8 @@ DOMAIN_CONTRIBUTION_AND_PROOF: 0x09000000
 # ---------------------------------------------------------------
 # 0x01000000
 ALTAIR_FORK_VERSION: 0x01000000
-# TBD
-ALTAIR_FORK_EPOCH: 18446744073709551615
+# TBD, temporarily: 2**63
+ALTAIR_FORK_EPOCH: 9223372036854775808
 
 
 # Sync protocol

--- a/configs/mainnet/merge.yaml
+++ b/configs/mainnet/merge.yaml
@@ -3,5 +3,5 @@
 # Fork
 # ---------------------------------------------------------------
 MERGE_FORK_VERSION: 0x02000000
-# TBD, temporarily max uint64 value: 2**64 - 1
-MERGE_FORK_EPOCH: 18446744073709551615
+# TBD, temporarily: 2**63
+MERGE_FORK_EPOCH: 9223372036854775808

--- a/configs/mainnet/sharding.yaml
+++ b/configs/mainnet/sharding.yaml
@@ -3,8 +3,8 @@
 # Fork
 # ---------------------------------------------------------------
 SHARDING_FORK_VERSION: 0x03000000
-# TBD, temporarily max uint64 value: 2**64 - 1
-SHARDING_FORK_EPOCH: 18446744073709551615
+# TBD, temporarily: 2**63
+SHARDING_FORK_EPOCH: 9223372036854775808
 
 
 # Beacon-chain

--- a/configs/minimal/altair.yaml
+++ b/configs/minimal/altair.yaml
@@ -38,7 +38,7 @@ DOMAIN_CONTRIBUTION_AND_PROOF: 0x09000000
 # [customized] Highest byte set to 0x01 to avoid collisions with mainnet versioning
 ALTAIR_FORK_VERSION: 0x01000001
 # [customized]
-ALTAIR_FORK_EPOCH: 18446744073709551615
+ALTAIR_FORK_EPOCH: 9223372036854775808
 
 
 # Sync protocol

--- a/configs/minimal/merge.yaml
+++ b/configs/minimal/merge.yaml
@@ -3,5 +3,5 @@
 # Fork
 # ---------------------------------------------------------------
 MERGE_FORK_VERSION: 0x02000001
-# TBD, temporarily max uint64 value: 2**64 - 1
-MERGE_FORK_EPOCH: 18446744073709551615
+# [customized]
+MERGE_FORK_EPOCH: 9223372036854775808

--- a/configs/minimal/sharding.yaml
+++ b/configs/minimal/sharding.yaml
@@ -3,8 +3,8 @@
 # Fork
 # ---------------------------------------------------------------
 SHARDING_FORK_VERSION: 0x03000001
-# TBD, temporarily max uint64 value: 2**64 - 1
-MERGE_FORK_EPOCH: 18446744073709551615
+# [customized]
+MERGE_FORK_EPOCH: 9223372036854775808
 
 
 # Beacon-chain

--- a/setup.py
+++ b/setup.py
@@ -437,6 +437,7 @@ def get_generalized_index(ssz_class: Any, *path: Sequence[Union[int, SSZVariable
     @classmethod
     def invariant_checks(cls) -> str:
         return '''
+assert ALTAIR_FORK_EPOCH % EPOCHS_PER_SYNC_COMMITTEE_PERIOD == 0
 assert (
     TIMELY_HEAD_WEIGHT + TIMELY_SOURCE_WEIGHT + TIMELY_TARGET_WEIGHT + SYNC_REWARD_WEIGHT + PROPOSER_WEIGHT
 ) == WEIGHT_DENOMINATOR'''

--- a/specs/altair/fork.md
+++ b/specs/altair/fork.md
@@ -26,7 +26,7 @@ Warning: this configuration is not definitive.
 | Name | Value |
 | - | - |
 | `ALTAIR_FORK_VERSION` | `Version('0x01000000')` |
-| `ALTAIR_FORK_EPOCH` | `Epoch(18446744073709551615)` **TBD** |
+| `ALTAIR_FORK_EPOCH` | `Epoch(9223372036854775808)` **TBD** |
 
 ## Fork to Altair
 

--- a/specs/merge/beacon-chain.md
+++ b/specs/merge/beacon-chain.md
@@ -68,7 +68,7 @@ Warning: this configuration is not definitive.
 | Name | Value |
 | - | - |
 | `MERGE_FORK_VERSION` | `Version('0x02000000')` |
-| `MERGE_FORK_EPOCH` | `Epoch(18446744073709551615)` **TBD** |
+| `MERGE_FORK_EPOCH` | `Epoch(9223372036854775808)` **TBD** |
 | `TRANSITION_TOTAL_DIFFICULTY` | **TBD** |
 
 ## Containers


### PR DESCRIPTION
### Issue
* **Suggestion**: align fork epoch with the start of `EPOCHS_PER_SYNC_COMMITTEE_PERIOD`.
* **Pros**:
    1. More stable network at the starting epochs of the fork.
    2. Aesthetically align the time setup.
* **Cons**: It would be more difficult to coordinate the suitable clock time.

If we do it, I'd like to add an invariant check to the pyspec builder. Therefore we have to adjust the temporary stub `ALTAIR_FORK_EPOCH` to the number that matches the assertion.

### Proposal 
1. Update the TBD `*_FORK_EPOCH` stub to `2**63`.
2. Add `ALTAIR_FORK_EPOCH % EPOCHS_PER_SYNC_COMMITTEE_PERIOD == 0` checks to pyspec builder.