### PR TITLE
add resourceunavailable error code with more guidance

### DIFF
--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -756,7 +756,7 @@ where `current_epoch` is defined by the current wall-clock time,
 and clients MUST support serving requests of blocks on this range.
 
 Peers that are unable to reply to block requests within the `MIN_EPOCHS_FOR_BLOCK_REQUESTS`
-epoch range SHOULD respond with error code `3: **ResourceUnavailable**`.
+epoch range SHOULD respond with error code `3: ResourceUnavailable`.
 Such peers that are unable to successfully reply to this range of requests MAY get descored
 or disconnected at any time.
 

--- a/specs/phase0/p2p-interface.md
+++ b/specs/phase0/p2p-interface.md
@@ -567,6 +567,9 @@ The response code can have one of the following values, encoded as a single unsi
   The response payload adheres to the `ErrorMessage` schema (described below).
 -  2: **ServerError** -- the responder encountered an error while processing the request.
   The response payload adheres to the `ErrorMessage` schema (described below).
+-  3: **ResourceUnavailable** -- the responder does not have requested resource.
+  The response payload adheres to the `ErrorMessage` schema (described below).
+  *Note*: This response code is only valid as a response to `BlocksByRange`.
 
 Clients MAY use response codes above `128` to indicate alternative, erroneous request-specific responses.
 
@@ -752,8 +755,10 @@ Clients MUST keep a record of signed blocks seen on the epoch range
 where `current_epoch` is defined by the current wall-clock time,
 and clients MUST support serving requests of blocks on this range.
 
-Peers that are unable to reply to block requests within the
-`MIN_EPOCHS_FOR_BLOCK_REQUESTS` epoch range MAY get descored or disconnected at any time.
+Peers that are unable to reply to block requests within the `MIN_EPOCHS_FOR_BLOCK_REQUESTS`
+epoch range SHOULD respond with error code `3: **ResourceUnavailable**`.
+Such peers that are unable to successfully reply to this range of requests MAY get descored
+or disconnected at any time.
 
 *Note*: The above requirement implies that nodes that start from a recent weak subjectivity checkpoint
 MUST backfill the local block database to at least epoch `current_epoch - MIN_EPOCHS_FOR_BLOCK_REQUESTS`


### PR DESCRIPTION
Add `ResourceUnavailable` back in with explicit guidance that it is currently only a valid response for `BlocksByRange` and also that such unsynced nodes `SHOULD` respond using it.

 Conversations on #2414 debate if/how this should be inserted. The crux is that some teams think the extra information will be valuable whereas others think it is only cumbersome without reducing complexity. I think the restricted use in this PR is a reasonable compromise.

Additionally for any client that finds the introduction of this error case as cumbersome/complex, I suggest that the receiving of this error code just gets put into the already existing `if bad_block_range_response()` control flow. If the information is indeed not valuable, it can easily just be lumped into the existing "bad response" code.