### PR TITLE
Clarify p2p validation conditions for Altair sync committees

### DIFF
--- a/specs/altair/p2p-interface.md
+++ b/specs/altair/p2p-interface.md
@@ -144,6 +144,7 @@ The following validations MUST pass before forwarding the `sync_committee_messag
 - _[IGNORE]_ The signature's slot is for the current slot (with a MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance), i.e. `sync_committee_message.slot == current_slot`.
 - _[IGNORE]_ The block being signed over (`sync_committee_message.beacon_block_root`) has been seen (via both gossip and non-gossip sources).
 - _[IGNORE]_ There has been no other valid sync committee signature for the declared `slot` for the validator referenced by `sync_committee_message.validator_index`.
+  Note this validation is _per topic_ so that for a given `slot`, multiple messages could be forwarded with the same `validator_index` as long as the `subnet_id`s are distinct.
 - _[REJECT]_ The `subnet_id` is valid for the given validator, i.e. `subnet_id in compute_subnets_for_sync_committee(state, sync_committee_message.validator_index)`.
   Note this validation implies the validator is part of the broader current sync committee along with the correct subcommittee.
 - _[REJECT]_ The `signature` is valid for the message `beacon_block_root` for the validator referenced by `validator_index`.


### PR DESCRIPTION
Addressing this comment:

> Secondly, the eth2 p2p-networking spec, explicitly has:

in #2471.

Will add another PR to address the message-id collision issue.