### PR TITLE
fix a typo: use `TIMELY_HEAD_WEIGHT` instead of `_INDEX`

### DIFF
--- a/specs/altair/beacon-chain.md
+++ b/specs/altair/beacon-chain.md
@@ -99,7 +99,7 @@ Altair is the first beacon chain hard fork. Its main features are:
 | Name | Value |
 | - | - |
 | `G2_POINT_AT_INFINITY` | `BLSSignature(b'\xc0' + b'\x00' * 95)` |
-| `PARTICIPATION_FLAG_WEIGHTS` | `[TIMELY_SOURCE_WEIGHT, TIMELY_TARGET_WEIGHT, TIMELY_HEAD_FLAG_INDEX]` |
+| `PARTICIPATION_FLAG_WEIGHTS` | `[TIMELY_SOURCE_WEIGHT, TIMELY_TARGET_WEIGHT, TIMELY_HEAD_WEIGHT]` |
 
 ## Configuration
 


### PR DESCRIPTION
Seems to be a typo in [PARTICIPATION_FLAG_WEIGHTS](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/altair/beacon-chain.md#misc): `TIMELY_HEAD_FLAG_INDEX` used, while other elements are of `_WEIGHT` kind