### PR TITLE
fix last beta.1 mainnet test

### DIFF
--- a/tests/core/pyspec/eth2spec/test/altair/epoch_processing/test_process_inactivity_updates.py
+++ b/tests/core/pyspec/eth2spec/test/altair/epoch_processing/test_process_inactivity_updates.py
@@ -218,7 +218,7 @@ def test_some_slashed_zero_scores_full_participation(spec, state):
 @spec_state_test
 @leaking()
 def test_some_slashed_zero_scores_full_participation_leaking(spec, state):
-    slash_some_validators(spec, state, rng=Random(33221))
+    slash_some_validators(spec, state, rng=Random(332243))
     yield from run_inactivity_scores_test(
         spec, state,
         set_full_participation, zero_inactivity_scores,


### PR DESCRIPTION
mainnet test generation failed on this test because it assumes that the proposer when `next_epoch_via_block` is called is not slashed, but the random `slash_some_validators` can collide with the to-be proposer.

Likely can make this more robust but just changing the random seed for now to avoid the collision (and get out these beta.1 tests!)


Mainnet testgen error being resolved below:
```
ERROR: failed to generate vector(s) for test /home/xymf/eth2/eth2.0-specs/../eth2.0-spec-tests/tests/mainnet/altair/epoch_processing/inactivity_updates/pyspec_tests/some_slashed_zero_scores_full_participation_leaking: Traceback (most recent call last):
  File "/home/xymf/eth2/eth2.0-specs/tests/generators/epoch_processing/venv/lib/python3.9/site-packages/eth2spec/gen_helpers/gen_base/gen_runner.py", line 142, in run_generator
    for (name, out_kind, data) in test_case.case_fn():
  File "/home/xymf/eth2/eth2.0-specs/tests/generators/epoch_processing/venv/lib/python3.9/site-packages/eth2spec/test/utils.py", line 31, in generator_mode
    for data in fn(*args, **kw):
  File "/home/xymf/eth2/eth2.0-specs/tests/generators/epoch_processing/venv/lib/python3.9/site-packages/eth2spec/test/context.py", line 281, in entry
    yield from res
  File "/home/xymf/eth2/eth2.0-specs/tests/generators/epoch_processing/venv/lib/python3.9/site-packages/eth2spec/test/altair/epoch_processing/test_process_inactivity_updates.py", line 222, in test_some_slashed_zero_scores_full_participation_leaking
    yield from run_inactivity_scores_test(
  File "/home/xymf/eth2/eth2.0-specs/tests/generators/epoch_processing/venv/lib/python3.9/site-packages/eth2spec/test/altair/epoch_processing/test_process_inactivity_updates.py", line 48, in run_inactivity_scores_test
    next_epoch_via_block(spec, state)
  File "/home/xymf/eth2/eth2.0-specs/tests/generators/epoch_processing/venv/lib/python3.9/site-packages/eth2spec/test/helpers/state.py", line 65, in next_epoch_via_block
    block = apply_empty_block(spec, state, state.slot + spec.SLOTS_PER_EPOCH - state.slot % spec.SLOTS_PER_EPOCH)
  File "/home/xymf/eth2/eth2.0-specs/tests/generators/epoch_processing/venv/lib/python3.9/site-packages/eth2spec/test/helpers/block.py", line 72, in apply_empty_block
    return transition_unsigned_block(spec, state, block)
  File "/home/xymf/eth2/eth2.0-specs/tests/generators/epoch_processing/venv/lib/python3.9/site-packages/eth2spec/test/helpers/block.py", line 63, in transition_unsigned_block
    spec.process_block(state, block)
  File "/home/xymf/eth2/eth2.0-specs/tests/generators/epoch_processing/venv/lib/python3.9/site-packages/eth2spec/altair/mainnet.py", line 1385, in process_block
    process_block_header(state, block)
  File "/home/xymf/eth2/eth2.0-specs/tests/generators/epoch_processing/venv/lib/python3.9/site-packages/eth2spec/altair/mainnet.py", line 1412, in process_block_header
    assert not proposer.slashed
AssertionError
```