### PR TITLE
Inactivity updates test generation, implement new participation flag updates testing

### DIFF
--- a/tests/core/pyspec/eth2spec/test/altair/epoch_processing/test_process_participation_flag_updates.py
+++ b/tests/core/pyspec/eth2spec/test/altair/epoch_processing/test_process_participation_flag_updates.py
@@ -1,0 +1,110 @@
+from random import Random
+
+from eth2spec.test.helpers.constants import MINIMAL
+from eth2spec.test.context import (
+    with_altair_and_later,
+    with_custom_state,
+    spec_test, spec_state_test,
+    with_presets,
+    single_phase,
+)
+from eth2spec.test.helpers.state import next_epoch_via_block
+from eth2spec.test.helpers.epoch_processing import run_epoch_processing_with
+
+
+def run_process_participation_flag_updates(spec, state):
+    yield from run_epoch_processing_with(spec, state, 'process_participation_flag_updates')
+
+
+@with_altair_and_later
+@spec_state_test
+def test_zeroed(spec, state):
+    next_epoch_via_block(spec, state)
+    state.current_epoch_participation = [0] * len(state.validators)
+    state.previous_epoch_participation = [0] * len(state.validators)
+    yield from run_process_participation_flag_updates(spec, state)
+
+
+@with_altair_and_later
+@spec_state_test
+def test_filled(spec, state):
+    next_epoch_via_block(spec, state)
+
+    full_flags = spec.ParticipationFlags(0)
+    for flag_index in range(len(spec.PARTICIPATION_FLAG_WEIGHTS)):
+        full_flags = spec.add_flag(full_flags, flag_index)
+
+    state.previous_epoch_participation = [full_flags] * len(state.validators)
+    state.current_epoch_participation = [full_flags] * len(state.validators)
+
+    yield from run_process_participation_flag_updates(spec, state)
+
+
+def random_flags(spec, state, seed: int, previous=True, current=True):
+    rng = Random(seed)
+    count = len(state.validators)
+    max_flag_value_excl = 2**len(spec.PARTICIPATION_FLAG_WEIGHTS)
+    if previous:
+        state.previous_epoch_participation = [rng.randrange(0, max_flag_value_excl) for _ in range(count)]
+    if current:
+        state.current_epoch_participation = [rng.randrange(0, max_flag_value_excl) for _ in range(count)]
+
+
+@with_altair_and_later
+@spec_state_test
+def test_random(spec, state):
+    next_epoch_via_block(spec, state)
+    random_flags(spec, state, 10)
+    yield from run_process_participation_flag_updates(spec, state)
+
+
+@with_altair_and_later
+@spec_state_test
+def test_random_genesis(spec, state):
+    random_flags(spec, state, 11)
+    yield from run_process_participation_flag_updates(spec, state)
+
+
+@with_altair_and_later
+@spec_state_test
+def test_zeroing(spec, state):
+    next_epoch_via_block(spec, state)
+    random_flags(spec, state, 12, current=False)
+    state.current_epoch_participation = [0] * len(state.validators)
+    yield from run_process_participation_flag_updates(spec, state)
+
+
+@with_altair_and_later
+@spec_state_test
+def test_prev_zeroed(spec, state):
+    next_epoch_via_block(spec, state)
+    random_flags(spec, state, 13, previous=False)
+    state.previous_epoch_participation = [0] * len(state.validators)
+    yield from run_process_participation_flag_updates(spec, state)
+
+
+def custom_validator_count(factor: float):
+    def initializer(spec):
+        num_validators = spec.SLOTS_PER_EPOCH * spec.MAX_COMMITTEES_PER_SLOT * spec.TARGET_COMMITTEE_SIZE
+        return [spec.MAX_EFFECTIVE_BALANCE] * int(float(int(num_validators)) * factor)
+    return initializer
+
+
+@with_altair_and_later
+@with_presets([MINIMAL], reason="mainnet config requires too many pre-generated public/private keys")
+@spec_test
+@with_custom_state(balances_fn=custom_validator_count(1.3), threshold_fn=lambda spec: spec.config.EJECTION_BALANCE)
+@single_phase
+def test_slightly_larger_random(spec, state):
+    random_flags(spec, state, 14)
+    yield from run_process_participation_flag_updates(spec, state)
+
+
+@with_altair_and_later
+@with_presets([MINIMAL], reason="mainnet config requires too many pre-generated public/private keys")
+@spec_test
+@with_custom_state(balances_fn=custom_validator_count(2.6), threshold_fn=lambda spec: spec.config.EJECTION_BALANCE)
+@single_phase
+def test_large_random(spec, state):
+    random_flags(spec, state, 15)
+    yield from run_process_participation_flag_updates(spec, state)

--- a/tests/core/pyspec/eth2spec/test/altair/epoch_processing/test_process_participation_flag_updates.py
+++ b/tests/core/pyspec/eth2spec/test/altair/epoch_processing/test_process_participation_flag_updates.py
@@ -21,7 +21,7 @@ def run_process_participation_flag_updates(spec, state):
 
 @with_altair_and_later
 @spec_state_test
