### PR TITLE
Modify sync committee logic and parameters to reduce variance

### DIFF
--- a/presets/mainnet/altair.yaml
+++ b/presets/mainnet/altair.yaml
@@ -14,8 +14,8 @@ PROPORTIONAL_SLASHING_MULTIPLIER_ALTAIR: 2
 # ---------------------------------------------------------------
 # 2**9 (= 512)
 SYNC_COMMITTEE_SIZE: 512
-# 2**9 (= 512)
-EPOCHS_PER_SYNC_COMMITTEE_PERIOD: 512
+# 2**8 (= 256)
+EPOCHS_PER_SYNC_COMMITTEE_PERIOD: 256
 
 
 # Sync protocol

--- a/specs/altair/beacon-chain.md
+++ b/specs/altair/beacon-chain.md
@@ -579,7 +579,7 @@ def process_sync_committee(state: BeaconState, aggregate: SyncAggregate) -> None
     # Apply participant and proposer rewards
     all_pubkeys = [v.pubkey for v in state.validators]
     committee_indices = [ValidatorIndex(all_pubkeys.index(pubkey)) for pubkey in state.current_sync_committee.pubkeys]
-    for index, participation_bit in zip(committee_indices, aggregate.sync_committee_bits):
+    for participant_index, participation_bit in zip(committee_indices, aggregate.sync_committee_bits):
         if participation_bit:
             increase_balance(state, participant_index, participant_reward)
             increase_balance(state, get_beacon_proposer_index(state), proposer_reward)

--- a/specs/altair/beacon-chain.md
+++ b/specs/altair/beacon-chain.md
@@ -86,10 +86,10 @@ Altair is the first beacon chain hard fork. Its main features are:
 
 | Name | Value |
 | - | - |
-| `TIMELY_SOURCE_WEIGHT` | `uint64(12)` |
-| `TIMELY_TARGET_WEIGHT` | `uint64(24)` |
-| `TIMELY_HEAD_WEIGHT` | `uint64(12)` |
-| `SYNC_REWARD_WEIGHT` | `uint64(8)` |
+| `TIMELY_SOURCE_WEIGHT` | `uint64(14)` |
+| `TIMELY_TARGET_WEIGHT` | `uint64(26)` |
+| `TIMELY_HEAD_WEIGHT` | `uint64(14)` |
+| `SYNC_REWARD_WEIGHT` | `uint64(2)` |
 | `PROPOSER_WEIGHT` | `uint64(8)` |
 | `WEIGHT_DENOMINATOR` | `uint64(64)` |
 
@@ -129,7 +129,7 @@ This patch updates a few configuration values to move penalty parameters closer 
 | Name | Value | Unit | Duration |
 | - | - | - | - |
 | `SYNC_COMMITTEE_SIZE` | `uint64(2**9)` (= 512) | Validators | |
-| `EPOCHS_PER_SYNC_COMMITTEE_PERIOD` | `uint64(2**9)` (= 512) | epochs | ~54 hours |
+| `EPOCHS_PER_SYNC_COMMITTEE_PERIOD` | `uint64(2**8)` (= 256) | epochs | ~27 hours |
 
 ## Configuration
 
@@ -579,10 +579,12 @@ def process_sync_committee(state: BeaconState, aggregate: SyncAggregate) -> None
     # Apply participant and proposer rewards
     all_pubkeys = [v.pubkey for v in state.validators]
     committee_indices = [ValidatorIndex(all_pubkeys.index(pubkey)) for pubkey in state.current_sync_committee.pubkeys]
