### PR TITLE
Add `message.topic` to gossipsub `message-id` in Altair

### DIFF
--- a/specs/altair/p2p-interface.md
+++ b/specs/altair/p2p-interface.md
@@ -77,11 +77,13 @@ The specification around the creation, validation, and dissemination of messages
 The derivation of the `message-id` has changed starting with Altair to incorporate the message `topic` along with the message `data`. These are fields of the `Message` Protobuf, and interpreted as empty byte strings if missing.
 The `message-id` MUST be the following 20 byte value computed from the message:
 * If `message.data` has a valid snappy decompression, set `message-id` to the first 20 bytes of the `SHA256` hash of
-  the concatenation of `MESSAGE_DOMAIN_VALID_SNAPPY` with the snappy decompressed message data and the topic name,
-  i.e. `SHA256(MESSAGE_DOMAIN_VALID_SNAPPY + snappy_decompress(message.data) + message.topic)[:20]`.
+  the concatenation of the following data: `MESSAGE_DOMAIN_VALID_SNAPPY`, the length of the topic byte string (encoded as little-endian `uint64`),
+  the topic byte string, and the snappy decompressed message data:
+  i.e. `SHA256(MESSAGE_DOMAIN_VALID_SNAPPY + uint_to_bytes(uint64(len(message.topic))) + message.topic + snappy_decompress(message.data)[:20]`.
 * Otherwise, set `message-id` to the first 20 bytes of the `SHA256` hash of
-  the concatenation of `MESSAGE_DOMAIN_INVALID_SNAPPY` with the raw message data and the topic name,
-  i.e. `SHA256(MESSAGE_DOMAIN_INVALID_SNAPPY + message.data + message.topic)[:20]`.
+  the concatenation of the following data: `MESSAGE_DOMAIN_INVALID_SNAPPY`, the length of the topic byte string (encoded as little-endian `uint64`),
+  the topic byte string, and the raw message data:
+  i.e. `SHA256(MESSAGE_DOMAIN_INVALID_SNAPPY + uint_to_bytes(uint64(len(message.topic))) + message.topic + message.data)[:20]`.
 
 The new topics along with the type of the `data` field of a gossipsub message are given in this table:
 

--- a/specs/altair/p2p-interface.md
+++ b/specs/altair/p2p-interface.md
@@ -74,7 +74,7 @@ New topics are added in Altair to support the sync committees and the beacon blo
 
 The specification around the creation, validation, and dissemination of messages has not changed from the Phase 0 document.
 
-The derivation of the `message-id` has changed starting with Altair to incorporate the message topic along with the message data.
+The derivation of the `message-id` has changed starting with Altair to incorporate the message `topic` along with the message `data`. These are fields of the `Message` Protobuf, and interpreted as empty byte strings if missing.
 The `message-id` MUST be the following 20 byte value computed from the message:
 * If `message.data` has a valid snappy decompression, set `message-id` to the first 20 bytes of the `SHA256` hash of
   the concatenation of `MESSAGE_DOMAIN_VALID_SNAPPY` with the snappy decompressed message data and the topic name,

--- a/specs/altair/p2p-interface.md
+++ b/specs/altair/p2p-interface.md
@@ -85,6 +85,12 @@ The `message-id` MUST be the following 20 byte value computed from the message:
   the topic byte string, and the raw message data:
   i.e. `SHA256(MESSAGE_DOMAIN_INVALID_SNAPPY + uint_to_bytes(uint64(len(message.topic))) + message.topic + message.data)[:20]`.
 
+Implementations may need to carefully handle the function that computes the `message-id`. In particular, messages on topics with the Phase 0
+fork digest should use the `message-id` procedure specified in the Phase 0 document.
+Messages on topics with the Altair fork digest should use the `message-id` procedure defined here.
+If an implementation only supports a single `message-id` function, it can define a switch inline;
+for example, `if topic in phase0_topics: return phase0_msg_id_fn(message) else return altair_msg_id_fn(message)`.
+
 The new topics along with the type of the `data` field of a gossipsub message are given in this table:
 
 | Name | Message Type |

--- a/specs/altair/p2p-interface.md
+++ b/specs/altair/p2p-interface.md
@@ -74,6 +74,15 @@ New topics are added in Altair to support the sync committees and the beacon blo
 
 The specification around the creation, validation, and dissemination of messages has not changed from the Phase 0 document.
 
+The derivation of the `message-id` has changed starting with Altair to incorporate the message topic along with the message data.
+The `message-id` MUST be the following 20 byte value computed from the message:
+* If `message.data` has a valid snappy decompression, set `message-id` to the first 20 bytes of the `SHA256` hash of
+  the concatenation of `MESSAGE_DOMAIN_VALID_SNAPPY` with the snappy decompressed message data and the topic name,
+  i.e. `SHA256(MESSAGE_DOMAIN_VALID_SNAPPY + snappy_decompress(message.data) + message.topic)[:20]`.
+* Otherwise, set `message-id` to the first 20 bytes of the `SHA256` hash of
+  the concatenation of `MESSAGE_DOMAIN_INVALID_SNAPPY` with the raw message data and the topic name,
+  i.e. `SHA256(MESSAGE_DOMAIN_INVALID_SNAPPY + message.data + message.topic)[:20]`.
+
 The new topics along with the type of the `data` field of a gossipsub message are given in this table:
 
 | Name | Message Type |


### PR DESCRIPTION
Fixes #2471.

In lieu of discriminating duplicated sync committee messages as suggested in #2471 by adding the `subnet_id` to the message itself, this PR suggests a solution by incorporating the topic name in to the gossipsub `message-id`. This solution should allow sync committee message duplicates to still remain distinct in the gossipsub machinery without needing to add an additional field to the message type.

Per discussion w/ @djrtwo and @protolambda, this avoids a potential DoS vector w/ the additional (unsigned) field and should harden message propagation across fork boundaries (as the fork digest will enter via the `message.topic`). This solution should also be a bit less intrusive than changing the sync committee structures further. Obviously open to other alternatives discovered during implementation :)