### PR TITLE
New union-based shard headers/commitments representation

### DIFF
--- a/presets/mainnet/sharding.yaml
+++ b/presets/mainnet/sharding.yaml
@@ -15,6 +15,8 @@ MAX_SHARD_PROPOSER_SLASHINGS: 16
 # Shard block configs
 # ---------------------------------------------------------------
 MAX_SHARD_HEADERS_PER_SHARD: 4
+# 2**8 (= 256)
+SHARD_STATE_MEMORY_SLOTS: 256
 # 2**11 (= 2,048)
 MAX_SAMPLES_PER_BLOCK: 2048
 # 2**10 (= 1,1024)

--- a/presets/minimal/sharding.yaml
+++ b/presets/minimal/sharding.yaml
@@ -15,6 +15,8 @@ MAX_SHARD_PROPOSER_SLASHINGS: 4
 # Shard block configs
 # ---------------------------------------------------------------
 MAX_SHARD_HEADERS_PER_SHARD: 4
+# 2**8 (= 256)
+SHARD_STATE_MEMORY_SLOTS: 256
 # 2**11 (= 2,048)
 MAX_SAMPLES_PER_BLOCK: 2048
 # 2**10 (= 1,1024)

--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -33,7 +33,7 @@
   - [`ShardBlobReference`](#shardblobreference)
   - [`SignedShardBlobReference`](#signedshardblobreference)
   - [`ShardProposerSlashing`](#shardproposerslashing)
-  - [`ShardCommitteeWork`](#shardcommitteework)
+  - [`ShardWork`](#shardwork)
 - [Helper functions](#helper-functions)
   - [Misc](#misc-2)
     - [`next_power_of_two`](#next_power_of_two)
@@ -185,7 +185,7 @@ class BeaconState(merge.BeaconState):  # [extends The Merge state]
     current_epoch_attestations: List[PendingAttestation, MAX_ATTESTATIONS * SLOTS_PER_EPOCH]
     # [New fields]
     # A ring buffer of the latest slots, with information per active shard.
-    shard_buffer: Vector[List[ShardCommitteeWork, MAX_SHARDS], SHARD_STATE_MEMORY_SLOTS]
+    shard_buffer: Vector[List[ShardWork, MAX_SHARDS], SHARD_STATE_MEMORY_SLOTS]
     shard_gasprice: uint64
     current_epoch_start_shard: Shard
 ```
@@ -282,7 +282,7 @@ class ShardProposerSlashing(Container):
     signed_reference_2: SignedShardBlobReference
 ```
 
-### `ShardCommitteeWork`
+### `ShardWork`
 
 ```python
 class ShardWork(Container):
@@ -765,7 +765,7 @@ def reset_pending_headers(state: BeaconState) -> None:
         buffer_index = slot % SHARD_STATE_MEMORY_SLOTS
         
         # Reset the shard work tracking
-        state.shard_buffer[buffer_index] = [ShardCommitteeWork() for _ in range(active_shards)]
+        state.shard_buffer[buffer_index] = [ShardWork() for _ in range(active_shards)]
 
         start_shard = get_start_shard(state, slot)
         for shard_index in range(state.shard_buffer[buffer_index]):

--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -480,7 +480,7 @@ def compute_committee_index_from_shard(state: BeaconState, slot: Slot, shard: Sh
     epoch = compute_epoch_at_slot(slot)
     active_shards = get_active_shard_count(state, epoch)
     index = CommitteeIndex((active_shards + shard - get_start_shard(state, slot)) % active_shards)
-    assert index >= get_committee_count_per_slot(state, epoch)
+    assert index < get_committee_count_per_slot(state, epoch)
     return index
 ```
 

--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -550,7 +550,7 @@ def update_pending_shard_work(state: BeaconState, attestation: Attestation) -> N
     header_index = [header.root for header in current_headers].index(attestation.data.shard_header_root)
 
     # Update votes bitfield in the state
-    pending_header: PendingShardHeader = state.shard_buffer[buffer_index][attestation_shard][header_index]
+    pending_header: PendingShardHeader = current_headers[header_index]
     full_committee = get_beacon_committee(state, attestation.data.slot, attestation.data.index)
     participants_balance = Gwei(0)
     for i, bit in enumerate(attestation.aggregation_bits):
@@ -594,7 +594,7 @@ def process_shard_header(state: BeaconState, signed_header: SignedShardBlobHeade
     assert header.body_summary.beacon_block_root == get_block_root_at_slot(state, header.slot - 1)
 
     # Check that this data is still pending
-    committee_work = state.shard_buffer[header.slot % SHARD_STATE_MEMORY_SLOTS][header.slot]
+    committee_work = state.shard_buffer[header.slot % SHARD_STATE_MEMORY_SLOTS][header.shard]
     assert committee_work.status.selector == PENDING_SHARD_DATA
 
     # Check that this header is not yet in the pending list
@@ -628,7 +628,7 @@ def process_shard_header(state: BeaconState, signed_header: SignedShardBlobHeade
     )
 
     # Include it in the pending list
-    state.shard_buffer[header.slot % SHARD_STATE_MEMORY_SLOTS][header.slot].append(pending_header)
+    state.shard_buffer[header.slot % SHARD_STATE_MEMORY_SLOTS][header.shard].append(pending_header)
 ```
 
 The degree proof works as follows. For a block `B` with length `l` (so `l`  values in `[0...l - 1]`, seen as a polynomial `B(X)` which takes these values),

--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -608,6 +608,7 @@ def process_shard_header(state: BeaconState, signed_header: SignedShardBlobHeade
 
     # Check that this header is not yet in the pending list
     current_headers: Sequence[PendingShardHeader] = committee_work.status.value
+    header_root = hash_tree_root(header)
     assert header_root not in [pending_header.root for pending_header in current_headers]
 
     # Verify proposer

--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -119,7 +119,7 @@ The following values are (non-configurable) constants used throughout the specif
 | `GASPRICE_ADJUSTMENT_COEFFICIENT` | `uint64(2**3)` (= 8) | Gasprice may decrease/increase by at most exp(1 / this value) *per epoch* |
 | `MAX_SHARD_PROPOSER_SLASHINGS` | `2**4` (= 16) | Maximum amount of shard proposer slashing operations per block |
 | `MAX_SHARD_HEADERS_PER_SHARD` | `4` | |
-| `SHARD_STATE_MEMORY_SLOTS` | `uint64(2**8)` (=256) | Number of slots for which shard commitments and confirmation status is directly available in the state |
+| `SHARD_STATE_MEMORY_SLOTS` | `uint64(2**8)` (= 256) | Number of slots for which shard commitments and confirmation status is directly available in the state |
 
 ### Shard block samples
 


### PR DESCRIPTION
Based on discord discussion, special thanks to @Nashatyrev for the suggestion of swapping pending-headers and confirmation data with a `Union`. This PR implements that, along with a special state for unconfirmable headers, and updates of the processing functions.

The state now contains a single field, a table with:
- `256` slots (TBD) lookback. This is a ring-buffer, so merkle proofs are stable throughout the slots (until the data is overwritten, beyond 256 slots).
- a List per slot, to just store the active-shards, instead of a super large vector
- a Union per shard/slot combination, to switch data depending on the shard-header-status
  - The selector can equal 3 status values:
    - `0`, `UNCONFIRMED_SHARD_DATA`: when pending shard headers are not confirmed within time, they get stale (no attestations can increase the vote bitfield anymore). The state-transition cleans this up by switching it to unconfirmed. It's a sane default as well. We also use this to mark shard/slot combinations that can never get a pending shard-header to begin with (when there is no committee assigned to this `(shard, slot)` combi).
    - `1`, `CONFIRMED_SHARD_DATA`: when a `2/3` majority is reached in the committee on any of the pending shard headers, it's confirmed, or the most-voted header at the end of the epoch. We reduce it to just track the commitment. The position within the state implies the `slot` and `shard`.
    - `2`, `PENDING_SHARD_DATA`: when we are processing attestations, we may see multiple different shard headers for the same `(slot, shard)`. These are likely slashable, but the committee can still confirm any of them.

Additionally, this PR:
- renames epoch processing functions to read like `{type of change}_{status of target data}_shard_{name of change}`. Previously the "header" wording was confusing with non-sharding functions that live in the same namespace.
- Fix doc section structure

~~This PR is a *work in progress*~~, using the new state representation, I'm also trying to address related issues:
- ~~Not all active shards may have a committee (also see #2452)~~ Mostly resolved I think. 2452 can address the P2P part.
- ~~The list-length of active shards per slot needs to be initialized correctly~~ Done.
- ~~The "dummy" pending shard-header is weird. Either need to remove it and handle it differently, or change the confirmation process (dummy headers should not be rewarded, and should be marked as unconfirmed)~~ Done.
- Maybe we should change `get_active_shard_count` to refer to the state. It is not ideal to keep the state data-structure in sync with the configuration.

