### PR TITLE
[pyspec] Use mainnet.py as the default spec

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -912,7 +912,8 @@ class PySpecCommand(Command):
 
         if not self.dry_run:
             with open(os.path.join(self.out_dir, '__init__.py'), 'w') as out:
-                out.write("")
+                # `mainnet` is the default spec.
+                out.write("from . import mainnet as spec\n")
 
 
 class BuildPyCommand(build_py):

--- a/setup.py
+++ b/setup.py
@@ -913,7 +913,7 @@ class PySpecCommand(Command):
         if not self.dry_run:
             with open(os.path.join(self.out_dir, '__init__.py'), 'w') as out:
                 # `mainnet` is the default spec.
-                out.write("from . import mainnet as spec\n")
+                out.write("from . import mainnet as spec  # noqa:F401\n")
 
 
 class BuildPyCommand(build_py):


### PR DESCRIPTION
After #2390, the pyspec outputs are `mainnet.py` and `minimal.py` files for each protocol upgrade (fork).
- {fork_name}/mainnet.py
- {fork_name}/minimal.py

To make it backward-compatible, this PR simply adds `from . import mainnet as spec` to the `{fork_name}/__init__.py` files so that the pyspec users can still call `from eth2spec.phase0 import spec`.