### PR TITLE
Bump `mypy` to v0.812

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1007,7 +1007,7 @@ setup(
     python_requires=">=3.8, <4",
     extras_require={
         "test": ["pytest>=4.4", "pytest-cov", "pytest-xdist"],
-        "lint": ["flake8==3.7.7", "mypy==0.800"],
+        "lint": ["flake8==3.7.7", "mypy==0.812"],
         "generator": ["python-snappy==0.5.4"],
     },
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -1007,7 +1007,7 @@ setup(
     python_requires=">=3.8, <4",
     extras_require={
         "test": ["pytest>=4.4", "pytest-cov", "pytest-xdist"],
-        "lint": ["flake8==3.7.7", "mypy==0.750"],
+        "lint": ["flake8==3.7.7", "mypy==0.800"],
         "generator": ["python-snappy==0.5.4"],
     },
     install_requires=[


### PR DESCRIPTION
- `mypy` v0.800 release adds Python 3.9 support.
- I verified that our current CI setting is able to support Python3.9 env (https://github.com/ethereum/eth2.0-specs/compare/py39-support) with this PR, but let's keep running CI with Python3.8 env for backward compatibility.
