### PR TITLE
Altair fork: add a link

### DIFF
--- a/specs/altair/fork.md
+++ b/specs/altair/fork.md
@@ -41,8 +41,8 @@ Note that for the pure Altair networks, we don't apply `upgrade_to_altair` since
 If `state.slot % SLOTS_PER_EPOCH == 0` and `compute_epoch_at_slot(state.slot) == ALTAIR_FORK_EPOCH`, an irregular state change is made to upgrade to Altair.
 
 The upgrade occurs after the completion of the inner loop of `process_slots` that sets `state.slot` equal to `ALTAIR_FORK_EPOCH * SLOTS_PER_EPOCH`.
-Care must be taken when transitioning through the fork boundary as implementations will need a modified state transition function that deviates from the Phase 0 spec.
-In particular, the outer `state_transition` function defined in the Phase 0 spec will not expose the precise fork slot to execute the upgrade in the presence of skipped slots at the fork boundary. Instead the logic must be within `process_slots`.
+Care must be taken when transitioning through the fork boundary as implementations will need a modified [state transition function](../phase0/beacon-chain.md#beacon-chain-state-transition-function) that deviates from the Phase 0 document.
+In particular, the outer `state_transition` function defined in the Phase 0 document will not expose the precise fork slot to execute the upgrade in the presence of skipped slots at the fork boundary. Instead the logic must be within `process_slots`.
 
 ```python
 def translate_participation(state: BeaconState, pending_attestations: Sequence[phase0.PendingAttestation]) -> None:


### PR DESCRIPTION
Two non-substantive changes:
 - Both Altair's validator and network docs refer Phase 0 spec as Phase 0 document, I thought it would be nice to align here
 - Adding a link to the state transition function from the Phase 0 document for ease of navigation