-def test_zeroed(spec, state):
+def test_all_zeroed(spec, state):
     next_epoch_via_block(spec, state)
     state.current_epoch_participation = [0] * len(state.validators)
     state.previous_epoch_participation = [0] * len(state.validators)
@@ -70,7 +70,7 @@ def test_random_genesis(spec, state):
 
 @with_altair_and_later
 @spec_state_test
-def test_zeroing(spec, state):
+def test_current_epoch_zeroed(spec, state):
     next_epoch_via_block(spec, state)
     random_flags(spec, state, 12, current=False)
     state.current_epoch_participation = [0] * len(state.validators)
@@ -79,7 +79,7 @@ def test_zeroing(spec, state):
 
 @with_altair_and_later
 @spec_state_test
-def test_prev_zeroed(spec, state):
+def test_previous_epoch_zeroed(spec, state):
     next_epoch_via_block(spec, state)
     random_flags(spec, state, 13, previous=False)
     state.previous_epoch_participation = [0] * len(state.validators)

--- a/tests/core/pyspec/eth2spec/test/altair/epoch_processing/test_process_participation_flag_updates.py
+++ b/tests/core/pyspec/eth2spec/test/altair/epoch_processing/test_process_participation_flag_updates.py
@@ -13,7 +13,7 @@ from eth2spec.test.helpers.epoch_processing import run_epoch_processing_with
 
 
 def run_process_participation_flag_updates(spec, state):
-    old = state.current_epoch_participation
+    old = state.current_epoch_participation.copy()
     yield from run_epoch_processing_with(spec, state, 'process_participation_flag_updates')
     assert state.current_epoch_participation == [0] * len(state.validators)
     assert state.previous_epoch_participation == old
@@ -99,6 +99,7 @@ def custom_validator_count(factor: float):
 @with_custom_state(balances_fn=custom_validator_count(1.3), threshold_fn=lambda spec: spec.config.EJECTION_BALANCE)
 @single_phase
 def test_slightly_larger_random(spec, state):
+    next_epoch_via_block(spec, state)
     random_flags(spec, state, 14)
     yield from run_process_participation_flag_updates(spec, state)
 
@@ -109,5 +110,6 @@ def test_slightly_larger_random(spec, state):
 @with_custom_state(balances_fn=custom_validator_count(2.6), threshold_fn=lambda spec: spec.config.EJECTION_BALANCE)
 @single_phase
 def test_large_random(spec, state):
+    next_epoch_via_block(spec, state)
     random_flags(spec, state, 15)
     yield from run_process_participation_flag_updates(spec, state)

--- a/tests/core/pyspec/eth2spec/test/altair/epoch_processing/test_process_participation_flag_updates.py
+++ b/tests/core/pyspec/eth2spec/test/altair/epoch_processing/test_process_participation_flag_updates.py
@@ -13,7 +13,10 @@ from eth2spec.test.helpers.epoch_processing import run_epoch_processing_with
 
 
 def run_process_participation_flag_updates(spec, state):
+    old = state.current_epoch_participation
     yield from run_epoch_processing_with(spec, state, 'process_participation_flag_updates')
+    assert state.current_epoch_participation == [0] * len(state.validators)
+    assert state.previous_epoch_participation == old
 
 
 @with_altair_and_later

--- a/tests/formats/epoch_processing/README.md
+++ b/tests/formats/epoch_processing/README.md
@@ -33,7 +33,7 @@ The provided pre-state is already transitioned to just before the specific sub-t
 Sub-transitions:
 
 - `justification_and_finalization`
-- `inactivity_penalty_updates` (Altair)
+- `inactivity_updates` (Altair)
 - `rewards_and_penalties`
 - `registry_updates`
 - `slashings`

--- a/tests/formats/epoch_processing/README.md
+++ b/tests/formats/epoch_processing/README.md
@@ -33,7 +33,7 @@ The provided pre-state is already transitioned to just before the specific sub-t
 Sub-transitions:
 
 - `justification_and_finalization`
-- `inactivity_penalty_updates`
+- `inactivity_penalty_updates` (Altair)
 - `rewards_and_penalties`
 - `registry_updates`
 - `slashings`
@@ -42,7 +42,8 @@ Sub-transitions:
 - `slashings_reset`
 - `randao_mixes_reset`
 - `historical_roots_update`
-- `participation_record_updates`
-- `sync_committee_updates`
+- `participation_record_updates` (Phase 0 only)
+- `participation_flag_updates` (Altair)
+- `sync_committee_updates` (Altair)
 
 The resulting state should match the expected `post` state.

--- a/tests/generators/epoch_processing/main.py
+++ b/tests/generators/epoch_processing/main.py
@@ -17,6 +17,8 @@ if __name__ == "__main__":
     ]}
     altair_mods = {
         **{key: 'eth2spec.test.altair.epoch_processing.test_process_' + key for key in [
+            'inactivity_updates',
+            'participation_flag_updates',
             'sync_committee_updates',
         ]},
         **phase_0_mods,


### PR DESCRIPTION
- Update `epoch_processing` test generator to output tests for missing tests
- Implement new `process_participation_flag_updates` tests
