### PR TITLE
Add randomized testing for Altair `process_sync_aggregate`

### DIFF
--- a/tests/core/pyspec/eth2spec/test/altair/block_processing/test_process_sync_aggregate.py
+++ b/tests/core/pyspec/eth2spec/test/altair/block_processing/test_process_sync_aggregate.py
@@ -489,7 +489,7 @@ def test_random_only_one_participant_with_duplicates(spec, state):
         spec,
         state,
         duplicates=True,
-        participation_fn=lambda comm: [rng.choice(comm)]
+        participation_fn=lambda comm: [rng.choice(comm)],
     )
 
 
@@ -502,7 +502,7 @@ def test_random_low_participation_with_duplicates(spec, state):
         spec,
         state,
         duplicates=True,
-        participation_fn=lambda comm: rng.sample(comm, int(len(comm) * 0.25))
+        participation_fn=lambda comm: rng.sample(comm, int(len(comm) * 0.25)),
     )
 
 
@@ -515,7 +515,7 @@ def test_random_high_participation_with_duplicates(spec, state):
         spec,
         state,
         duplicates=True,
-        participation_fn=lambda comm: rng.sample(comm, int(len(comm) * 0.75))
+        participation_fn=lambda comm: rng.sample(comm, int(len(comm) * 0.75)),
     )
 
 
@@ -528,7 +528,7 @@ def test_random_all_but_one_participating_with_duplicates(spec, state):
         spec,
         state,
         duplicates=True,
-        participation_fn=lambda comm: rng.sample(comm, len(comm) - 1)
+        participation_fn=lambda comm: rng.sample(comm, len(comm) - 1),
     )
 
 
