### PR TITLE
add/update comments on shard blob/header/reference body field

### DIFF
--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -216,6 +216,7 @@ class ShardBlobHeader(Container):
     # Slot and shard that this header is intended for
     slot: Slot
     shard: Shard
+    # SSZ-summary of ShardBlobBody
     body_summary: ShardBlobBodySummary
     # Proposer of the shard-blob
     proposer_index: ValidatorIndex
@@ -253,7 +254,7 @@ class ShardBlobReference(Container):
     # Slot and shard that this reference is intended for
     slot: Slot
     shard: Shard
-    # Hash-tree-root of commitment data
+    # Hash-tree-root of ShardBlobBody
     body_root: Root
     # Proposer of the shard-blob
     proposer_index: ValidatorIndex

--- a/specs/sharding/p2p-interface.md
+++ b/specs/sharding/p2p-interface.md
@@ -64,6 +64,7 @@ class ShardBlob(Container):
     # Slot and shard that this blob is intended for
     slot: Slot
     shard: Shard
+    # Shard data with related commitments and beacon anchor
     body: ShardBlobBody
     # Proposer of the shard-blob
     proposer_index: ValidatorIndex


### PR DESCRIPTION
The previous comment about commitment data was confusing (too general, could be any selection of commitments), this fixes that, plus comments on the `body` fields in the other variants of the shard blob.
