### PR TITLE
Fix typing problem in `sharding.process_block`

### DIFF
--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -459,7 +459,9 @@ def process_block(state: BeaconState, block: BeaconBlock) -> None:
     process_randao(state, block.body)
     process_eth1_data(state, block.body)
     process_operations(state, block.body)  # [Modified in Sharding]
-    process_execution_payload(state, block.body)  # [New in Merge]
+    # Pre-merge, skip execution payload processing
+    if is_execution_enabled(state, block):
+        process_execution_payload(state, block.body.execution_payload, EXECUTION_ENGINE)  # [New in Merge]
 ```
 
 #### Operations


### PR DESCRIPTION
There is a typing problem in [sharding.process_block](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/sharding/beacon-chain.md#block-processing): it calls [merge.process_execution_payload](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/merge/beacon-chain.md#process_execution_payload), but supplies wrong amount of arguments - two instead of three, second one being of a wrong type.

It looks like [this](https://github.com/ethereum/eth2.0-specs/commit/521cffc3e9c4de950489470eb1eefbf2871a5c33) `merge` fix (and perhaps some others) hasn't been yet propagated to `sharding`.

I tried to replicate propagate the change to `sharding`, however, not 100% sure about the `if is_execution_enabled(state, block):` line.