### PR TITLE
Fix `PARTICIPATION_FLAG_WEIGHTS` to use correct head weight

### DIFF
--- a/specs/altair/beacon-chain.md
+++ b/specs/altair/beacon-chain.md
@@ -99,7 +99,7 @@ Altair is the first beacon chain hard fork. Its main features are:
 | Name | Value |
 | - | - |
 | `G2_POINT_AT_INFINITY` | `BLSSignature(b'\xc0' + b'\x00' * 95)` |
-| `PARTICIPATION_FLAG_WEIGHTS` | `[TIMELY_SOURCE_WEIGHT, TIMELY_TARGET_WEIGHT, TIMELY_HEAD_FLAG_INDEX]` |
+| `PARTICIPATION_FLAG_WEIGHTS` | `[TIMELY_SOURCE_WEIGHT, TIMELY_TARGET_WEIGHT, TIMELY_HEAD_WEIGHT]` |
 
 ## Configuration
 


### PR DESCRIPTION
Replacing `TIMELY_HEAD_FLAG_INDEX` with `TIMELY_HEAD_WEIGHT`. This was discovered by my spec test implementation in alpha.3
