### PR TITLE
Union type update

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1017,7 +1017,7 @@ setup(
         "py_ecc==5.2.0",
         "milagro_bls_binding==1.6.3",
         "dataclasses==0.6",
-        "remerkleable==0.1.19",
+        "remerkleable==0.1.20",
         RUAMEL_YAML_VERSION,
         "lru-dict==1.1.6",
         MARKO_VERSION,

--- a/tests/core/pyspec/eth2spec/utils/ssz/ssz_typing.py
+++ b/tests/core/pyspec/eth2spec/utils/ssz/ssz_typing.py
@@ -2,6 +2,7 @@
 # Ignore linter: This module makes importing SSZ types easy, and hides away the underlying library from the spec.
 
 from remerkleable.complex import Container, Vector, List
+from remerkleable.union import Union
 from remerkleable.basic import boolean, bit, uint, byte, uint8, uint16, uint32, uint64, uint128, uint256
 from remerkleable.bitfields import Bitvector, Bitlist
 from remerkleable.byte_arrays import ByteVector, Bytes1, Bytes4, Bytes8, Bytes32, Bytes48, Bytes96, ByteList


### PR DESCRIPTION
- Clarify missing `Union` type in SSZ spec
- Use "selector" wording instead of "type", since there may be multiple options of the same type in rare cases.
- Reduce selector to 1 byte, and reserve the top 128 values (most significant bit) for future backwards-compatible extensions
- Fix `null` reference in python-ish spec. It's referenced as the native-none/nil/null of the implementation anyway.
- Update serialization and merkleization to cover `None` case in the `Union`

Note: this change is assumed to be backwards-compatible, since `Union` is not used anywhere in the spec. Outside of the spec there is one known case in the DB format of Lighthouse, but the old serialization/deserialization can be kept around there.

TODO:
- [x] See https://github.com/protolambda/remerkleable/pull/9 for remerkleable update. If I get an ACK on this PR, I will make a new remerkleable release, and update the pyspec, so we can start using `Union` in the spec and testing.
  - Update: see remerkleable v0.1.20

fixes #2270
