### PR TITLE
Fix sync committee penalty tests on #2453

### DIFF
--- a/tests/core/pyspec/eth2spec/test/altair/block_processing/test_process_sync_committee.py
+++ b/tests/core/pyspec/eth2spec/test/altair/block_processing/test_process_sync_committee.py
@@ -118,7 +118,7 @@ def test_invalid_signature_extra_participant(spec, state):
 def compute_sync_committee_inclusion_reward(spec, state):
     total_active_increments = spec.get_total_active_balance(state) // spec.EFFECTIVE_BALANCE_INCREMENT
     total_base_rewards = spec.Gwei(spec.get_base_reward_per_increment(state) * total_active_increments)
-    max_participant_rewards = spec.Gwei(total_base_rewards * spec.SYNC_REWARD_WEIGHT // \
+    max_participant_rewards = spec.Gwei(total_base_rewards * spec.SYNC_REWARD_WEIGHT //
                                         spec.WEIGHT_DENOMINATOR // spec.SLOTS_PER_EPOCH)
     return spec.Gwei(max_participant_rewards // spec.SYNC_COMMITTEE_SIZE)
 

--- a/tests/core/pyspec/eth2spec/test/helpers/sync_committee.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/sync_committee.py
@@ -1,3 +1,5 @@
+from collections import Counter
+
 from eth2spec.test.helpers.keys import privkeys
 from eth2spec.test.helpers.block import (
     build_empty_block_for_next_slot,
@@ -33,3 +35,42 @@ def compute_aggregate_sync_committee_signature(spec, state, slot, participants, 
             )
         )
     return bls.Aggregate(signatures)
+
+
+def compute_sync_committee_inclusion_reward(spec, state):
+    total_active_increments = spec.get_total_active_balance(state) // spec.EFFECTIVE_BALANCE_INCREMENT
+    total_base_rewards = spec.get_base_reward_per_increment(state) * total_active_increments
+    max_participant_rewards = (total_base_rewards * spec.SYNC_REWARD_WEIGHT
+                               // spec.WEIGHT_DENOMINATOR // spec.SLOTS_PER_EPOCH)
+    return max_participant_rewards // spec.SYNC_COMMITTEE_SIZE
+
+
+def compute_sync_committee_participant_reward_and_penalty(
+        spec, state, participant_index, committee_indices, committee_bits):
+    inclusion_reward = compute_sync_committee_inclusion_reward(spec, state)
+
+    included_indices = [index for index, bit in zip(committee_indices, committee_bits) if bit]
+    not_included_indices = [index for index, bit in zip(committee_indices, committee_bits) if not bit]
+    included_multiplicities = Counter(included_indices)
+    not_included_multiplicities = Counter(not_included_indices)
+    return (
+        spec.Gwei(inclusion_reward * included_multiplicities[participant_index]),
+        spec.Gwei(inclusion_reward * not_included_multiplicities[participant_index])
+    )
+
+
+def compute_sync_committee_proposer_reward(spec, state, committee_indices, committee_bits):
+    proposer_reward_denominator = spec.WEIGHT_DENOMINATOR - spec.PROPOSER_WEIGHT
+    inclusion_reward = compute_sync_committee_inclusion_reward(spec, state)
+    participant_number = committee_bits.count(True)
+    participant_reward = inclusion_reward * spec.PROPOSER_WEIGHT // proposer_reward_denominator
+    return spec.Gwei(participant_reward * participant_number)
+
+
+def compute_committee_indices(spec, state, committee):
+    """
+    Given a ``committee``, calculate and return the related indices
+    """
+    all_pubkeys = [v.pubkey for v in state.validators]
+    committee_indices = [all_pubkeys.index(pubkey) for pubkey in committee.pubkeys]
+    return committee_indices


### PR DESCRIPTION
This PR is based on #2453

1. cherry-pick #2461 changes (Thanks to @potuz)
2. [Refactoring] Move some helper functions from `test_process_sync_committee.py` to `eth2spec/test/helpers/sync_committee.py`
3. Fix the tests by including the sync committee rewards and penalties.
    - We have some assertions that check if the result balance is expected. Now #2453 introduces new per-block rewards/penalties so we have to compute them.
