### PR TITLE
Pyspec builder internal config formatting fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -596,7 +596,7 @@ def objects_to_spec(preset_name: str,
 
     def format_config_var(name: str, vardef: VariableDefinition) -> str:
         if vardef.type_name is None:
-            out = f'{name}={vardef.value}'
+            out = f'{name}={vardef.value},'
         else:
             out = f'{name}={vardef.type_name}({vardef.value}),'
         if vardef.comment is not None:


### PR DESCRIPTION
Silly 1-char bug in pyspec builder: When an untyped var is not the last config var, it needs a comma. When it is the last config var, the comma is still ok.

This affects `TRANSITION_TOTAL_DIFFICULTY` in the build output, when more config vars follow (not currently the case, but this changes when we expand/reorganize the Merge doc). Thanks @mkalinin for finding this issue.
