### PR TITLE
target sync committee aggregators to 16

### DIFF
--- a/specs/altair/validator.md
+++ b/specs/altair/validator.md
@@ -73,7 +73,7 @@ This document is currently illustrative for early Altair testnets and some parts
 
 | Name | Value | Unit |
 | - | - | :-: |
-| `TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE` | `2**2` (= 4) | validators |
+| `TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE` | `2**4` (= 16) | validators |
 | `SYNC_COMMITTEE_SUBNET_COUNT` | `4` | The number of sync committee subnets used in the gossipsub aggregation protocol. |
 
 ## Containers

--- a/tests/core/pyspec/eth2spec/test/altair/unittests/validator/test_validator.py
+++ b/tests/core/pyspec/eth2spec/test/altair/unittests/validator/test_validator.py
@@ -13,6 +13,7 @@ from eth2spec.test.context import (
     with_presets,
 )
 from eth2spec.test.helpers.constants import (
+    MAINNET,
     MINIMAL,
 )
 
@@ -260,16 +261,21 @@ def test_get_sync_committee_selection_proof(spec, state):
 
 @with_altair_and_later
 @spec_state_test
-@always_bls
+@with_presets([MAINNET], reason="to test against the mainnet SYNC_COMMITTEE_SIZE")
 def test_is_sync_committee_aggregator(spec, state):
-    sample_count = int(spec.SYNC_COMMITTEE_SIZE // spec.SYNC_COMMITTEE_SUBNET_COUNT)
+    sample_count = int(spec.SYNC_COMMITTEE_SIZE // spec.SYNC_COMMITTEE_SUBNET_COUNT) * 100
     is_aggregator_count = 0
     for i in range(sample_count):
         signature = spec.hash(i.to_bytes(32, byteorder="little"))
         if spec.is_sync_committee_aggregator(signature):
             is_aggregator_count += 1
 
-    assert is_aggregator_count == spec.TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE
+    # Accept ~10% deviation
+    assert (
+        spec.TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE * 100 * 0.9
+        <= is_aggregator_count
+        <= spec.TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE * 100 * 1.1
+    )
 
 
 @with_altair_and_later


### PR DESCRIPTION
@mcdee Did some quick math to show that the current configuration of `TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE` as `4` had an unacceptably high probability of sync committee subnets not having aggregators.

@hwwhww tossed the math and some options into this [spreadsheet](https://docs.google.com/spreadsheets/d/1C7pBqEWJgzk3_jesLkqJoDTnjZOODnGTOJUrxUMdxMA/edit?usp=sharing). Based on discussions, it looks like the choice of `16` is the right tradeoff to generally have a high chance of having at least one aggregator per slot, even on a daily basis.

Note, that `4` was naively selected to reduce chatter on yet another global channel, but assuming attestation aggregation is not already overwhelming, this increases global messages for ~6% (4 more 16 aggregator topics on top of the 64 attestation topics that also have 16 aggregator targets)