### PR TITLE
Shard builder <> proposer separation

### DIFF
--- a/presets/mainnet/sharding.yaml
+++ b/presets/mainnet/sharding.yaml
@@ -1,22 +1,24 @@
 # Mainnet preset - Sharding
 
-# Beacon-chain
-# ---------------------------------------------------------------
 # Misc
+# ---------------------------------------------------------------
 # 2**10 (= 1,024)
 MAX_SHARDS: 1024
-# 2**6 = 64
+# 2**6 (= 64)
 INITIAL_ACTIVE_SHARDS: 64
 # 2**3 (= 8)
-GASPRICE_ADJUSTMENT_COEFFICIENT: 8
+SAMPLE_PRICE_ADJUSTMENT_COEFFICIENT: 8
 # 2**4 (= 16)
 MAX_SHARD_PROPOSER_SLASHINGS: 16
-
-# Shard block configs
-# ---------------------------------------------------------------
+#
 MAX_SHARD_HEADERS_PER_SHARD: 4
 # 2**8 (= 256)
 SHARD_STATE_MEMORY_SLOTS: 256
+# 2**40 (= 1,099,511,627,776)
+BLOB_BUILDER_REGISTRY_LIMIT: 1099511627776
+
+# Shard blob samples
+# ---------------------------------------------------------------
 # 2**11 (= 2,048)
 MAX_SAMPLES_PER_BLOCK: 2048
 # 2**10 (= 1,1024)
@@ -25,6 +27,6 @@ TARGET_SAMPLES_PER_BLOCK: 1024
 # Gwei values
 # ---------------------------------------------------------------
 # 2**33 (= 8,589,934,592) Gwei
-MAX_GASPRICE: 8589934592
+MAX_SAMPLE_PRICE: 8589934592
 # 2**3 (= 8) Gwei
-MIN_GASPRICE: 8
+MIN_SAMPLE_PRICE: 8

--- a/presets/minimal/sharding.yaml
+++ b/presets/minimal/sharding.yaml
@@ -1,6 +1,6 @@
 # Minimal preset - Sharding
 
-# Beacon-chain
+# Misc
 # ---------------------------------------------------------------
 # Misc
 # [customized] reduced for testing
@@ -8,15 +8,18 @@ MAX_SHARDS: 8
 # [customized] reduced for testing
 INITIAL_ACTIVE_SHARDS: 2
 # 2**3 (= 8)
-GASPRICE_ADJUSTMENT_COEFFICIENT: 8
+SAMPLE_PRICE_ADJUSTMENT_COEFFICIENT: 8
 # [customized] reduced for testing
 MAX_SHARD_PROPOSER_SLASHINGS: 4
-
-# Shard block configs
-# ---------------------------------------------------------------
+#
 MAX_SHARD_HEADERS_PER_SHARD: 4
 # 2**8 (= 256)
 SHARD_STATE_MEMORY_SLOTS: 256
+# 2**40 (= 1,099,511,627,776)
+BLOB_BUILDER_REGISTRY_LIMIT: 1099511627776
+
+# Shard blob samples
+# ---------------------------------------------------------------
 # 2**11 (= 2,048)
 MAX_SAMPLES_PER_BLOCK: 2048
 # 2**10 (= 1,1024)
@@ -25,6 +28,6 @@ TARGET_SAMPLES_PER_BLOCK: 1024
 # Gwei values
 # ---------------------------------------------------------------
 # 2**33 (= 8,589,934,592) Gwei
-MAX_GASPRICE: 8589934592
+MAX_SAMPLE_PRICE: 8589934592
 # 2**3 (= 8) Gwei
-MIN_GASPRICE: 8
+MIN_SAMPLE_PRICE: 8