@@ -542,7 +542,7 @@ def test_random_misc_balances_and_half_participation_with_duplicates(spec, state
         spec,
         state,
         duplicates=True,
-        participation_fn=lambda comm: rng.sample(comm, len(comm) // 2)
+        participation_fn=lambda comm: rng.sample(comm, len(comm) // 2),
     )
 
 
@@ -554,7 +554,7 @@ def test_random_only_one_participant_without_duplicates(spec, state):
     yield from _test_harness_for_randomized_test_case(
         spec,
         state,
-        participation_fn=lambda comm: [rng.choice(comm)]
+        participation_fn=lambda comm: [rng.choice(comm)],
     )
 
 
@@ -566,7 +566,7 @@ def test_random_low_participation_without_duplicates(spec, state):
     yield from _test_harness_for_randomized_test_case(
         spec,
         state,
-        participation_fn=lambda comm: rng.sample(comm, int(len(comm) * 0.25))
+        participation_fn=lambda comm: rng.sample(comm, int(len(comm) * 0.25)),
     )
 
 
@@ -578,7 +578,7 @@ def test_random_high_participation_without_duplicates(spec, state):
     yield from _test_harness_for_randomized_test_case(
         spec,
         state,
-        participation_fn=lambda comm: rng.sample(comm, int(len(comm) * 0.75))
+        participation_fn=lambda comm: rng.sample(comm, int(len(comm) * 0.75)),
     )
 
 
@@ -590,7 +590,7 @@ def test_random_all_but_one_participating_without_duplicates(spec, state):
     yield from _test_harness_for_randomized_test_case(
         spec,
         state,
-        participation_fn=lambda comm: rng.sample(comm, len(comm) - 1)
+        participation_fn=lambda comm: rng.sample(comm, len(comm) - 1),
     )
 
 
@@ -603,5 +603,5 @@ def test_random_misc_balances_and_half_participation_without_duplicates(spec, st
     yield from _test_harness_for_randomized_test_case(
         spec,
         state,
-        participation_fn=lambda comm: rng.sample(comm, len(comm) // 2)
+        participation_fn=lambda comm: rng.sample(comm, len(comm) // 2),
     )

--- a/tests/core/pyspec/eth2spec/test/altair/block_processing/test_process_sync_aggregate.py
+++ b/tests/core/pyspec/eth2spec/test/altair/block_processing/test_process_sync_aggregate.py
@@ -206,7 +206,6 @@ def test_sync_committee_rewards_duplicate_committee_no_participation(spec, state
     committee_indices = get_committee_indices(spec, state, duplicates=True)
     committee_size = len(committee_indices)
     committee_bits = [False] * committee_size
-    assert len(committee_bits) == committee_size
     active_validator_count = len(spec.get_active_validator_indices(state, spec.get_current_epoch(state)))
 
     # Preconditions of this test case

--- a/tests/core/pyspec/eth2spec/test/altair/block_processing/test_process_sync_aggregate.py
+++ b/tests/core/pyspec/eth2spec/test/altair/block_processing/test_process_sync_aggregate.py
@@ -17,8 +17,12 @@ from eth2spec.test.helpers.sync_committee import (
     compute_committee_indices,
 )
 from eth2spec.test.context import (
+    default_activation_threshold,
     expect_assertion_error,
+    misc_balances,
+    single_phase,
     with_altair_and_later,
+    with_custom_state,
     with_presets,
     spec_state_test,
     always_bls,
@@ -456,3 +460,148 @@ def test_proposer_in_committee_with_participation(spec, state):
         else:
             state_transition_and_sign_block(spec, state, block)
     raise AssertionError("failed to find a proposer in the sync committee set; check test setup")
+
+
+def _test_harness_for_randomized_test_case(spec, state, duplicates=False, participation_fn=None):
+    committee_indices = get_committee_indices(spec, state, duplicates=duplicates)
+
+    if participation_fn:
+        participating_indices = participation_fn(committee_indices)
+    else:
+        participating_indices = committee_indices
+
+    committee_bits = [index in participating_indices for index in committee_indices]
+    committee_size = len(committee_indices)
+    if duplicates:
+        assert committee_size > len(set(committee_indices))
+    else:
+        assert committee_size == len(set(committee_indices))
+
+    yield from run_successful_sync_committee_test(spec, state, committee_indices, committee_bits)
+
+
+@with_altair_and_later
+@with_presets([MAINNET], reason="to create duplicate committee")
+@spec_state_test
+def test_random_only_one_participant_with_duplicates(spec, state):
+    rng = random.Random(101)
+    yield from _test_harness_for_randomized_test_case(
+        spec,
+        state,
+        duplicates=True,
+        participation_fn=lambda comm: [rng.choice(comm)]
+    )
+
+
+@with_altair_and_later
+@with_presets([MAINNET], reason="to create duplicate committee")
+@spec_state_test
+def test_random_low_participation_with_duplicates(spec, state):
+    rng = random.Random(201)
+    yield from _test_harness_for_randomized_test_case(
+        spec,
+        state,
+        duplicates=True,
+        participation_fn=lambda comm: rng.sample(comm, int(len(comm) * 0.25))
+    )
+
+
+@with_altair_and_later
+@with_presets([MAINNET], reason="to create duplicate committee")
+@spec_state_test
+def test_random_high_participation_with_duplicates(spec, state):
+    rng = random.Random(301)
+    yield from _test_harness_for_randomized_test_case(
+        spec,
+        state,
+        duplicates=True,
+        participation_fn=lambda comm: rng.sample(comm, int(len(comm) * 0.75))
+    )
+
+
+@with_altair_and_later
+@with_presets([MAINNET], reason="to create duplicate committee")
+@spec_state_test
+def test_random_all_but_one_participating_with_duplicates(spec, state):
+    rng = random.Random(401)
+    yield from _test_harness_for_randomized_test_case(
+        spec,
+        state,
+        duplicates=True,
+        participation_fn=lambda comm: rng.sample(comm, len(comm) - 1)
+    )
+
+
+@with_altair_and_later
+@with_presets([MAINNET], reason="to create duplicate committee")
+@with_custom_state(balances_fn=misc_balances, threshold_fn=default_activation_threshold)
+@single_phase
+def test_random_misc_balances_and_half_participation_with_duplicates(spec, state):
+    rng = random.Random(1401)
+    yield from _test_harness_for_randomized_test_case(
+        spec,
+        state,
+        duplicates=True,
+        participation_fn=lambda comm: rng.sample(comm, len(comm) // 2)
+    )
+
+
+@with_altair_and_later
+@with_presets([MINIMAL], reason="to create nonduplicate committee")
+@spec_state_test
+def test_random_only_one_participant_without_duplicates(spec, state):
+    rng = random.Random(501)
+    yield from _test_harness_for_randomized_test_case(
+        spec,
+        state,
+        participation_fn=lambda comm: [rng.choice(comm)]
+    )
+
+
+@with_altair_and_later
+@with_presets([MINIMAL], reason="to create nonduplicate committee")
+@spec_state_test
+def test_random_low_participation_without_duplicates(spec, state):
+    rng = random.Random(601)
+    yield from _test_harness_for_randomized_test_case(
+        spec,
+        state,
+        participation_fn=lambda comm: rng.sample(comm, int(len(comm) * 0.25))
+    )
+
+
+@with_altair_and_later
+@with_presets([MINIMAL], reason="to create nonduplicate committee")
+@spec_state_test
+def test_random_high_participation_without_duplicates(spec, state):
+    rng = random.Random(701)
+    yield from _test_harness_for_randomized_test_case(
+        spec,
+        state,
+        participation_fn=lambda comm: rng.sample(comm, int(len(comm) * 0.75))
+    )
+
+
+@with_altair_and_later
+@with_presets([MINIMAL], reason="to create nonduplicate committee")
+@spec_state_test
+def test_random_all_but_one_participating_without_duplicates(spec, state):
+    rng = random.Random(801)
+    yield from _test_harness_for_randomized_test_case(
+        spec,
+        state,
+        participation_fn=lambda comm: rng.sample(comm, len(comm) - 1)
+    )
+
+
+@with_altair_and_later
+@with_presets([MINIMAL], reason="to create nonduplicate committee")
+@with_custom_state(balances_fn=misc_balances, threshold_fn=default_activation_threshold)
+@single_phase
+def test_random_misc_balances_and_half_participation_without_duplicates(spec, state):
+    rng = random.Random(1501)
+    yield from _test_harness_for_randomized_test_case(
+        spec,
+        state,
+        participation_fn=lambda comm: rng.sample(comm, len(comm) // 2)
+    )


### PR DESCRIPTION
Adds some randomized testing for sync aggregate processing.

The following test cases are added for **both** committees with duplicated indices and committees without duplicated indices.

- Only 1 member participates
- 25% participates (under the sync protocol threshold)
- 75% participates (over the sync protocol threshold)
- All but 1 member participates
- 50% participates with miscellaneous balances

NOTE: the cases of 0% participation and 100% participation are already covered by existing tests (however, they all use the same rng seed)