### PR TITLE
Fix typing problem: append is invoked on a ShardWork instance

### DIFF
--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -608,7 +608,7 @@ def process_shard_header(state: BeaconState, signed_header: SignedShardBlobHeade
     assert committee_work.status.selector == SHARD_WORK_PENDING
 
     # Check that this header is not yet in the pending list
-    current_headers: MutableSequence[PendingShardHeader] = committee_work.status.value
+    current_headers: List[PendingShardHeader, MAX_SHARD_HEADERS_PER_SHARD] = committee_work.status.value
     header_root = hash_tree_root(header)
     assert header_root not in [pending_header.root for pending_header in current_headers]
 

--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -608,7 +608,7 @@ def process_shard_header(state: BeaconState, signed_header: SignedShardBlobHeade
     assert committee_work.status.selector == SHARD_WORK_PENDING
 
     # Check that this header is not yet in the pending list
-    current_headers: Sequence[PendingShardHeader] = committee_work.status.value
+    current_headers: MutableSequence[PendingShardHeader] = committee_work.status.value
     header_root = hash_tree_root(header)
     assert header_root not in [pending_header.root for pending_header in current_headers]
 
@@ -640,7 +640,7 @@ def process_shard_header(state: BeaconState, signed_header: SignedShardBlobHeade
     )
 
     # Include it in the pending list
-    state.shard_buffer[header.slot % SHARD_STATE_MEMORY_SLOTS][header.shard].append(pending_header)
+    current_headers.append(pending_header)
 ```
 
 The degree proof works as follows. For a block `B` with length `l` (so `l`  values in `[0...l - 1]`, seen as a polynomial `B(X)` which takes these values),


### PR DESCRIPTION
There is a typing problem in [process_shard_header](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/sharding/beacon-chain.md#process_shard_header):
```
state.shard_buffer[header.slot % SHARD_STATE_MEMORY_SLOTS][header.shard].append(pending_header)
```

`state.shard_buffer[...][...]` has type [ShardWork](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/sharding/beacon-chain.md#shardwork), which doesn't have an `append` method. Though its `status` field is a `Union` which has `List` as one of the options (which does have the `append` method).

The PR contains a proposed fix, which in addition uses `current_headers` variable instead of `state.shard_buffer[header.slot % SHARD_STATE_MEMORY_SLOTS][header.shard]`. Since `state.shard_buffer` and `header.slot` are not mutated in between `current_headers` definition and the `append` invocation, both expressions should point to the same location.

There are two advantages of doing so:
- it's more concise for a human reader and perhaps more informative (i.e. avoid unnecessary aliasing)
- for a static type checker, it can be more tricky to prove that the two expressions are actually aliases. In such case, the type checker would conservatively treat the `state.shard_buffer[...][...].status` at the end of the method (where `append` is invoked) as potentially pointing to another location. In particular, that means that the appropriate `Union` discriminating check may have to be made (e.g. `state.shard_buffer[...][...].status.selector == SHARD_WORK_PENDING`).

**NB** Originally `current_headers` had type `Sequence`, which lacks `append` method, so I changed its type to `List[PendingShardHeader, ...]`. It's more lengthy and in theory `MutableSequence` would work better, however, [remerkleable.List](https://github.com/protolambda/remerkleable/blob/ba34ea3984ac9cc5c963b67a053c8745f4e16815/remerkleable/complex.py#L255) doesn't inherit the interface at the moment.

