### PR TITLE
Update remerkleable to v0.1.22: list lookup speed improvement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1024,7 +1024,7 @@ setup(
         "py_ecc==5.2.0",
         "milagro_bls_binding==1.6.3",
         "dataclasses==0.6",
-        "remerkleable==0.1.21",
+        "remerkleable==0.1.22",
         RUAMEL_YAML_VERSION,
         "lru-dict==1.1.6",
         MARKO_VERSION,


### PR DESCRIPTION
Previously remerkleable would continue to use the SSZ-typed integers internally, after checking bounds, and do type-coercions/checks on every step down in the tree, in extreme cases. This release fixes that, and should improve the eth2-specs testing speed.

Also, reminder: run `citest` locally to use CI settings (milagro BLS instead of py-ecc BLS), for faster testing.

7m8s -> 5m35s