-    participant_indices = [index for index, bit in zip(committee_indices, aggregate.sync_committee_bits) if bit]
-    for participant_index in participant_indices:
-        increase_balance(state, participant_index, participant_reward)
-        increase_balance(state, get_beacon_proposer_index(state), proposer_reward)
+    for index, participation_bit in zip(committee_indices, aggregate.sync_committee_bits):
+        if participant_bit:
+            increase_balance(state, participant_index, participant_reward)
+            increase_balance(state, get_beacon_proposer_index(state), proposer_reward)
+        else:
+            decrease_balance(state, participant_index, participant_reward)
 ```
 
 ### Epoch processing

--- a/specs/altair/beacon-chain.md
+++ b/specs/altair/beacon-chain.md
@@ -580,7 +580,7 @@ def process_sync_committee(state: BeaconState, aggregate: SyncAggregate) -> None
     all_pubkeys = [v.pubkey for v in state.validators]
     committee_indices = [ValidatorIndex(all_pubkeys.index(pubkey)) for pubkey in state.current_sync_committee.pubkeys]
     for index, participation_bit in zip(committee_indices, aggregate.sync_committee_bits):
-        if participant_bit:
+        if participation_bit:
             increase_balance(state, participant_index, participant_reward)
             increase_balance(state, get_beacon_proposer_index(state), proposer_reward)
         else:

--- a/tests/core/pyspec/eth2spec/test/altair/block_processing/test_process_sync_committee.py
+++ b/tests/core/pyspec/eth2spec/test/altair/block_processing/test_process_sync_committee.py
@@ -1,4 +1,3 @@
-from collections import Counter
 import random
 from eth2spec.test.helpers.block import (
     build_empty_block_for_next_slot,
@@ -13,6 +12,9 @@ from eth2spec.test.helpers.constants import (
 )
 from eth2spec.test.helpers.sync_committee import (
     compute_aggregate_sync_committee_signature,
+    compute_sync_committee_participant_reward_and_penalty,
+    compute_sync_committee_proposer_reward,
+    compute_committee_indices,
 )
 from eth2spec.test.context import (
     expect_assertion_error,
@@ -61,15 +63,6 @@ def get_committee_indices(spec, state, duplicates=False):
         state.randao_mixes[randao_index] = hash(state.randao_mixes[randao_index])
 
 
-def compute_committee_indices(spec, state, committee):
-    """
-    Given a ``committee``, calculate and return the related indices
-    """
-    all_pubkeys = [v.pubkey for v in state.validators]
-    committee_indices = [all_pubkeys.index(pubkey) for pubkey in committee.pubkeys]
-    return committee_indices
-
-
 @with_altair_and_later
 @spec_state_test
 @always_bls
@@ -115,65 +108,20 @@ def test_invalid_signature_extra_participant(spec, state):
     yield from run_sync_committee_processing(spec, state, block, expect_exception=True)
 
 
-def compute_sync_committee_inclusion_reward(spec,
-                                            state,
-                                            participant_index,
-                                            committee_indices,
-                                            committee_bits):
-    total_active_increments = spec.get_total_active_balance(state) // spec.EFFECTIVE_BALANCE_INCREMENT
-    total_base_rewards = spec.Gwei(spec.get_base_reward_per_increment(state) * total_active_increments)
-    max_epoch_rewards = spec.Gwei(total_base_rewards * spec.SYNC_REWARD_WEIGHT // spec.WEIGHT_DENOMINATOR)
-    included_indices = [index for index, bit in zip(committee_indices, committee_bits) if bit]
-    max_slot_rewards = spec.Gwei(
-        max_epoch_rewards * len(included_indices)
-        // len(committee_indices) // spec.SLOTS_PER_EPOCH
-    )
-
-    # Compute the participant and proposer sync rewards
-    committee_effective_balance = sum([state.validators[index].effective_balance for index in included_indices])
-    committee_effective_balance = max(spec.EFFECTIVE_BALANCE_INCREMENT, committee_effective_balance)
-    effective_balance = state.validators[participant_index].effective_balance
-    return spec.Gwei(max_slot_rewards * effective_balance // committee_effective_balance)
-
-
-def compute_sync_committee_participant_reward(spec, state, participant_index, committee_indices, committee_bits):
-    included_indices = [index for index, bit in zip(committee_indices, committee_bits) if bit]
-    multiplicities = Counter(included_indices)
-
-    inclusion_reward = compute_sync_committee_inclusion_reward(
-        spec, state, participant_index, committee_indices, committee_bits,
-    )
-    return spec.Gwei(inclusion_reward * multiplicities[participant_index])
-
-
-def compute_sync_committee_proposer_reward(spec, state, committee_indices, committee_bits):
-    proposer_reward = 0
-    for index, bit in zip(committee_indices, committee_bits):
-        if not bit:
-            continue
-        inclusion_reward = compute_sync_committee_inclusion_reward(
-            spec, state, index, committee_indices, committee_bits,
-        )
-        proposer_reward_denominator = (
-            (spec.WEIGHT_DENOMINATOR - spec.PROPOSER_WEIGHT)
-            * spec.WEIGHT_DENOMINATOR
-            // spec.PROPOSER_WEIGHT
-        )
-        proposer_reward += spec.Gwei((inclusion_reward * spec.WEIGHT_DENOMINATOR) // proposer_reward_denominator)
-    return proposer_reward
-
-
 def validate_sync_committee_rewards(spec, pre_state, post_state, committee_indices, committee_bits, proposer_index):
     for index in range(len(post_state.validators)):
         reward = 0
+        penalty = 0
         if index in committee_indices:
-            reward += compute_sync_committee_participant_reward(
+            _reward, _penalty = compute_sync_committee_participant_reward_and_penalty(
                 spec,
                 pre_state,
                 index,
                 committee_indices,
                 committee_bits,
             )
+            reward += _reward
+            penalty += _penalty
 
         if proposer_index == index:
             reward += compute_sync_committee_proposer_reward(
@@ -183,7 +131,7 @@ def validate_sync_committee_rewards(spec, pre_state, post_state, committee_indic
                 committee_bits,
             )
 
-        assert post_state.balances[index] == pre_state.balances[index] + reward
+        assert post_state.balances[index] == pre_state.balances[index] + reward - penalty
 
 
 def run_successful_sync_committee_test(spec, state, committee_indices, committee_bits):

--- a/tests/core/pyspec/eth2spec/test/helpers/sync_committee.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/sync_committee.py
@@ -1,3 +1,5 @@
+from collections import Counter
+
 from eth2spec.test.helpers.keys import privkeys
 from eth2spec.test.helpers.block import (
     build_empty_block_for_next_slot,
@@ -33,3 +35,42 @@ def compute_aggregate_sync_committee_signature(spec, state, slot, participants, 
             )
         )
     return bls.Aggregate(signatures)
+
+
+def compute_sync_committee_inclusion_reward(spec, state):
+    total_active_increments = spec.get_total_active_balance(state) // spec.EFFECTIVE_BALANCE_INCREMENT
+    total_base_rewards = spec.get_base_reward_per_increment(state) * total_active_increments
+    max_participant_rewards = (total_base_rewards * spec.SYNC_REWARD_WEIGHT
+                               // spec.WEIGHT_DENOMINATOR // spec.SLOTS_PER_EPOCH)
+    return max_participant_rewards // spec.SYNC_COMMITTEE_SIZE
+
+
+def compute_sync_committee_participant_reward_and_penalty(
+        spec, state, participant_index, committee_indices, committee_bits):
+    inclusion_reward = compute_sync_committee_inclusion_reward(spec, state)
+
+    included_indices = [index for index, bit in zip(committee_indices, committee_bits) if bit]
+    not_included_indices = [index for index, bit in zip(committee_indices, committee_bits) if not bit]
+    included_multiplicities = Counter(included_indices)
+    not_included_multiplicities = Counter(not_included_indices)
+    return (
+        spec.Gwei(inclusion_reward * included_multiplicities[participant_index]),
+        spec.Gwei(inclusion_reward * not_included_multiplicities[participant_index])
+    )
+
+
+def compute_sync_committee_proposer_reward(spec, state, committee_indices, committee_bits):
+    proposer_reward_denominator = spec.WEIGHT_DENOMINATOR - spec.PROPOSER_WEIGHT
+    inclusion_reward = compute_sync_committee_inclusion_reward(spec, state)
+    participant_number = committee_bits.count(True)
+    participant_reward = inclusion_reward * spec.PROPOSER_WEIGHT // proposer_reward_denominator
+    return spec.Gwei(participant_reward * participant_number)
+
+
+def compute_committee_indices(spec, state, committee):
+    """
+    Given a ``committee``, calculate and return the related indices
+    """
+    all_pubkeys = [v.pubkey for v in state.validators]
+    committee_indices = [all_pubkeys.index(pubkey) for pubkey in committee.pubkeys]
+    return committee_indices


### PR DESCRIPTION
Sync committee rewards as currently implemented significantly increase variance in proposer rewards: https://github.com/ethereum/eth2.0-specs/issues/2448

For example, if there are 200000 validators (6.4m ETH staked), then during each 1/4-eek (~54 hour) period there is a chance of 512/200000 that a validator will get accepted into the sync committee, so on average that will happen once every 200000/512 * 1/4 = 97.6 eeks, or close to two years. The payout of this "lottery" is 1/8 of that, or ~12.2 eeks (a bit less than four months) of revenue. This is much more severe than block proposing (a chance of 1/200000 per slot, or a lottery worth ~0.38 eeks of revenue once every ~3.05 eeks).

This PR is an alternative to the #2448 author's proposed fix (#2450) and makes three changes to cut make the sync committee lottery less drastic and bring variance closer in line with what is available from block proposing:

* Reduce the `SYNC_REWARD_WEIGHT` from 8 to 2
* Add a penalty for not participating in the sync committee, so that despite the first change the total net reward for participating vs not participating is only cut down by 2x
* Reduce the sync committee period from 1/4 eek to 1/8 eek (~27 hours)

With these three factors combined, the lottery reduces to ~1.5 eeks of revenue, on average occurring every ~48 eeks. Validators who are maximally unlucky (ie. never become part of a sync committee) only lose ~3.12% of their rewards instead of ~12.5%.

The compromises that this approach makes are:

* In the extreme case where >50% of proposers are operating inefficiently, being in a sync committee becomes a net burden. However, this should be extremely rare, and in such cases validators would likely be suffering inactivity leak penalties anyway.
* Incentive to participate in a sync committee decreased by 2x (but this is IMO an improvement; sync committees are _not_ as important as proposals and deserve to have lower rewards)
* Minimum data syncing needed to maintain a light client increases by 2x (from 24 kB per 54 hours to 24 kB per 27 hours). A burden for on-chain light clients, but still insignificant for others.