### PR TITLE
Add tests for SyncAggregate with no participants and all zero signature

### DIFF
--- a/tests/core/pyspec/eth2spec/test/altair/block_processing/test_process_sync_aggregate.py
+++ b/tests/core/pyspec/eth2spec/test/altair/block_processing/test_process_sync_aggregate.py
@@ -131,6 +131,21 @@ def test_invalid_signature_no_participants(spec, state):
 @with_altair_and_later
 @spec_state_test
 @always_bls
+def test_invalid_signature_infinite_signature_with_participants(spec, state):
+    committee_indices = compute_committee_indices(spec, state, state.current_sync_committee)
+
+    block = build_empty_block_for_next_slot(spec, state)
+    # Exclude one participant whose signature was included.
+    block.body.sync_aggregate = spec.SyncAggregate(
+        sync_committee_bits=[True for _ in committee_indices],
+        sync_committee_signature=spec.G2_POINT_AT_INFINITY
+    )
+    yield from run_sync_committee_processing(spec, state, block, expect_exception=True)
+
+
+@with_altair_and_later
+@spec_state_test
+@always_bls
 def test_invalid_signature_extra_participant(spec, state):
     committee_indices = compute_committee_indices(spec, state, state.current_sync_committee)
     rng = random.Random(3030)

--- a/tests/core/pyspec/eth2spec/test/altair/block_processing/test_process_sync_aggregate.py
+++ b/tests/core/pyspec/eth2spec/test/altair/block_processing/test_process_sync_aggregate.py
@@ -116,6 +116,21 @@ def test_invalid_signature_missing_participant(spec, state):
 @with_altair_and_later
 @spec_state_test
 @always_bls
+def test_invalid_signature_no_participants(spec, state):
+    committee_indices = compute_committee_indices(spec, state, state.current_sync_committee)
+
+    block = build_empty_block_for_next_slot(spec, state)
+    # Exclude one participant whose signature was included.
+    block.body.sync_aggregate = spec.SyncAggregate(
+        sync_committee_bits=[False for _ in committee_indices],
+        sync_committee_signature=b'\x00' * 96
+    )
+    yield from run_sync_committee_processing(spec, state, block, expect_exception=True)
+
+
+@with_altair_and_later
+@spec_state_test
+@always_bls
 def test_invalid_signature_extra_participant(spec, state):
     committee_indices = compute_committee_indices(spec, state, state.current_sync_committee)
     rng = random.Random(3030)


### PR DESCRIPTION
Adds a test for `SyncAggregate` processing where there are no participants and the signature is all zeros instead of the infinite point.
Also a test for the infinite signature when there are participants.