### PR TITLE
extend inactivity updates tests

### DIFF
--- a/tests/core/pyspec/eth2spec/test/altair/epoch_processing/test_process_inactivity_updates.py
+++ b/tests/core/pyspec/eth2spec/test/altair/epoch_processing/test_process_inactivity_updates.py
@@ -4,7 +4,7 @@ from eth2spec.test.context import spec_state_test, with_altair_and_later
 from eth2spec.test.helpers.inactivity_scores import randomize_inactivity_scores, zero_inactivity_scores
 from eth2spec.test.helpers.state import (
     next_epoch_via_block,
-    set_full_participation, set_full_participation_previous_epoch,
+    set_full_participation,
     set_empty_participation,
 )
 from eth2spec.test.helpers.epoch_processing import (
@@ -57,7 +57,6 @@ def run_inactivity_scores_test(spec, state, participation_fn=None, inactivity_sc
 @spec_state_test
 def test_all_zero_inactivity_scores_empty_participation(spec, state):
     yield from run_inactivity_scores_test(spec, state, set_empty_participation, zero_inactivity_scores)
-    # Not yet in leak so no leak score added even though no participation
     assert set(state.inactivity_scores) == set([0])
 
 
@@ -119,7 +118,7 @@ def test_all_zero_inactivity_scores_full_participation_leaking(spec, state):
     # Only set full participation in previous epoch to remain in leak
     yield from run_inactivity_scores_test(
         spec, state,
-        set_full_participation_previous_epoch, zero_inactivity_scores,
+        set_full_participation, zero_inactivity_scores,
     )
 
     # Check still in leak
@@ -189,7 +188,7 @@ def test_random_inactivity_scores_full_participation_leaking(spec, state):
     # Only set full participation in previous epoch to remain in leak
     yield from run_inactivity_scores_test(
         spec, state,
-        set_full_participation_previous_epoch, randomize_inactivity_scores, Random(33333),
+        set_full_participation, randomize_inactivity_scores, Random(33333),
     )
 
     # Check still in leak
@@ -222,7 +221,7 @@ def test_some_slashed_zero_scores_full_participation_leaking(spec, state):
     slash_some_validators(spec, state, rng=Random(33221))
     yield from run_inactivity_scores_test(
         spec, state,
-        set_full_participation_previous_epoch, zero_inactivity_scores,
+        set_full_participation, zero_inactivity_scores,
     )
 
     # Check still in leak
@@ -243,7 +242,7 @@ def test_some_slashed_full_random(spec, state):
     slash_some_validators(spec, state, rng=rng)
     yield from run_inactivity_scores_test(
         spec, state,
-        randomize_previous_epoch_participation, randomize_inactivity_scores, rng=rng,
+        randomize_attestation_participation, randomize_inactivity_scores, rng=rng,
     )
 
 
@@ -257,3 +256,6 @@ def test_some_slashed_full_random_leaking(spec, state):
         spec, state,
         randomize_previous_epoch_participation, randomize_inactivity_scores, rng=rng,
     )
+
+    # Check still in leak
+    assert spec.is_in_inactivity_leak(state)

--- a/tests/core/pyspec/eth2spec/test/altair/epoch_processing/test_process_inactivity_updates.py
+++ b/tests/core/pyspec/eth2spec/test/altair/epoch_processing/test_process_inactivity_updates.py
@@ -1,26 +1,20 @@
 from random import Random
 
 from eth2spec.test.context import spec_state_test, with_altair_and_later
-from eth2spec.test.helpers.inactivity_scores import randomize_inactivity_scores
+from eth2spec.test.helpers.inactivity_scores import randomize_inactivity_scores, zero_inactivity_scores
 from eth2spec.test.helpers.state import (
     next_epoch_via_block,
+    set_full_participation, set_full_participation_previous_epoch,
+    set_empty_participation,
 )
 from eth2spec.test.helpers.epoch_processing import (
     run_epoch_processing_with
 )
 from eth2spec.test.helpers.random import (
     randomize_attestation_participation,
+    randomize_previous_epoch_participation,
 )
-
-
-def set_full_participation(spec, state):
-    full_flags = spec.ParticipationFlags(0)
-    for flag_index in range(len(spec.PARTICIPATION_FLAG_WEIGHTS)):
-        full_flags = spec.add_flag(full_flags, flag_index)
-
-    for index in range(len(state.validators)):
-        state.current_epoch_participation[index] = full_flags
-        state.previous_epoch_participation[index] = full_flags
+from eth2spec.test.helpers.rewards import leaking
 
 
 def run_process_inactivity_updates(spec, state):
@@ -33,58 +27,169 @@ def test_genesis(spec, state):
     yield from run_process_inactivity_updates(spec, state)
 
 
+@with_altair_and_later
+@spec_state_test
+def test_genesis_random_scores(spec, state):
+    rng = Random(10102)
+    state.inactivity_scores = [rng.randint(0, 100) for _ in state.inactivity_scores]
+    pre_scores = state.inactivity_scores.copy()
+
+    yield from run_process_inactivity_updates(spec, state)
+
+    assert state.inactivity_scores == pre_scores
+
+
 #
 # Genesis epoch processing is skipped
 # Thus all of following tests all go past genesis epoch to test core functionality
 #
 
+def run_inactivity_scores_test(spec, state, participation_fn=None, inactivity_scores_fn=None, rng=Random(10101)):
+    next_epoch_via_block(spec, state)
+    if participation_fn is not None:
+        participation_fn(spec, state, rng=rng)
+    if inactivity_scores_fn is not None:
+        inactivity_scores_fn(spec, state, rng=rng)
+    yield from run_process_inactivity_updates(spec, state)
+
+
 @with_altair_and_later
 @spec_state_test
 def test_all_zero_inactivity_scores_empty_participation(spec, state):
-    next_epoch_via_block(spec, state)
-    state.inactivity_scores = [0] * len(state.validators)
-    yield from run_process_inactivity_updates(spec, state)
+    yield from run_inactivity_scores_test(spec, state, set_empty_participation, zero_inactivity_scores)
+    assert set(state.inactivity_scores) == set([0])
+
+
+@with_altair_and_later
+@spec_state_test
+@leaking()
+def test_all_zero_inactivity_scores_empty_participation_leaking(spec, state):
+    yield from run_inactivity_scores_test(spec, state, set_empty_participation, zero_inactivity_scores)
+
+    # Should still in be leak
+    assert spec.is_in_inactivity_leak(state)
+
+    for score in state.inactivity_scores:
+        assert score > 0
 
 
 @with_altair_and_later
 @spec_state_test
 def test_all_zero_inactivity_scores_random_participation(spec, state):
-    next_epoch_via_block(spec, state)
-    state.inactivity_scores = [0] * len(state.validators)
-    randomize_attestation_participation(spec, state, rng=Random(5555))
-    yield from run_process_inactivity_updates(spec, state)
+    yield from run_inactivity_scores_test(
+        spec, state,
+        randomize_attestation_participation, zero_inactivity_scores, rng=Random(5555),
+    )
+    assert set(state.inactivity_scores) == set([0])
+
+
+@with_altair_and_later
+@spec_state_test
+@leaking()
+def test_all_zero_inactivity_scores_random_participation_leaking(spec, state):
+    # Only randompize participation in previous epoch to remain in leak
+    yield from run_inactivity_scores_test(
+        spec, state,
+        randomize_previous_epoch_participation, zero_inactivity_scores, rng=Random(5555),
+    )
+
+    # Check still in leak
+    assert spec.is_in_inactivity_leak(state)
+
+    assert 0 in state.inactivity_scores
+    assert len(set(state.inactivity_scores)) > 1
 
 
 @with_altair_and_later
 @spec_state_test
 def test_all_zero_inactivity_scores_full_participation(spec, state):
-    next_epoch_via_block(spec, state)
-    set_full_participation(spec, state)
-    state.inactivity_scores = [0] * len(state.validators)
-    yield from run_process_inactivity_updates(spec, state)
+    yield from run_inactivity_scores_test(
+        spec, state,
+        set_full_participation, zero_inactivity_scores,
+    )
+
+    assert set(state.inactivity_scores) == set([0])
+
+
+@with_altair_and_later
+@spec_state_test
+@leaking()
+def test_all_zero_inactivity_scores_full_participation_leaking(spec, state):
+    # Only set full participation in previous epoch to remain in leak
+    yield from run_inactivity_scores_test(
+        spec, state,
+        set_full_participation_previous_epoch, zero_inactivity_scores,
+    )
+
+    # Check still in leak
+    assert spec.is_in_inactivity_leak(state)
+
+    assert set(state.inactivity_scores) == set([0])
 
 
 @with_altair_and_later
 @spec_state_test
 def test_random_inactivity_scores_empty_participation(spec, state):
-    next_epoch_via_block(spec, state)
-    randomize_inactivity_scores(spec, state, rng=Random(9999))
-    yield from run_process_inactivity_updates(spec, state)
+    yield from run_inactivity_scores_test(
+        spec, state,
+        set_empty_participation, randomize_inactivity_scores, Random(9999),
+    )
+
+
+@with_altair_and_later
+@spec_state_test
+@leaking()
+def test_random_inactivity_scores_empty_participation_leaking(spec, state):
+    yield from run_inactivity_scores_test(
+        spec, state,
+        set_empty_participation, randomize_inactivity_scores, Random(9999),
+    )
+
+    # Check still in leak
+    assert spec.is_in_inactivity_leak(state)
 
 
 @with_altair_and_later
 @spec_state_test
 def test_random_inactivity_scores_random_participation(spec, state):
-    next_epoch_via_block(spec, state)
-    randomize_attestation_participation(spec, state, rng=Random(22222))
-    randomize_inactivity_scores(spec, state, rng=Random(22222))
-    yield from run_process_inactivity_updates(spec, state)
+    yield from run_inactivity_scores_test(
+        spec, state,
+        randomize_attestation_participation, randomize_inactivity_scores, Random(22222),
+    )
+
+
+@with_altair_and_later
+@spec_state_test
+@leaking()
+def test_random_inactivity_scores_random_participation_leaking(spec, state):
+    # Only randompize participation in previous epoch to remain in leak
+    yield from run_inactivity_scores_test(
+        spec, state,
+        randomize_previous_epoch_participation, randomize_inactivity_scores, Random(22222),
+    )
+
+    # Check still in leak
+    assert spec.is_in_inactivity_leak(state)
 
 
 @with_altair_and_later
 @spec_state_test
 def test_random_inactivity_scores_full_participation(spec, state):
-    next_epoch_via_block(spec, state)
-    set_full_participation(spec, state)
-    randomize_inactivity_scores(spec, state, rng=Random(33333))
-    yield from run_process_inactivity_updates(spec, state)
+    yield from run_inactivity_scores_test(
+        spec, state,
+        set_full_participation, randomize_inactivity_scores, Random(33333),
+    )
+
+
+@with_altair_and_later
+@spec_state_test
+@leaking()
+def test_random_inactivity_scores_full_participation_leaking(spec, state):
+    # Only set full participation in previous epoch to remain in leak
+    yield from run_inactivity_scores_test(
+        spec, state,
+        set_full_participation_previous_epoch, randomize_inactivity_scores, Random(33333),
+    )
+
+    # Check still in leak
+    assert spec.is_in_inactivity_leak(state)

--- a/tests/core/pyspec/eth2spec/test/altair/epoch_processing/test_process_inactivity_updates.py
+++ b/tests/core/pyspec/eth2spec/test/altair/epoch_processing/test_process_inactivity_updates.py
@@ -57,6 +57,7 @@ def run_inactivity_scores_test(spec, state, participation_fn=None, inactivity_sc
 @spec_state_test
 def test_all_zero_inactivity_scores_empty_participation(spec, state):
     yield from run_inactivity_scores_test(spec, state, set_empty_participation, zero_inactivity_scores)
+    # Not yet in leak so no leak score added even though no participation
     assert set(state.inactivity_scores) == set([0])
 
 
@@ -87,7 +88,7 @@ def test_all_zero_inactivity_scores_random_participation(spec, state):
 @spec_state_test
 @leaking()
 def test_all_zero_inactivity_scores_random_participation_leaking(spec, state):
-    # Only randompize participation in previous epoch to remain in leak
+    # Only randomize participation in previous epoch to remain in leak
     yield from run_inactivity_scores_test(
         spec, state,
         randomize_previous_epoch_participation, zero_inactivity_scores, rng=Random(5555),

--- a/tests/core/pyspec/eth2spec/test/altair/rewards/test_inactivity_scores.py
+++ b/tests/core/pyspec/eth2spec/test/altair/rewards/test_inactivity_scores.py
@@ -112,7 +112,7 @@ def test_random_high_inactivity_scores_leaking(spec, state):
 
 @with_altair_and_later
 @spec_state_test
-@leaking(epochs=5)
-def test_random_high_inactivity_scores_leaking_5_epochs(spec, state):
+@leaking(epochs=8)
+def test_random_high_inactivity_scores_leaking_8_epochs(spec, state):
     randomize_inactivity_scores(spec, state, minimum=500000, maximum=5000000, rng=Random(9998))
     yield from rewards_helpers.run_test_full_random(spec, state, rng=Random(9998))

--- a/tests/core/pyspec/eth2spec/test/altair/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/altair/sanity/test_blocks.py
@@ -102,7 +102,7 @@ def test_inactivity_scores_leaking(spec, state):
     yield 'blocks', [signed_block]
     yield 'post', state
 
-    # No particiaption during a leak so all scores should increase
+    # No participation during a leak so all scores should increase
     for pre, post in zip(previous_inactivity_scores, state.inactivity_scores):
         assert post == pre + spec.config.INACTIVITY_SCORE_BIAS
 

--- a/tests/core/pyspec/eth2spec/test/altair/sanity/test_blocks.py
+++ b/tests/core/pyspec/eth2spec/test/altair/sanity/test_blocks.py
@@ -131,7 +131,5 @@ def test_inactivity_scores_full_participation_leaking(spec, state):
     yield 'post', state
 
     # Full particiaption during a leak so all scores should decrease by 1
-    print(previous_inactivity_scores)
-    print(state.inactivity_scores)
     for pre, post in zip(previous_inactivity_scores, state.inactivity_scores):
         assert post == pre - 1

--- a/tests/core/pyspec/eth2spec/test/helpers/inactivity_scores.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/inactivity_scores.py
@@ -3,3 +3,7 @@ from random import Random
 
 def randomize_inactivity_scores(spec, state, minimum=0, maximum=50000, rng=Random(4242)):
     state.inactivity_scores = [rng.randint(minimum, maximum) for _ in range(len(state.validators))]
+
+
+def zero_inactivity_scores(spec, state, rng=None):
+    state.inactivity_scores = [0] * len(state.validators)

--- a/tests/core/pyspec/eth2spec/test/helpers/random.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/random.py
@@ -100,6 +100,13 @@ def randomize_epoch_participation(spec, state, epoch, rng):
             epoch_participation[index] = flags
 
 
+def randomize_previous_epoch_participation(spec, state, rng=Random(8020)):
+    cached_prepare_state_with_attestations(spec, state)
+    randomize_epoch_participation(spec, state, spec.get_previous_epoch(state), rng)
+    if not is_post_altair(spec):
+        state.current_epoch_attestations = []
+
+
 def randomize_attestation_participation(spec, state, rng=Random(8020)):
     cached_prepare_state_with_attestations(spec, state)
     randomize_epoch_participation(spec, state, spec.get_previous_epoch(state), rng)

--- a/tests/core/pyspec/eth2spec/test/helpers/random.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/random.py
@@ -105,6 +105,8 @@ def randomize_previous_epoch_participation(spec, state, rng=Random(8020)):
     randomize_epoch_participation(spec, state, spec.get_previous_epoch(state), rng)
     if not is_post_altair(spec):
         state.current_epoch_attestations = []
+    else:
+        state.current_epoch_participation = [spec.ParticipationFlags(0b0000_0000) for _ in range(len(state.validators))]
 
 
 def randomize_attestation_participation(spec, state, rng=Random(8020)):

--- a/tests/core/pyspec/eth2spec/test/helpers/rewards.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/rewards.py
@@ -260,9 +260,9 @@ def run_get_inactivity_penalty_deltas(spec, state):
 
 def transition_state_to_leak(spec, state, epochs=None):
     if epochs is None:
-        # +1 to trigger inactivity_score transitions
-        epochs = spec.MIN_EPOCHS_TO_INACTIVITY_PENALTY + 1
-    assert epochs >= spec.MIN_EPOCHS_TO_INACTIVITY_PENALTY
+        # +2 because finality delay is based on previous_epoch and must be more than `MIN_EPOCHS_TO_INACTIVITY_PENALTY`
+        epochs = spec.MIN_EPOCHS_TO_INACTIVITY_PENALTY + 2
+    assert epochs > spec.MIN_EPOCHS_TO_INACTIVITY_PENALTY
 
     for _ in range(epochs):
         next_epoch(spec, state)

--- a/tests/core/pyspec/eth2spec/test/helpers/rewards.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/rewards.py
@@ -266,6 +266,7 @@ def transition_state_to_leak(spec, state, epochs=None):
 
     for _ in range(epochs):
         next_epoch(spec, state)
+    assert spec.is_in_inactivity_leak(state)
 
 
 _cache_dict = LRU(size=10)

--- a/tests/core/pyspec/eth2spec/test/phase0/rewards/test_leak.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/rewards/test_leak.py
@@ -145,8 +145,8 @@ def test_full_random_leak(spec, state):
 
 @with_all_phases
 @spec_state_test
-@leaking(epochs=5)
-def test_full_random_five_epoch_leak(spec, state):
+@leaking(epochs=7)
+def test_full_random_seven_epoch_leak(spec, state):
     yield from rewards_helpers.run_test_full_random(spec, state)
 
 


### PR DESCRIPTION
* Add a number of `process_inactivity_scores` tests
* Add one more sanity test for inactivity score updates block test
* [side bonus] Fix `leaking()` default calculation which only worked in most tests because they called variants of `prepare_state_with_attestations` which transitioned forward 1 epoch, pushing it truly into a leak

working through tests [here](https://docs.google.com/spreadsheets/d/1CbJy3iCRfXnG_jclMrDpktE-gEOXP9nAtGzoUYmuLVM/edit#gid=0). Those marked "PR 2511" are ones added in this PR