### PR TITLE
Fix typo: `change()` should be invoked on `ShardWork.status`

### DIFF
--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -576,12 +576,12 @@ def update_pending_shard_work(state: BeaconState, attestation: Attestation) -> N
         # TODO In Altair: set participation bit flag for voters of this early winning header
         if pending_header.commitment == DataCommitment():
             # The committee voted to not confirm anything
-            state.shard_buffer[buffer_index][attestation_shard].change(
+            state.shard_buffer[buffer_index][attestation_shard].status.change(
                 selector=SHARD_WORK_UNCONFIRMED,
                 value=None,
             )
         else:
-            state.shard_buffer[buffer_index][attestation_shard].change(
+            state.shard_buffer[buffer_index][attestation_shard].status.change(
                 selector=SHARD_WORK_CONFIRMED,
                 value=pending_header.commitment,
             )
@@ -785,7 +785,7 @@ def reset_pending_shard_work(state: BeaconState) -> None:
             shard = (start_shard + committee_index) % active_shards
             # a committee is available, initialize a pending shard-header list
             committee_length = len(get_beacon_committee(state, slot, committee_index))
-            state.shard_buffer[buffer_index][shard].change(
+            state.shard_buffer[buffer_index][shard].status.change(
                 selector=SHARD_WORK_PENDING,
                 value=List[PendingShardHeader, MAX_SHARD_HEADERS_PER_SHARD](
                     PendingShardHeader(


### PR DESCRIPTION
There is an inconsistency in how `change()` is called in the `sharding` spec: sometimes it's invoked on a `ShardWork` instance, while other times - on its [`status`](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/sharding/beacon-chain.md#shardwork) field (of type `Union`).
The latter variant seems to be more [appropriate](https://github.com/protolambda/remerkleable/blob/ba34ea3984ac9cc5c963b67a053c8745f4e16815/remerkleable/union.py#L125).