### PR TITLE
Penalize sync comiittee

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -479,7 +479,7 @@ def get_generalized_index(ssz_class: Any, *path: Sequence[Union[int, SSZVariable
     def invariant_checks(cls) -> str:
         return '''
 assert (
-    TIMELY_HEAD_WEIGHT + TIMELY_SOURCE_WEIGHT + TIMELY_TARGET_WEIGHT + SYNC_REWARD_WEIGHT + PROPOSER_WEIGHT
+    TIMELY_HEAD_WEIGHT + TIMELY_SOURCE_WEIGHT + TIMELY_TARGET_WEIGHT + PROPOSER_WEIGHT
 ) == WEIGHT_DENOMINATOR'''
 
 

--- a/specs/altair/validator.md
+++ b/specs/altair/validator.md
@@ -430,7 +430,7 @@ Any bits modified for the sync committee responsibilities are unset in the ENR o
 
   *Note*: The first sync committee from phase 0 to the Altair fork will not be known until the fork happens, which implies subnet assignments are not known until then.
 Early sync committee members should listen for topic subscriptions from peers and employ discovery via the ENR advertisements near the fork boundary to form initial subnets.
-Some early sync committee rewards may be missed while the initial subnets form.
+Some early sync committee penalties may be unavoidable while the initial subnets form.
 
 * To join a sync committee subnet, select a random number of epochs before the end of the current sync committee period between 1 and `SYNC_COMMITTEE_SUBNET_COUNT`, inclusive.
 Validators should join their member subnet at the beginning of the epoch they have randomly selected.


### PR DESCRIPTION
This PR solves #2448  by inverting the logic for sync committee participation rewards into penalizing lack of participation. This way the vast majority of validators are not hindered nor need to resort to luck. 

The one `base_reward` per epoch invariant is preserved by this PR, the only change is that the rewards weights should sum up to the `WEIGHT_DENOMINATOR`, but not including the `SYNC_PENALTY_WEIGHT` which is now otherwise an independent constant. 

Notice that there may be a false feeling that validators in the sync committee are now penalized since they may receive stiff penalties for missing participation in a slot, that otherwise wouldn't. However, with this approach, even after being penalized for missing a sync committee participation, the overall result for those validators is exactly the same as in the current rewards-based mechanism. 

There are other options to mitigate the problem of #2448 like reducing the `SYNC_REWARD_WEIGHT` and `EPOCHS_PER_SYNC_COMMITTEE_PERIOD` but these all lead to relying on luck to some factor. Given that the sync committee size is minimum compared to the active validator set, any set of constants will always result in a non-trivial probability of a high number of validators not being included in a committee for two years. 

Discussions in 
https://discord.com/channels/595666850260713488/595701319793377299/847063172174577744