--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -17,7 +17,7 @@
   - [Shard Work Status](#shard-work-status)
 - [Preset](#preset)
   - [Misc](#misc-1)
-  - [Shard block samples](#shard-block-samples)
+  - [Shard blob samples](#shard-blob-samples)
   - [Precomputed size verification points](#precomputed-size-verification-points)
   - [Gwei values](#gwei-values)
 - [Configuration](#configuration)

--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -151,6 +151,7 @@ TODO: `WEIGHT_DENOMINATOR` needs to be adjusted, but this breaks a lot of Altair
 | Name | Value | Notes |
 | - | - | - |
 | `MAX_SHARDS` | `uint64(2**10)` (= 1,024) | Theoretical max shard count (used to determine data structure sizes) |
+| `INITIAL_ACTIVE_SHARDS` | `uint64(2**6)` (= 64) | Initial shard count |
 | `SAMPLE_PRICE_ADJUSTMENT_COEFFICIENT` | `uint64(2**3)` (= 8) | Sample price may decrease/increase by at most exp(1 / this value) *per epoch* |
 | `MAX_SHARD_PROPOSER_SLASHINGS` | `2**4` (= 16) | Maximum amount of shard proposer slashing operations per block |
 | `MAX_SHARD_HEADERS_PER_SHARD` | `4` | |
@@ -181,9 +182,8 @@ TODO: `WEIGHT_DENOMINATOR` needs to be adjusted, but this breaks a lot of Altair
 
 ## Configuration
 
-| Name | Value | Notes |
-| - | - | - |
-| `INITIAL_ACTIVE_SHARDS` | `uint64(2**6)` (= 64) | Initial shard count |
+Note: some preset variables may become run-time configurable for testnets, but default to a preset while the spec is unstable.  
+E.g. `INITIAL_ACTIVE_SHARDS`, `MAX_SAMPLES_PER_BLOB` and `TARGET_SAMPLES_PER_BLOB`.
 
 ## Updated containers
 

--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -853,7 +853,6 @@ def process_pending_shard_confirmations(state: BeaconState) -> None:
             committee_work = state.shard_buffer[buffer_index][shard_index]
             if committee_work.status.selector == SHARD_WORK_PENDING:
                 winning_header = max(committee_work.status.value, key=lambda header: header.weight)
-                # TODO In Altair: set participation bit flag of voters for winning header
                 if winning_header.attested.commitment == DataCommitment():
                     committee_work.status.change(selector=SHARD_WORK_UNCONFIRMED, value=None)
                 else:

--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -437,13 +437,13 @@ def compute_previous_slot(slot: Slot) -> Slot:
 #### `compute_updated_sample_price`
 
 ```python
-def compute_updated_sample_price(prev_price: Gwei, samples: uint64, active_shards: uint64) -> Gwei:
+def compute_updated_sample_price(prev_price: Gwei, samples_length: uint64, active_shards: uint64) -> Gwei:
     adjustment_quotient = active_shards * SLOTS_PER_EPOCH * SAMPLE_PRICE_ADJUSTMENT_COEFFICIENT
-    if samples > TARGET_SAMPLES_PER_BLOB:
-        delta = max(1, prev_price * (samples - TARGET_SAMPLES_PER_BLOB) // TARGET_SAMPLES_PER_BLOB // adjustment_quotient)
+    if samples_length > TARGET_SAMPLES_PER_BLOB:
+        delta = max(1, prev_price * (samples_length - TARGET_SAMPLES_PER_BLOB) // TARGET_SAMPLES_PER_BLOB // adjustment_quotient)
         return min(prev_price + delta, MAX_SAMPLE_PRICE)
     else:
-        delta = max(1, prev_price * (TARGET_SAMPLES_PER_BLOB - samples) // TARGET_SAMPLES_PER_BLOB // adjustment_quotient)
+        delta = max(1, prev_price * (TARGET_SAMPLES_PER_BLOB - samples_length) // TARGET_SAMPLES_PER_BLOB // adjustment_quotient)
         return max(prev_price, MIN_SAMPLE_PRICE + delta) - delta
 ```
 

--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -732,9 +732,9 @@ def process_shard_header(state: BeaconState, signed_header: SignedShardBlobHeade
 
     # Charge EIP 1559 fee, builder pays for opportunity, and is responsible for later availability,
     # or fail to publish at their own expense.
-    samples = blob_summary.commitment.length
+    samples = body_summary.commitment.length
     # TODO: overflows, need bigger int type
-    max_fee = blob_summary.max_fee_per_sample * samples
+    max_fee = body_summary.max_fee_per_sample * samples
 
     # Builder must have sufficient balance, even if max_fee is not completely utilized
     assert state.blob_builder_balances[header.builder_index] >= max_fee
@@ -744,7 +744,7 @@ def process_shard_header(state: BeaconState, signed_header: SignedShardBlobHeade
     assert max_fee >= base_fee
 
     # Remaining fee goes towards proposer for prioritizing, up to a maximum
-    max_priority_fee = blob_summary.max_priority_fee_per_sample * samples
+    max_priority_fee = body_summary.max_priority_fee_per_sample * samples
     priority_fee = min(max_fee - base_fee, max_priority_fee)
 
     # Burn base fee, take priority fee
@@ -759,7 +759,7 @@ def process_shard_header(state: BeaconState, signed_header: SignedShardBlobHeade
     initial_votes = Bitlist[MAX_VALIDATORS_PER_COMMITTEE]([0] * committee_length)
     pending_header = PendingShardHeader(
         attested=AttestedDataCommitment(
-            commitment=blob_summary.commitment,
+            commitment=body_summary.commitment,
             root=header_root,
             includer_index=get_beacon_proposer_index(state),
         )

--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -618,7 +618,7 @@ def process_attested_shard_work(state: BeaconState, attestation: Attestation) ->
     if committee_work.status.selector != SHARD_WORK_PENDING:
         # If the data was already confirmed, check if this matches, to apply the flag to the attesters.
         if committee_work.status.selector == SHARD_WORK_CONFIRMED:
-            attested: AttestedDataCommitment = current_headers[header_index]
+            attested: AttestedDataCommitment = committee_work.status.value
             if attested.root == attestation.data.shard_blob_root:
                 batch_apply_participation_flag(state, attestation.aggregation_bits,
                                                attestation.data.target.epoch,

--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -182,7 +182,7 @@ TODO: `WEIGHT_DENOMINATOR` needs to be adjusted, but this breaks a lot of Altair
 
 ## Configuration
 
-Note: some preset variables may become run-time configurable for testnets, but default to a preset while the spec is unstable.  
+Note: Some preset variables may become run-time configurable for testnets, but default to a preset while the spec is unstable.  
 E.g. `INITIAL_ACTIVE_SHARDS`, `MAX_SAMPLES_PER_BLOB` and `TARGET_SAMPLES_PER_BLOB`.
 
 ## Updated containers

--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -770,8 +770,11 @@ def process_shard_header(state: BeaconState, signed_block_header: SignedShardBlo
     )
 
     # Charge builder, with hard balance requirement
-    fee = Gwei(123)  # TODO
+    fee = Gwei(123)  # TODO EIP 1559 like fee? Burn some of it?
     charge_builder(state, builder_index, fee)
+    # TODO: proposer is charged for confirmed headers (see charge_confirmed_shard_fees).
+    #  Need to align incentive, so proposer does not gain from including unconfirmed headers
+    increase_balance(state, block_header.proposer_index, fee)
 
     # Initialize the pending header
     index = compute_committee_index_from_shard(state, slot, shard)

--- a/specs/sharding/beacon-chain.md
+++ b/specs/sharding/beacon-chain.md
@@ -216,10 +216,6 @@ class BeaconBlockBody(merge.BeaconBlockBody):  # [extends The Merge block body]
 
 ```python
 class BeaconState(merge.BeaconState):
-    # [Updated fields] (Warning: this changes with Altair, Sharding will rebase to use participation-flags)
-    previous_epoch_attestations: List[PendingAttestation, MAX_ATTESTATIONS * SLOTS_PER_EPOCH]
-    current_epoch_attestations: List[PendingAttestation, MAX_ATTESTATIONS * SLOTS_PER_EPOCH]
-    # [New fields]
     # Blob builder registry.
     blob_builders: List[Builder, BLOB_BUILDER_REGISTRY_LIMIT]
     blob_builder_balances: List[Gwei, BLOB_BUILDER_REGISTRY_LIMIT]

--- a/specs/sharding/p2p-interface.md
+++ b/specs/sharding/p2p-interface.md
@@ -13,10 +13,10 @@
   - [Misc](#misc)
 - [Gossip domain](#gossip-domain)
   - [Topics and messages](#topics-and-messages)
-    - [Shard blob subnets](#shard-blob-subnets)
+    - [Shard block subnets](#shard-block-subnets)
       - [`shard_block_{subnet_id}`](#shard_block_subnet_id)
     - [Global topics](#global-topics)
-      - [`shard_header`](#shard_header)
+      - [`shard_block_header`](#shard_block_header)
       - [`shard_proposer_slashing`](#shard_proposer_slashing)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->

--- a/specs/sharding/p2p-interface.md
+++ b/specs/sharding/p2p-interface.md
@@ -11,10 +11,6 @@
 - [Introduction](#introduction)
 - [Constants](#constants)
   - [Misc](#misc)
-- [New containers](#new-containers)
-  - [ShardBlobBody](#shardblobbody)
-  - [ShardBlob](#shardblob)
-  - [SignedShardBlob](#signedshardblob)
 - [Gossip domain](#gossip-domain)
   - [Topics and messages](#topics-and-messages)
     - [Shard blob subnets](#shard-blob-subnets)
@@ -39,47 +35,6 @@ The adjustments and additions for Shards are outlined in this document.
 | Name | Value | Description |
 | ---- | ----- | ----------- |
 | `SHARD_BLOB_SUBNET_COUNT` | `64` | The number of `shard_blob_{subnet_id}` subnets used in the gossipsub protocol. |
-
-## New containers
-
-### ShardBlobBody
-
-```python
-class ShardBlobBody(Container):
-    # The actual data commitment
-    commitment: DataCommitment
-    # Proof that the degree < commitment.length
-    degree_proof: BLSCommitment
-    # The actual data. Should match the commitment and degree proof.
-    data: List[BLSPoint, POINTS_PER_SAMPLE * MAX_SAMPLES_PER_BLOCK]
-    # Latest block root of the Beacon Chain, before shard_blob.slot
-    beacon_block_root: Root
-```
-
-The user MUST always verify the commitments in the `body` are valid for the `data` in the `body`.
-
-### ShardBlob
-
-```python
-class ShardBlob(Container):
-    # Slot and shard that this blob is intended for
-    slot: Slot
-    shard: Shard
-    # Shard data with related commitments and beacon anchor
-    body: ShardBlobBody
-    # Proposer of the shard-blob
-    proposer_index: ValidatorIndex
-```
-
-This is the expanded form of the `ShardBlobHeader` type.
-
-### SignedShardBlob
-
-```python
-class SignedShardBlob(Container):
-    message: ShardBlob
-    signature: BLSSignature
-```
 
 ## Gossip domain
 

--- a/specs/sharding/p2p-interface.md
+++ b/specs/sharding/p2p-interface.md
@@ -13,10 +13,11 @@
   - [Misc](#misc)
 - [Gossip domain](#gossip-domain)
   - [Topics and messages](#topics-and-messages)
-    - [Shard block subnets](#shard-block-subnets)
-      - [`shard_block_{subnet_id}`](#shard_block_subnet_id)
+    - [Shard blob subnets](#shard-blob-subnets)
+      - [`shard_blob_{subnet_id}`](#shard_blob_subnet_id)
     - [Global topics](#global-topics)
-      - [`shard_block_header`](#shard_block_header)
+      - [`shard_blob_header`](#shard_blob_header)
+      - [`shard_blob_tx`](#shard_blob_tx)
       - [`shard_proposer_slashing`](#shard_proposer_slashing)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -34,7 +35,7 @@ The adjustments and additions for Shards are outlined in this document.
 
 | Name | Value | Description |
 | ---- | ----- | ----------- |
-| `SHARD_BLOCK_SUBNET_COUNT` | `64` | The number of `shard_block_{subnet_id}` subnets used in the gossipsub protocol. |
+| `SHARD_BLOB_SUBNET_COUNT` | `64` | The number of `shard_blob_{subnet_id}` subnets used in the gossipsub protocol. |
 
 ## Gossip domain
 
@@ -42,24 +43,25 @@ The adjustments and additions for Shards are outlined in this document.
 
 Following the same scheme as the [Phase0 gossip topics](../phase0/p2p-interface.md#topics-and-messages), names and payload types are:
 
-| Name                             | Message Type              |
-|----------------------------------|---------------------------|
-| `shard_block_{subnet_id}`        | `SignedShardBlock`        |
-| `shard_block_header`             | `SignedShardBlockHeader`  |
-| `shard_proposer_slashing`        | `ShardProposerSlashing`   |
+| Name                            | Message Type             |
+|---------------------------------|--------------------------|
+| `shard_blob_{subnet_id}`        | `SignedShardBlob`        |
+| `shard_blob_header`             | `SignedShardBlobHeader`  |
+| `shard_blob_tx`                 | `SignedShardBlobHeader`  |
+| `shard_proposer_slashing`       | `ShardProposerSlashing`  |
 
 The [DAS network specification](./das-p2p.md) defines additional topics.
 
-#### Shard block subnets
+#### Shard blob subnets
 
-Shard block subnets are used by builders to make their blobs available after selection by shard proposers.
+Shard blob subnets are used by builders to make their blobs available after selection by shard proposers.
 
-##### `shard_block_{subnet_id}`
+##### `shard_blob_{subnet_id}`
 
-Shard block data, in the form of a `SignedShardBlock` is published to the `shard_block_{subnet_id}` subnets.
+Shard blob data, in the form of a `SignedShardBlob` is published to the `shard_blob_{subnet_id}` subnets.
 
 ```python
-def compute_subnet_for_shard_block(state: BeaconState, slot: Slot, shard: Shard) -> uint64:
+def compute_subnet_for_shard_blob(state: BeaconState, slot: Slot, shard: Shard) -> uint64:
     """
     Compute the correct subnet for a shard blob publication.
     Note, this mimics compute_subnet_for_attestation().
@@ -69,75 +71,97 @@ def compute_subnet_for_shard_block(state: BeaconState, slot: Slot, shard: Shard)
     slots_since_epoch_start = Slot(slot % SLOTS_PER_EPOCH)
     committees_since_epoch_start = committees_per_slot * slots_since_epoch_start
 
-    return uint64((committees_since_epoch_start + committee_index) % SHARD_BLOCK_SUBNET_COUNT)
+    return uint64((committees_since_epoch_start + committee_index) % SHARD_BLOB_SUBNET_COUNT)
 ```
 
-The following validations MUST pass before forwarding the `signed_block` on the horizontal subnet or creating samples for it.
+The following validations MUST pass before forwarding the `signed_blob`,
+on the horizontal subnet or creating samples for it. Alias `blob = signed_blob.message`.
 
-We define some aliases to the nested contents of `signed_block`:
-```python
-block: ShardBlock = signed_block.message
-signed_blob: SignedShardBlob = block.signed_blob
-blob: ShardBlob = signed_blob.message
-```
-
-- _[IGNORE]_ The `block` is not from a future slot (with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance) --
+- _[IGNORE]_ The `blob` is not from a future slot (with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance) --
   i.e. validate that `blob.slot <= current_slot`
   (a client MAY queue future blobs for processing at the appropriate slot).
-- _[IGNORE]_ The `blob` is new enough to be still be processed --
+- _[IGNORE]_ The `blob` is new enough to still be processed --
   i.e. validate that `compute_epoch_at_slot(blob.slot) >= get_previous_epoch(state)`
-- _[REJECT]_ The shard should have a committee at slot --
+- _[REJECT]_ The shard blob is for an active shard --
+  i.e. `blob.shard < get_active_shard_count(state, compute_epoch_at_slot(blob.slot))`
+- _[REJECT]_ The `blob.shard` MUST have a committee at the `blob.slot` --
   i.e. validate that `compute_committee_index_from_shard(state, blob.slot, blob.shard)` doesn't raise an error
 - _[REJECT]_ The shard blob is for the correct subnet --
-  i.e. `compute_subnet_for_shard_block(state, blob.slot, blob.shard) == subnet_id`
-- _[IGNORE]_ The block is the first block with valid signature received for the `(block.proposer_index, blob.slot, blob.shard)` combination.
+  i.e. `compute_subnet_for_shard_blob(state, blob.slot, blob.shard) == subnet_id`
+- _[IGNORE]_ The blob is the first blob with valid signature received for the `(blob.proposer_index, blob.slot, blob.shard)` combination.
 - _[REJECT]_ The blob is not too large, the data MUST NOT be larger than the SSZ list-limit, and a client MAY be more strict.
 - _[REJECT]_ The `blob.body.data` MUST NOT contain any point `p >= MODULUS`. Although it is a `uint256`, not the full 256 bit range is valid.
-- _[REJECT]_ The block proposer signature, `signed_block.signature`, is valid with respect to the `proposer_index` pubkey.
 - _[REJECT]_ The blob builder exists and has sufficient balance to back the fee payment.
-- _[REJECT]_ The blob builder signature, `signed_blob.signature`, is valid with respect to the `builder_index` pubkey.
-- _[REJECT]_ The block is proposed by the expected `proposer_index` for the block's slot
+- _[REJECT]_ The blob signature is valid for the aggregate of proposer and builder, `signed_blob.signature`,
+  i.e. `bls.FastAggregateVerify([builder_pubkey, proposer_pubkey], blob_signing_root, signed_blob.signature)`.
+- _[REJECT]_ The blob is proposed by the expected `proposer_index` for the blob's `slot` and `shard`,
   in the context of the current shuffling (defined by `blob.body.beacon_block_root`/`slot`).
   If the `proposer_index` cannot immediately be verified against the expected shuffling,
-  the block MAY be queued for later processing while proposers for the block's branch are calculated --
+  the blob MAY be queued for later processing while proposers for the blob's branch are calculated --
   in such a case _do not_ `REJECT`, instead `IGNORE` this message.
 
 #### Global topics
 
-There are two additional global topics for Sharding.
+There are three additional global topics for Sharding.
 
-One is used to propagate shard block headers (`shard_block_header`) to all nodes on the network.
-Another one is used to propagate shard proposer slashings (`shard_proposer_slashing`).
+- `shard_blob_header`: co-signed headers, to be included on-chain, and signaling builders to publish full data.
+- `shard_blob_tx`: builder-signed headers, also known as "data transaction".
+- `shard_proposer_slashing`: slashings of duplicate shard proposals
 
-##### `shard_block_header`
+##### `shard_blob_header`
 
-Shard header data, in the form of a `SignedShardBlockHeader` is published to the global `shard_block_header` subnet.
-Shard block headers select shard blob bids by builders, and should be timely to ensure builders can publish the full shard block timely.
+Shard header data, in the form of a `SignedShardBlobHeader` is published to the global `shard_blob_header` subnet.
+Shard blob headers select shard blob bids by builders,
+and should be timely to ensure builders can publish the full shard blob before subsequent attestations.
 
-The following validations MUST pass before forwarding the `signed_block_header` (with inner `message` as `header`) on the network.
+The following validations MUST pass before forwarding the `signed_blob_header` on the network. Alias `header = signed_blob_header.message`
 
-We define some aliases to the nested contents of `signed_block_header`:
-```python
-block_header: ShardBlockHeader = signed_block_header.message
-signed_blob_header: SignedShardBlobHeader = header.signed_blob_header
-blob_header: ShardBlobHeader = signed_blob_header.message
-```
-
-- _[IGNORE]_ The header is not from a future slot (with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance) --
-  i.e. validate that `blob_header.slot <= current_slot`
+- _[IGNORE]_ The `header` is not from a future slot (with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance) --
+  i.e. validate that `header.slot <= current_slot`
   (a client MAY queue future headers for processing at the appropriate slot).
-- _[IGNORE]_ The header is new enough to be still be processed --
-  i.e. validate that `compute_epoch_at_slot(blob_header.slot) >= get_previous_epoch(state)`
-- _[IGNORE]_ The header is the first header with valid signature received for the `(block_header.proposer_index, blob_header.slot, blob_header.shard)` combination.
-- _[REJECT]_ The `shard` MUST have a committee at the `slot` --
-  i.e. validate that `compute_committee_index_from_shard(state, blob_header.slot, blob_header.shard)` doesn't raise an error
-- _[REJECT]_ The proposer signature, `signed_shard_block_header.signature`, is valid with respect to the `block_header.proposer_index` pubkey.
-- _[REJECT]_ The header is proposed by the expected `proposer_index` for the block's slot
+- _[IGNORE]_ The header is new enough to still be processed --
+  i.e. validate that `compute_epoch_at_slot(header.slot) >= get_previous_epoch(state)`
+- _[REJECT]_ The shard header is for an active shard --
+  i.e. `header.shard < get_active_shard_count(state, compute_epoch_at_slot(header.slot))`
+- _[REJECT]_ The `header.shard` MUST have a committee at the `header.slot` --
+  i.e. validate that `compute_committee_index_from_shard(state, header.slot, header.shard)` doesn't raise an error
+- _[IGNORE]_ The header is the first header with valid signature received for the `(header.proposer_index, header.slot, header.shard)` combination.
+- _[REJECT]_ The blob builder exists and has sufficient balance to back the fee payment.
+- _[REJECT]_ The header signature is valid for the aggregate of proposer and builder, `signed_blob_header.signature`,
+  i.e. `bls.FastAggregateVerify([builder_pubkey, proposer_pubkey], blob_signing_root, signed_blob_header.signature)`.
+- _[REJECT]_ The header is proposed by the expected `proposer_index` for the blob's `header.slot` and `header.shard`
   in the context of the current shuffling (defined by `header.body_summary.beacon_block_root`/`slot`).
   If the `proposer_index` cannot immediately be verified against the expected shuffling,
-  the block MAY be queued for later processing while proposers for the block's branch are calculated --
+  the blob MAY be queued for later processing while proposers for the blob's branch are calculated --
   in such a case _do not_ `REJECT`, instead `IGNORE` this message.
 
+##### `shard_blob_tx`
+
+Shard data-transactions, in the form of a `SignedShardBlobHeader` is published to the global `shard_blob_tx` subnet.
+These shard blob headers are signed solely by the blob-builder.
+
+The following validations MUST pass before forwarding the `signed_blob_header` on the network. Alias `header = signed_blob_header.message`
+
+- _[IGNORE]_ The `header` is not from a future slot (with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance) --
+  i.e. validate that `header.slot <= current_slot`
+  (a client MAY queue future headers for processing at the appropriate slot).
+- _[IGNORE]_ The header is new enough to still be processed --
+  i.e. validate that `compute_epoch_at_slot(header.slot) >= get_previous_epoch(state)`
+- _[REJECT]_ The shard header is for an active shard --
+  i.e. `header.shard < get_active_shard_count(state, compute_epoch_at_slot(header.slot))`
+- _[REJECT]_ The `header.shard` MUST have a committee at the `header.slot` --
+  i.e. validate that `compute_committee_index_from_shard(state, header.slot, header.shard)` doesn't raise an error
+- _[IGNORE]_ The header is the first header with valid signature received for the `(header.builder_index, header.slot, header.shard)` combination.
+- _[REJECT]_ The blob builder exists and has sufficient balance to back the fee payment.
+- _[IGNORE]_ The header fee SHOULD be higher than previously seen headers for `(header.slot, header.shard)`, from any builder.
+  Propagating nodes MAY increase fee increments in case of spam.
+- _[REJECT]_ The header signature is valid for ONLY the builder, `signed_blob_header.signature`,
+  i.e. `bls.Verify(builder_pubkey, blob_signing_root, signed_blob_header.signature)`. The signature is not an aggregate with the proposer.
+- _[REJECT]_ The header is designated for proposal by the expected `proposer_index` for the blob's `header.slot` and `header.shard`
+  in the context of the current shuffling (defined by `header.body_summary.beacon_block_root`/`slot`).
+  If the `proposer_index` cannot immediately be verified against the expected shuffling,
+  the blob MAY be queued for later processing while proposers for the blob's branch are calculated --
+  in such a case _do not_ `REJECT`, instead `IGNORE` this message.
 
 ##### `shard_proposer_slashing`
 
@@ -145,6 +169,6 @@ Shard proposer slashings, in the form of `ShardProposerSlashing`, are published 
 
 The following validations MUST pass before forwarding the `shard_proposer_slashing` on to the network.
 - _[IGNORE]_ The shard proposer slashing is the first valid shard proposer slashing received
-  for the proposer with index `proposer_slashing.signed_reference_1.message.proposer_index`.
-  The `slot` and `shard` are ignored, there are no per-shard slashings.
+  for the proposer with index `proposer_slashing.proposer_index`.
+  The `proposer_slashing.slot` and `proposer_slashing.shard` are ignored, there are no repeated or per-shard slashings.
 - _[REJECT]_ All of the conditions within `process_shard_proposer_slashing` pass validation.

--- a/specs/sharding/p2p-interface.md
+++ b/specs/sharding/p2p-interface.md
@@ -14,7 +14,7 @@
 - [Gossip domain](#gossip-domain)
   - [Topics and messages](#topics-and-messages)
     - [Shard blob subnets](#shard-blob-subnets)
-      - [`shard_blob_{subnet_id}`](#shard_blob_subnet_id)
+      - [`shard_block_{subnet_id}`](#shard_block_subnet_id)
     - [Global topics](#global-topics)
       - [`shard_header`](#shard_header)
       - [`shard_proposer_slashing`](#shard_proposer_slashing)
@@ -34,7 +34,7 @@ The adjustments and additions for Shards are outlined in this document.
 
 | Name | Value | Description |
 | ---- | ----- | ----------- |
-| `SHARD_BLOB_SUBNET_COUNT` | `64` | The number of `shard_blob_{subnet_id}` subnets used in the gossipsub protocol. |
+| `SHARD_BLOCK_SUBNET_COUNT` | `64` | The number of `shard_block_{subnet_id}` subnets used in the gossipsub protocol. |
 
 ## Gossip domain
 
@@ -44,22 +44,22 @@ Following the same scheme as the [Phase0 gossip topics](../phase0/p2p-interface.
 
 | Name                             | Message Type              |
 |----------------------------------|---------------------------|
-| `shard_blob_{subnet_id}`         | `SignedShardBlob`         |
-| `shard_header`                   | `SignedShardBlobHeader`   |
+| `shard_block_{subnet_id}`        | `SignedShardBlock`        |
+| `shard_block_header`             | `SignedShardBlockHeader`  |
 | `shard_proposer_slashing`        | `ShardProposerSlashing`   |
 
 The [DAS network specification](./das-p2p.md) defines additional topics.
 
-#### Shard blob subnets
+#### Shard block subnets
 
-Shard blob subnets are used to propagate shard blobs to subsections of the network.
+Shard block subnets are used by builders to make their blobs available after selection by shard proposers.
 
-##### `shard_blob_{subnet_id}`
+##### `shard_block_{subnet_id}`
 
-Shard block data, in the form of a `SignedShardBlob` is published to the `shard_blob_{subnet_id}` subnets.
+Shard block data, in the form of a `SignedShardBlock` is published to the `shard_block_{subnet_id}` subnets.
 
 ```python
-def compute_subnet_for_shard_blob(state: BeaconState, slot: Slot, shard: Shard) -> uint64:
+def compute_subnet_for_shard_block(state: BeaconState, slot: Slot, shard: Shard) -> uint64:
     """
     Compute the correct subnet for a shard blob publication.
     Note, this mimics compute_subnet_for_attestation().
@@ -69,11 +69,19 @@ def compute_subnet_for_shard_blob(state: BeaconState, slot: Slot, shard: Shard) 
     slots_since_epoch_start = Slot(slot % SLOTS_PER_EPOCH)
     committees_since_epoch_start = committees_per_slot * slots_since_epoch_start
 
-    return uint64((committees_since_epoch_start + committee_index) % SHARD_BLOB_SUBNET_COUNT)
+    return uint64((committees_since_epoch_start + committee_index) % SHARD_BLOCK_SUBNET_COUNT)
 ```
 
-The following validations MUST pass before forwarding the `signed_blob` (with inner `message` as `blob`) on the horizontal subnet or creating samples for it.
-- _[IGNORE]_ The `blob` is not from a future slot (with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance) --
+The following validations MUST pass before forwarding the `signed_block` on the horizontal subnet or creating samples for it.
+
+We define some aliases to the nested contents of `signed_block`:
+```python
+block: ShardBlock = signed_block.message
+signed_blob: SignedShardBlob = block.signed_blob
+blob: ShardBlob = signed_blob.message
+```
+
+- _[IGNORE]_ The `block` is not from a future slot (with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance) --
   i.e. validate that `blob.slot <= current_slot`
   (a client MAY queue future blobs for processing at the appropriate slot).
 - _[IGNORE]_ The `blob` is new enough to be still be processed --
@@ -81,36 +89,49 @@ The following validations MUST pass before forwarding the `signed_blob` (with in
 - _[REJECT]_ The shard should have a committee at slot --
   i.e. validate that `compute_committee_index_from_shard(state, blob.slot, blob.shard)` doesn't raise an error
 - _[REJECT]_ The shard blob is for the correct subnet --
-  i.e. `compute_subnet_for_shard_blob(state, blob.slot, blob.shard) == subnet_id`
-- _[IGNORE]_ The blob is the first blob with valid signature received for the `(blob.proposer_index, blob.slot, blob.shard)` combination.
-- _[REJECT]_ As already limited by the SSZ list-limit, it is important the blob is well-formatted and not too large.
+  i.e. `compute_subnet_for_shard_block(state, blob.slot, blob.shard) == subnet_id`
+- _[IGNORE]_ The block is the first block with valid signature received for the `(block.proposer_index, blob.slot, blob.shard)` combination.
+- _[REJECT]_ The blob is not too large, the data MUST NOT be larger than the SSZ list-limit, and a client MAY be more strict.
 - _[REJECT]_ The `blob.body.data` MUST NOT contain any point `p >= MODULUS`. Although it is a `uint256`, not the full 256 bit range is valid.
-- _[REJECT]_ The proposer signature, `signed_blob.signature`, is valid with respect to the `proposer_index` pubkey.
-- _[REJECT]_ The blob is proposed by the expected `proposer_index` for the blob's slot
+- _[REJECT]_ The block proposer signature, `signed_block.signature`, is valid with respect to the `proposer_index` pubkey.
+- _[REJECT]_ The blob builder exists and has sufficient balance to back the fee payment.
+- _[REJECT]_ The blob builder signature, `signed_blob.signature`, is valid with respect to the `builder_index` pubkey.
+- _[REJECT]_ The block is proposed by the expected `proposer_index` for the block's slot
   in the context of the current shuffling (defined by `blob.body.beacon_block_root`/`slot`).
   If the `proposer_index` cannot immediately be verified against the expected shuffling,
-  the block MAY be queued for later processing while proposers for the blob's branch are calculated --
+  the block MAY be queued for later processing while proposers for the block's branch are calculated --
   in such a case _do not_ `REJECT`, instead `IGNORE` this message.
 
 #### Global topics
 
-There are two additional global topics for Sharding, one is used to propagate shard blob headers (`shard_header`) to
-all nodes on the network. Another one is used to propagate validator message (`shard_proposer_slashing`).
+There are two additional global topics for Sharding.
 
-##### `shard_header`
+One is used to propagate shard block headers (`shard_block_header`) to all nodes on the network.
+Another one is used to propagate shard proposer slashings (`shard_proposer_slashing`).
 
-Shard header data, in the form of a `SignedShardBlobHeader` is published to the global `shard_header` subnet.
+##### `shard_block_header`
 
-The following validations MUST pass before forwarding the `signed_shard_blob_header` (with inner `message` as `header`) on the network.
-- _[IGNORE]_ The `header` is not from a future slot (with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance) --
-  i.e. validate that `header.slot <= current_slot`
+Shard header data, in the form of a `SignedShardBlockHeader` is published to the global `shard_block_header` subnet.
+Shard block headers select shard blob bids by builders, and should be timely to ensure builders can publish the full shard block timely.
+
+The following validations MUST pass before forwarding the `signed_block_header` (with inner `message` as `header`) on the network.
+
+We define some aliases to the nested contents of `signed_block_header`:
+```python
+block_header: ShardBlockHeader = signed_block_header.message
+signed_blob_header: SignedShardBlobHeader = header.signed_blob_header
+blob_header: ShardBlobHeader = signed_blob_header.message
+```
+
+- _[IGNORE]_ The header is not from a future slot (with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance) --
+  i.e. validate that `blob_header.slot <= current_slot`
   (a client MAY queue future headers for processing at the appropriate slot).
-- _[IGNORE]_ The `header` is new enough to be still be processed --
-  i.e. validate that `compute_epoch_at_slot(header.slot) >= get_previous_epoch(state)`
-- _[IGNORE]_ The header is the first header with valid signature received for the `(header.proposer_index, header.slot, header.shard)` combination.
-- _[REJECT]_ The shard should have a committee at slot --
-  i.e. validate that `compute_committee_index_from_shard(state, header.slot, header.shard)` doesn't raise an error
-- _[REJECT]_ The proposer signature, `signed_shard_blob_header.signature`, is valid with respect to the `proposer_index` pubkey.
+- _[IGNORE]_ The header is new enough to be still be processed --
+  i.e. validate that `compute_epoch_at_slot(blob_header.slot) >= get_previous_epoch(state)`
+- _[IGNORE]_ The header is the first header with valid signature received for the `(block_header.proposer_index, blob_header.slot, blob_header.shard)` combination.
+- _[REJECT]_ The `shard` MUST have a committee at the `slot` --
+  i.e. validate that `compute_committee_index_from_shard(state, blob_header.slot, blob_header.shard)` doesn't raise an error
+- _[REJECT]_ The proposer signature, `signed_shard_block_header.signature`, is valid with respect to the `block_header.proposer_index` pubkey.
 - _[REJECT]_ The header is proposed by the expected `proposer_index` for the block's slot
   in the context of the current shuffling (defined by `header.body_summary.beacon_block_root`/`slot`).
   If the `proposer_index` cannot immediately be verified against the expected shuffling,
@@ -124,6 +145,6 @@ Shard proposer slashings, in the form of `ShardProposerSlashing`, are published 
 
 The following validations MUST pass before forwarding the `shard_proposer_slashing` on to the network.
 - _[IGNORE]_ The shard proposer slashing is the first valid shard proposer slashing received
-  for the proposer with index `proposer_slashing.signed_header_1.message.proposer_index`.
+  for the proposer with index `proposer_slashing.signed_reference_1.message.proposer_index`.
   The `slot` and `shard` are ignored, there are no per-shard slashings.
 - _[REJECT]_ All of the conditions within `process_shard_proposer_slashing` pass validation.


### PR DESCRIPTION
Warning: this is highly experimental, not a definitive sharding design.

### Changes

- [x] Refactor to have "blobs" (data bundles) and "blocks" (selected bundles)
- [x] Define shard builders, creating shard blob headers to bid to proposers (data-transactions)
- [x] Remove the shard-committee requirement
- [x] Shard proposers charge shard builders for selecting their blob
- [x] Move availability (publishing) responsibility to shard blob builder (if they do not publish the full data, they lose their fee for no gain)
- [x] Network spec updates
- [ ] Sharding validator spec (new)
- [x] Builder pubkey and balance state
- [x] Reward/fee processing
- [ ] Change shard-block subnet backbone to use network-identity (p2p peer ID or node ID) to map nodes to subnets, and penalize (through p2p scoring) nodes that do not contribute to the backbone.


Here is a quick sketch of the message timing:
![image](https://user-images.githubusercontent.com/19571989/122492620-62af1080-cfe6-11eb-813a-bcf7a18ca198.png)


### Motivation

- **"Firewall" sharding MEV**:
  - If shard proposers get an equal opportunity to tap into the market around extracted value, validator work does not centralize the same way as shard builders might, while still enjoying fees.
  - Anyone is able to become a shard builder
  - See related eth1-mainnet discussions
    - https://ethresear.ch/t/proposer-block-builder-separation-friendly-fee-market-designs/9725
    - https://ethresear.ch/t/flashbots-frontrunning-the-mev-crisis/8251
- **Open shard data usage to any application**:
  - Shard blobs (flattened L2 transaction bundles) can be anything, and the validator does not have to learn the protocol
  - Shard proposers can be 
- **Reduce validator requirements**
  - Network load reduction
    - Previous shard-committee network backbone was not good enough (a ~1/5000 chance of proposing at any slot to do propagate full shard data)
    - Proposers can listen on a global data-tx topic. 64*N data-transactions without payload, per 12 seconds, is manageable. Or e.g. split in `shard_count / 4` subnets. Trade-off between proposer subscription management and gossip topic load. But greatly reduced compared to propagating full shard-blobs for a day for a single proposal.
    - No direct communication between builder and proposer necessary. The block header is small and propagated quickly, the builder picks up on it, takes the signature, and publishes the block (wrap their blob with the signature they just received). Multiple nodes can perform this for extra availability.
  - No need to make shard data available as shard proposer, the builder can specialize in this, and has incentive to.
    - Builder is not encumbered with the same validator network privacy concerns
    - Builder can stay on one shard, does not have to get shuffled, good for network stability
    - Builder can publish as group of nodes / L2 construction, with L2-specific compensation/organization
    - Builder incentive is better aligned with data publishing work after paying a fee upfront, independent of their performance.
- More fair MEV:
    - Builders can lock in a commitment to their blob (data bundle) before revealing it.
    - If reorgs or committee-mingling are a concern (i.e. full data was published, but not recognized by validators), a L2 can opt to encrypt their shard data and reveal the key later, independent of L1.
    - Separating out MEV means decentralized validator pools stand a better chance to split rewards fairly.
- No shard-committee caching necessary, simplifying the beacon node

### Related problems and proposed solutions

- *problem*: **volatile asks for data**, shard data usage is not constant
  *solution*: **EIP-1559 elasticity**, a base-fee is adjusted to target a desired capacity, while the actual capacity is elastic (like EIP-1559 does with gas).
  
- *problem*: **fee manipulation**, validators (N.B. proposers), should not gain/lose extra fees by manipulating capacity (capacity and prioritization are separated).
  *solution*: **burn the base fee**, as confirmed data decreases available resources, this compensates for protocol capacity, without favoring any validator in particular.

- *problem*: **shard proposers unfit to build**, shard proposers are selected on short notice, cannot carry the data-availability publisher responsibility well, nor specialize easily into wide variety of buildable blobs  
  *solution*: **builder separation**, shard proposers just perform leader work (selecting transactions), as random shuffled workers. The publisher responsibility is moved to builders.
  
- *problem*: **data-tx promises**, data that never becomes available is useless, but can occupy just as many resources (e.g. committee listens for data, maintains subnet, and may be attacked with double proposals)
  *solution*: **builder always pays fees**: shard proposers are paid for their opportunity by builders, regardless of availability.
  The base fee is paid for claiming the capacity as builder. Builders need to publish to utilize their opportunity.

- *problem*: **load-balancing**, if one shard is popular, and the other is not, then distributing load would be better
  *solution*: **uniformity, no chaining**, shards are as uniform as possible, to easily switch between them,
  use multiple of them per slot for a single application, and share a base-fee for cross-shard capacity elasticity.

- *problem*: **shard proposer privacy/targetability**
  *solution*: no weaker than beacon-proposers: a shard-proposer is randomly selected just in time, separates their network identity, and can opt for sentry/proxy/etc. approaches if necessary. 
  Long-term randomness improves (VDF) and single-secret-leader-election (SSLE) may be used. Involved gossip-topics are all global, no long-term topic->validator reversal concerns.

- *problem*: **shard data-tx market accessibility**, fast proposer shuffling requires proposers to be aware of the latest transactions.
  *solution*: data-transactions are small fee-paying headers, thus possible to share on a global gossip topic, and efficient / DoS-safe if filtered by fee.

- *problem*: **shard subnet stability**, if shard-proposers are only temporary, shard subnets have no stable participants
  *solution*: **builders and DHT-like assignments**:
    - builders are incentivized to always be subscribed to publish their data upon getting selected, and can do so more frequently than a normal shard proposer can
    - propagating shard-data of a single shard is doable by every node, subscribing to `shard_id = hash(nodeID.to_bytes() + ((slot + offset) // sub_window_duration).to_bytes()) % shard_count` can become part of peer-scoring (negative if not subscribed as expected).

- *problem/solution*: **MEV**, see motivation section.
- *problem/solution*: **Shard proposer requirements**, see motivation section.

### EIP-1559 translation to data layer

- Work unit: `gas` -> `samples`, data is measured in samples, subdivided into points (each point is approx. 32 bytes of data). Every sample in a block is an equal amount of work (for fee purposes).
- Transaction fields:
    - `max_priority_fee_per_gas` -> `max_priority_fee_per_sample`: maximum fees going towards shard proposer, after base fee is paid for
    - `max_fee_per_gas` -> `max_fee_per_sample`: cost bound of transaction
    - `gas_limit` -> ~~`sample_limit`~~: not necessary, fixed amount of data points (and thus samples) per blob
- Processing context:
    - `base_fee_per_gas` -> `base_fee_per_sample`: base fee, continually adjusted to target `TARGET_SAMPLES_PER_BLOB`
- Base fee adjustments:
    - `post.base_fee_per_sample = ` # TODO

### Roles

- builder:
   - dedicated to chosen work (L2s, shards, etc.)
   - burns for capacity
   - pays for priority
   - publishes partially signed headers as data-txs
   - publishes data for opportunity cost
- shard proposer
   - stateless, shuffled often
   - prioritizes for largest fee
   - selects for reward
   - completes data-tx signature to propose
   - proposes once, or slashable
   - publishes signed data-tx asap for better attester shard-reward share chances
- beacon proposer
   - includes new shard headers, 
   - slashes double shard proposals for reward
   - includes attestations for share of attester rewards
   - can back-fill missing shard-headers, and re-include attestations to get them confirmed
- attester
   - attests shard blobs, rewarded if confirmed
   - ensures availability with proof-of-custody scheme (= easily trip and slashed if acting lazy)

### Incentives

Fees/burns/penalties/rewards/incentives/shares:
- [burn] builder->chain: base-fee, target capacity, protect protocol
- [fee] builder->shard-proposer: priority fee, market to reduce data-tx spam
- [incentive] builder->attester: publishes data to attest, or opportunity lost, paid for nothing
- [slashing] shard-proposer-slashing
  - [incentive] shard-proposer->shard-proposer: only select single data-tx
  - [share] shard-proposer->beacon-proposer: share of slashing for finder
  - [share] burn the rest (against shard-beacon proposers collusion case)
- [incentive] beacon-proposer->beacon-proposer: include shard header, or miss out on attestation reward
- [reward] shard attester reward
  - [share] chain->attester: attested correct shard root
  - [share] chain->beacon-proposer: inclusion reward
- [incentive] user->builder: users can fund builder with any value to build something for them (e.g. pack rollup transactions), builder pays ETH to protocol
- Work in progress! (needs deeper look into attacks/incentives)


### TODO

- [x] Builder->Proposer fee payment computation. (like EIP 1559)
- [ ] Look into bug (and possible fix) found by @dankrad : a shard proposer publishing late may gain a fee, but the builder needs time to make the data available. It's possible to include the header on-chain the slot it's designated for, encouraging that may alleviate some of the concern. Alternatively incentives with an attestation bit for availability may help (iirc).
- [x] Adjust rewards (probably wait for rebase onto Altair, when we implement shard attestation rewards as well)
- [ ] Proofreads/review. Lots of new types and names, imminent mix-up/typos.
- [ ] Testing. We will make the spec executable for unit-testing and test-vector production after the rebase of the Merge and Sharding spec onto Altair.

### Out of scope

There are more (very experimental) ideas;
- Builder deposits
- Builder withdrawals
- Different types of builders. Should contracts be able to pay a fee for shard data? I.e. replace builder signature with something more generic to ensure fee payment. Data-construction may still be a problem though. BLS already allows for some more sophisticated signing setups than just a single signer.
- Shard staggering (sub slot delays per shard, to offer lower latency availability). Maybe for sharding refactor round 3 (if this is 2, and 1 was #2455)

And special thanks to @Nashatyrev for continued sharding prototype work on Teku. The spec is unstable at times, implementing a running prototype is not light work.
