### PR TITLE
Altair: missing `block_root` in `SyncCommitteeSignature`

### DIFF
--- a/specs/altair/validator.md
+++ b/specs/altair/validator.md
@@ -282,7 +282,12 @@ def get_sync_committee_signature(state: BeaconState,
     signing_root = compute_signing_root(block_root, domain)
     signature = bls.Sign(privkey, signing_root)
 
-    return SyncCommitteeSignature(slot=state.slot, beacon_block_root=block_root, validator_index=validator_index, signature=signature)
+    return SyncCommitteeSignature(
+        slot=state.slot,
+        beacon_block_root=block_root,
+        validator_index=validator_index,
+        signature=signature,
+    )
 ```
 
 ##### Broadcast sync committee signature

--- a/specs/altair/validator.md
+++ b/specs/altair/validator.md
@@ -282,7 +282,7 @@ def get_sync_committee_signature(state: BeaconState,
     signing_root = compute_signing_root(block_root, domain)
     signature = bls.Sign(privkey, signing_root)
 
-    return SyncCommitteeSignature(slot=state.slot, validator_index=validator_index, signature=signature)
+    return SyncCommitteeSignature(slot=state.slot, beacon_block_root=block_root, validator_index=validator_index, signature=signature)
 ```
 
 ##### Broadcast sync committee signature


### PR DESCRIPTION
It seems like we forgot to include `beacon_block_root` in `SyncCommitteeSignature` for `get_sync_committee_signature`