### PR TITLE
sharding: minor config fixes

### DIFF
--- a/configs/mainnet/sharding.yaml
+++ b/configs/mainnet/sharding.yaml
@@ -34,11 +34,6 @@ MAX_GASPRICE: 8589934592
 # 2**3 (= 8) Gwei
 MIN_GASPRICE: 8
 
-# Time parameters
-# ---------------------------------------------------------------
-# 2**8 (= 256) | epochs
-SHARD_COMMITTEE_PERIOD: 256
-
 # Signature domains
 # ---------------------------------------------------------------
 DOMAIN_SHARD_PROPOSER: 0x80000000

--- a/configs/minimal/sharding.yaml
+++ b/configs/minimal/sharding.yaml
@@ -4,7 +4,7 @@
 # ---------------------------------------------------------------
 SHARDING_FORK_VERSION: 0x03000001
 # TBD, temporarily max uint64 value: 2**64 - 1
-MERGE_FORK_EPOCH: 18446744073709551615
+SHARDING_FORK_EPOCH: 18446744073709551615
 
 
 # Beacon-chain
@@ -33,11 +33,6 @@ TARGET_SAMPLES_PER_BLOCK: 1024
 MAX_GASPRICE: 8589934592
 # 2**3 (= 8) Gwei
 MIN_GASPRICE: 8
-
-# Time parameters
-# ---------------------------------------------------------------
-# 2**8 (= 256) | epochs
-SHARD_COMMITTEE_PERIOD: 256
 
 # Signature domains
 # ---------------------------------------------------------------

--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -16,7 +16,6 @@
   - [Shard block configs](#shard-block-configs)
   - [Precomputed size verification points](#precomputed-size-verification-points)
   - [Gwei values](#gwei-values)
-  - [Time parameters](#time-parameters)
   - [Domain types](#domain-types)
 - [Updated containers](#updated-containers)
   - [`AttestationData`](#attestationdata)
@@ -122,12 +121,6 @@ The following values are (non-configurable) constants used throughout the specif
 | - | - | - | - |
 | `MAX_GASPRICE` | `Gwei(2**33)` (= 8,589,934,592) | Gwei | Max gasprice charged for a TARGET-sized shard block |  
 | `MIN_GASPRICE` | `Gwei(2**3)` (= 8) | Gwei | Min gasprice charged for a TARGET-sized shard block |
-
-### Time parameters
-
-| Name | Value | Unit | Duration |
-| - | - | :-: | :-: |
-| `SHARD_COMMITTEE_PERIOD` | `Epoch(2**8)` (= 256) | epochs | ~27 hours |
 
 ### Domain types
 


### PR DESCRIPTION
- Remove duplicate sharding config var `SHARD_COMMITTEE_PERIOD`: it was already defined in phase0
- Fix minimal-sharding-config fork epoch name