### PR TITLE
Update `get_next_sync_committee` notes

### DIFF
--- a/specs/altair/beacon-chain.md
+++ b/specs/altair/beacon-chain.md
@@ -278,7 +278,7 @@ def get_next_sync_committee_indices(state: BeaconState) -> Sequence[ValidatorInd
 
 #### `get_next_sync_committee`
 
-*Note*: The function `get_next_sync_committee` should only be called at sync committee period boundaries and upgrading state to Altair.
+*Note*: The function `get_next_sync_committee` should only be called at sync committee period boundaries and when [upgrading state to Altair](./fork.md#upgrading-the-state).
 
 ```python
 def get_next_sync_committee(state: BeaconState) -> SyncCommittee:

--- a/specs/altair/beacon-chain.md
+++ b/specs/altair/beacon-chain.md
@@ -278,7 +278,7 @@ def get_next_sync_committee_indices(state: BeaconState) -> Sequence[ValidatorInd
 
 #### `get_next_sync_committee`
 
-*Note*: The function `get_next_sync_committee` should only be called at sync committee period boundaries.
+*Note*: The function `get_next_sync_committee` should only be called at sync committee period boundaries and upgrading state to Altair.
 
 ```python
 def get_next_sync_committee(state: BeaconState) -> SyncCommittee:


### PR DESCRIPTION
This PR clarified that `get_next_sync_committee` is also called when upgrading beacon state to Altair