### PR TITLE
Rebase The Merge onto Altair base functionality

### DIFF
--- a/specs/merge/beacon-chain.md
+++ b/specs/merge/beacon-chain.md
@@ -1,7 +1,5 @@
 # Ethereum 2.0 The Merge
 
-**Warning**: This document is currently based on [Phase 0](../phase0/beacon-chain.md) and will be rebased on [Altair](../altair/beacon-chain.md).
-
 **Notice**: This document is a work-in-progress for researchers and implementers.
 
 ## Table of contents
@@ -69,7 +67,17 @@ This patch adds transaction execution to the beacon chain as part of the Merge f
 #### `BeaconBlockBody`
 
 ```python
-class BeaconBlockBody(phase0.BeaconBlockBody):
+class BeaconBlockBody(Container):
+    randao_reveal: BLSSignature
+    eth1_data: Eth1Data  # Eth1 data vote
+    graffiti: Bytes32  # Arbitrary data
+    # Operations
+    proposer_slashings: List[ProposerSlashing, MAX_PROPOSER_SLASHINGS]
+    attester_slashings: List[AttesterSlashing, MAX_ATTESTER_SLASHINGS]
+    attestations: List[Attestation, MAX_ATTESTATIONS]
+    deposits: List[Deposit, MAX_DEPOSITS]
+    voluntary_exits: List[SignedVoluntaryExit, MAX_VOLUNTARY_EXITS]
+    sync_aggregate: SyncAggregate
     # Execution
     execution_payload: ExecutionPayload  # [New in Merge]
 ```
@@ -77,7 +85,41 @@ class BeaconBlockBody(phase0.BeaconBlockBody):
 #### `BeaconState`
 
 ```python
-class BeaconState(phase0.BeaconState):
+class BeaconState(altair.BeaconState):
+    # Versioning
+    genesis_time: uint64
+    genesis_validators_root: Root
+    slot: Slot
+    fork: Fork
+    # History
+    latest_block_header: BeaconBlockHeader
+    block_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
+    state_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
+    historical_roots: List[Root, HISTORICAL_ROOTS_LIMIT]
+    # Eth1
+    eth1_data: Eth1Data
+    eth1_data_votes: List[Eth1Data, EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH]
+    eth1_deposit_index: uint64
+    # Registry
+    validators: List[Validator, VALIDATOR_REGISTRY_LIMIT]
+    balances: List[Gwei, VALIDATOR_REGISTRY_LIMIT]
+    # Randomness
+    randao_mixes: Vector[Bytes32, EPOCHS_PER_HISTORICAL_VECTOR]
+    # Slashings
+    slashings: Vector[Gwei, EPOCHS_PER_SLASHINGS_VECTOR]  # Per-epoch sums of slashed effective balances
+    # Participation
+    previous_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
+    current_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
+    # Finality
+    justification_bits: Bitvector[JUSTIFICATION_BITS_LENGTH]  # Bit set for every recent justified epoch
+    previous_justified_checkpoint: Checkpoint
+    current_justified_checkpoint: Checkpoint
+    finalized_checkpoint: Checkpoint
+    # Inactivity
+    inactivity_scores: List[uint64, VALIDATOR_REGISTRY_LIMIT]
+    # Sync
+    current_sync_committee: SyncCommittee
+    next_sync_committee: SyncCommittee
     # Execution
     latest_execution_payload_header: ExecutionPayloadHeader  # [New in Merge]
 ```
@@ -190,6 +232,7 @@ def process_block(state: BeaconState, block: BeaconBlock) -> None:
     process_randao(state, block.body)
     process_eth1_data(state, block.body)
     process_operations(state, block.body)
+    process_sync_aggregate(state, block.body.sync_aggregate)
     if is_execution_enabled(state, block.body):
         process_execution_payload(state, block.body.execution_payload, EXECUTION_ENGINE)  # [New in Merge]
 ```
@@ -232,7 +275,7 @@ def process_execution_payload(state: BeaconState, payload: ExecutionPayload, exe
 
 *Note*: The function `initialize_beacon_state_from_eth1` is modified for pure Merge testing only.
 
-*Note*: The function `initialize_beacon_state_from_eth1` is modified to use `MERGE_FORK_VERSION` and initialize `latest_execution_payload_header`.
+*Note*: The function `initialize_beacon_state_from_eth1` is modified: (1) using `MERGE_FORK_VERSION` as the current fork version, (2) utilizing the Merge `BeaconBlockBody` when constructing the initial `latest_block_header`, and (3) initialize `latest_execution_payload_header`.
 
 ```python
 def initialize_beacon_state_from_eth1(eth1_block_hash: Bytes32,
@@ -268,6 +311,11 @@ def initialize_beacon_state_from_eth1(eth1_block_hash: Bytes32,
 
     # Set genesis validators root for domain separation and chain versioning
     state.genesis_validators_root = hash_tree_root(state.validators)
+
+    # Fill in sync committees
+    # Note: A duplicate committee is assigned for the current and next committee at genesis
+    state.current_sync_committee = get_next_sync_committee(state)
+    state.next_sync_committee = get_next_sync_committee(state)
 
     # [New in Merge] Initialize the execution payload header (with block number set to 0)
     state.latest_execution_payload_header.block_hash = eth1_block_hash

--- a/specs/merge/beacon-chain.md
+++ b/specs/merge/beacon-chain.md
@@ -85,7 +85,7 @@ class BeaconBlockBody(Container):
 #### `BeaconState`
 
 ```python
-class BeaconState(altair.BeaconState):
+class BeaconState(Container):
     # Versioning
     genesis_time: uint64
     genesis_validators_root: Root

--- a/specs/merge/fork.md
+++ b/specs/merge/fork.md
@@ -91,6 +91,9 @@ def upgrade_to_merge(pre: altair.BeaconState) -> BeaconState:
         finalized_checkpoint=pre.finalized_checkpoint,
         # Inactivity
         inactivity_scores=pre.inactivity_scores,
+        # Sync
+        current_sync_committee=pre.current_sync_committee,
+        next_sync_committee=pre.next_sync_committee,
         # Execution-layer
         latest_execution_payload_header=ExecutionPayloadHeader(),
     )

--- a/specs/merge/validator.md
+++ b/specs/merge/validator.md
@@ -1,7 +1,5 @@
 # Ethereum 2.0 The Merge
 
-**Warning:** This document is currently based on [Phase 0](../phase0/validator.md) but will be rebased to [Altair](../altair/validator.md) once the latter is shipped.
-
 **Notice**: This document is a work-in-progress for researchers and implementers.
 
 ## Table of contents
@@ -29,9 +27,11 @@ This document represents the changes to be made in the code of an "honest valida
 
 ## Prerequisites
 
-This document is an extension of the [Phase 0 -- Validator](../phase0/validator.md). All behaviors and definitions defined in the Phase 0 doc carry over unless explicitly noted or overridden.
+This document is an extension of the [Altair -- Honest Validator](../altair/validator.md) guide.
+All behaviors and definitions defined in this document, and documents it extends, carry over unless explicitly noted or overridden.
 
-All terminology, constants, functions, and protocol mechanics defined in the updated Beacon Chain doc of [The Merge](./beacon-chain.md) are requisite for this document and used throughout. Please see related Beacon Chain doc before continuing and use them as a reference throughout.
+All terminology, constants, functions, and protocol mechanics defined in the updated Beacon Chain doc of [The Merge](./beacon-chain.md) are requisite for this document and used throughout.
+Please see related Beacon Chain doc before continuing and use them as a reference throughout.
 
 ## Protocols
 

--- a/specs/sharding/p2p-interface.md
+++ b/specs/sharding/p2p-interface.md
@@ -29,8 +29,7 @@
 
 ## Introduction
 
-The specification of these changes continues in the same format as the [Phase0](../phase0/p2p-interface.md) and
-[Altair](../altair/p2p-interface.md) network specifications, and assumes them as pre-requisite.
+The specification of these changes continues in the same format as the network specifications of previous upgrades, and assumes them as pre-requisite.
 The adjustments and additions for Shards are outlined in this document.
 
 ## Constants

--- a/tests/core/pyspec/eth2spec/test/context.py
+++ b/tests/core/pyspec/eth2spec/test/context.py
@@ -347,10 +347,6 @@ def with_phases(phases, other_phases=None):
                 preset_name = kw.pop('preset')
             targets = spec_targets[preset_name]
 
-            # TODO: test state is dependent on phase0 but is immediately transitioned to later phases.
-            #  A new state-creation helper for later phases may be in place, and then tests can run without phase0
-            available_phases.add(PHASE0)
-
             # Populate all phases for multi-phase tests
             phase_dir = {}
             if PHASE0 in available_phases:
@@ -433,23 +429,15 @@ def with_config_overrides(config_overrides):
 
 
 def is_post_altair(spec):
-    if spec.fork == MERGE:  # TODO: remove parallel Altair-Merge condition after rebase.
-        return False
-    if spec.fork in FORKS_BEFORE_ALTAIR:
-        return False
-    return True
+    return spec.fork not in FORKS_BEFORE_ALTAIR
 
 
 def is_post_merge(spec):
-    if spec.fork == ALTAIR:  # TODO: remove parallel Altair-Merge condition after rebase.
-        return False
-    if spec.fork in FORKS_BEFORE_MERGE:
-        return False
-    return True
+    return spec.fork not in FORKS_BEFORE_MERGE
 
 
-with_altair_and_later = with_phases([ALTAIR])  # TODO: include Merge, but not until Merge work is rebased.
-with_merge_and_later = with_phases([MERGE])
+with_altair_and_later = with_phases([ALTAIR, MERGE])
+with_merge_and_later = with_phases([MERGE])  # TODO: include sharding when spec stabilizes.
 
 
 def fork_transition_test(pre_fork_name, post_fork_name, fork_epoch=None):

--- a/tests/core/pyspec/eth2spec/test/helpers/block_processing.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/block_processing.py
@@ -30,6 +30,7 @@ def get_process_calls(spec):
         # Merge
         'process_application_payload':
             lambda state, block: spec.process_application_payload(state, block.body),
+        # TODO: add sharding processing functions when spec stabilizes.
         # Custody Game
         'process_custody_game_operations':
             lambda state, block: spec.process_custody_game_operations(state, block.body),

--- a/tests/core/pyspec/eth2spec/test/helpers/constants.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/constants.py
@@ -18,12 +18,9 @@ DAS = SpecForkName('das')
 ALL_PHASES = (PHASE0, ALTAIR, MERGE)
 # The forks that output to the test vectors.
 TESTGEN_FORKS = (PHASE0, ALTAIR, MERGE)
-# TODO: everything runs in parallel to Altair.
-# After features are rebased on the Altair fork, this can be reduced to just PHASE0.
-FORKS_BEFORE_ALTAIR = (PHASE0, MERGE, SHARDING, CUSTODY_GAME, DAS)
 
-# TODO: when rebasing Merge onto Altair, add ALTAIR to this tuple.
-FORKS_BEFORE_MERGE = (PHASE0,)
+FORKS_BEFORE_ALTAIR = (PHASE0,)
+FORKS_BEFORE_MERGE = (PHASE0, ALTAIR)
 
 #
 # Config

--- a/tests/core/pyspec/eth2spec/test/helpers/epoch_processing.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/epoch_processing.py
@@ -28,7 +28,7 @@ def get_process_calls(spec):
             'process_participation_record_updates'
         ),
         'process_sync_committee_updates',  # altair
-        'process_shard_epoch_increment'  # sharding
+        # TODO: add sharding processing functions when spec stabilizes.
     ]
 
 

--- a/tests/core/pyspec/eth2spec/test/helpers/genesis.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/genesis.py
@@ -1,7 +1,6 @@
 from eth2spec.test.helpers.constants import (
-    ALTAIR,
-    FORKS_BEFORE_ALTAIR,
-    MERGE,
+    ALTAIR, MERGE,
+    FORKS_BEFORE_ALTAIR, FORKS_BEFORE_MERGE,
 )
 from eth2spec.test.helpers.keys import pubkeys
 
@@ -25,11 +24,13 @@ def create_genesis_state(spec, validator_balances, activation_threshold):
     deposit_root = b'\x42' * 32
 
     eth1_block_hash = b'\xda' * 32
+    previous_version = spec.config.GENESIS_FORK_VERSION
     current_version = spec.config.GENESIS_FORK_VERSION
 
     if spec.fork == ALTAIR:
         current_version = spec.config.ALTAIR_FORK_VERSION
     elif spec.fork == MERGE:
+        previous_version = spec.config.ALTAIR_FORK_VERSION
         current_version = spec.config.MERGE_FORK_VERSION
 
     state = spec.BeaconState(
@@ -41,7 +42,7 @@ def create_genesis_state(spec, validator_balances, activation_threshold):
             block_hash=eth1_block_hash,
         ),
         fork=spec.Fork(
-            previous_version=spec.config.GENESIS_FORK_VERSION,
+            previous_version=previous_version,
             current_version=current_version,
             epoch=spec.GENESIS_EPOCH,
         ),
@@ -72,5 +73,10 @@ def create_genesis_state(spec, validator_balances, activation_threshold):
         # Note: A duplicate committee is assigned for the current and next committee at genesis
         state.current_sync_committee = spec.get_next_sync_committee(state)
         state.next_sync_committee = spec.get_next_sync_committee(state)
+
+    if spec.fork not in FORKS_BEFORE_MERGE:
+        # Initialize the execution payload header (with block number and genesis time set to 0)
+        state.latest_execution_payload_header.block_hash = eth1_block_hash
+        state.latest_execution_payload_header.random = eth1_block_hash
 
     return state

--- a/tests/core/pyspec/eth2spec/test/helpers/merge/fork.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/merge/fork.py
@@ -4,9 +4,6 @@ MERGE_FORK_TEST_META_TAGS = {
 
 
 def run_fork_test(post_spec, pre_state):
-    # Clean up state to be more realistic
-    pre_state.current_epoch_attestations = []
-
     yield 'pre', pre_state
 
     post_state = post_spec.upgrade_to_merge(pre_state)

--- a/tests/core/pyspec/eth2spec/test/helpers/merge/fork.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/merge/fork.py
@@ -24,10 +24,14 @@ def run_fork_test(post_spec, pre_state):
         'randao_mixes',
         # Slashings
         'slashings',
-        # Attestations
-        'previous_epoch_attestations', 'current_epoch_attestations',
+        # Participation
+        'previous_epoch_participation', 'current_epoch_participation',
         # Finality
         'justification_bits', 'previous_justified_checkpoint', 'current_justified_checkpoint', 'finalized_checkpoint',
+        # Inactivity
+        'inactivity_scores',
+        # Sync
+        'current_sync_committee', 'next_sync_committee'
     ]
     for field in stable_fields:
         assert getattr(pre_state, field) == getattr(post_state, field)

--- a/tests/core/pyspec/eth2spec/test/merge/fork/test_merge_fork_basic.py
+++ b/tests/core/pyspec/eth2spec/test/merge/fork/test_merge_fork_basic.py
@@ -7,7 +7,7 @@ from eth2spec.test.context import (
 )
 from eth2spec.test.utils import with_meta_tags
 from eth2spec.test.helpers.constants import (
-    PHASE0, MERGE,
+    ALTAIR, MERGE,
     MINIMAL,
 )
 from eth2spec.test.helpers.state import (
@@ -20,7 +20,7 @@ from eth2spec.test.helpers.merge.fork import (
 )
 
 
-@with_phases(phases=[PHASE0], other_phases=[MERGE])
+@with_phases(phases=[ALTAIR], other_phases=[MERGE])
 @spec_test
 @with_state
 @with_meta_tags(MERGE_FORK_TEST_META_TAGS)
@@ -28,7 +28,7 @@ def test_fork_base_state(spec, phases, state):
     yield from run_fork_test(phases[MERGE], state)
 
 
-@with_phases(phases=[PHASE0], other_phases=[MERGE])
+@with_phases(phases=[ALTAIR], other_phases=[MERGE])
 @spec_test
 @with_state
 @with_meta_tags(MERGE_FORK_TEST_META_TAGS)
@@ -37,7 +37,7 @@ def test_fork_next_epoch(spec, phases, state):
     yield from run_fork_test(phases[MERGE], state)
 
 
-@with_phases(phases=[PHASE0], other_phases=[MERGE])
+@with_phases(phases=[ALTAIR], other_phases=[MERGE])
 @spec_test
 @with_state
 @with_meta_tags(MERGE_FORK_TEST_META_TAGS)
@@ -46,7 +46,7 @@ def test_fork_next_epoch_with_block(spec, phases, state):
     yield from run_fork_test(phases[MERGE], state)
 
 
-@with_phases(phases=[PHASE0], other_phases=[MERGE])
+@with_phases(phases=[ALTAIR], other_phases=[MERGE])
 @spec_test
 @with_state
 @with_meta_tags(MERGE_FORK_TEST_META_TAGS)
@@ -56,7 +56,7 @@ def test_fork_many_next_epoch(spec, phases, state):
     yield from run_fork_test(phases[MERGE], state)
 
 
-@with_phases(phases=[PHASE0], other_phases=[MERGE])
+@with_phases(phases=[ALTAIR], other_phases=[MERGE])
 @with_custom_state(balances_fn=low_balances, threshold_fn=lambda spec: spec.config.EJECTION_BALANCE)
 @spec_test
 @with_meta_tags(MERGE_FORK_TEST_META_TAGS)
@@ -64,7 +64,7 @@ def test_fork_random_low_balances(spec, phases, state):
     yield from run_fork_test(phases[MERGE], state)
 
 
-@with_phases(phases=[PHASE0], other_phases=[MERGE])
+@with_phases(phases=[ALTAIR], other_phases=[MERGE])
 @with_custom_state(balances_fn=misc_balances, threshold_fn=lambda spec: spec.config.EJECTION_BALANCE)
 @spec_test
 @with_meta_tags(MERGE_FORK_TEST_META_TAGS)
@@ -72,7 +72,7 @@ def test_fork_random_misc_balances(spec, phases, state):
     yield from run_fork_test(phases[MERGE], state)
 
 
-@with_phases(phases=[PHASE0], other_phases=[MERGE])
+@with_phases(phases=[ALTAIR], other_phases=[MERGE])
 @with_presets([MINIMAL],
               reason="mainnet config leads to larger validator set than limit of public/private keys pre-generated")
 @with_custom_state(balances_fn=large_validator_set, threshold_fn=lambda spec: spec.config.EJECTION_BALANCE)

--- a/tests/core/pyspec/eth2spec/test/merge/fork/test_merge_fork_random.py
+++ b/tests/core/pyspec/eth2spec/test/merge/fork/test_merge_fork_random.py
@@ -16,10 +16,7 @@ from eth2spec.test.helpers.merge.fork import (
     MERGE_FORK_TEST_META_TAGS,
     run_fork_test,
 )
-from eth2spec.test.helpers.random import (
-    randomize_state,
-    randomize_attestation_participation,
-)
+from eth2spec.test.helpers.random import randomize_state
 
 
 @with_phases(phases=[ALTAIR], other_phases=[MERGE])
@@ -56,39 +53,6 @@ def test_merge_fork_random_2(spec, phases, state):
 def test_merge_fork_random_3(spec, phases, state):
     randomize_state(spec, state, rng=Random(4040))
     yield from run_fork_test(phases[MERGE], state)
-
-
-@with_phases(phases=[ALTAIR], other_phases=[MERGE])
-@spec_test
-@with_state
-@with_meta_tags(MERGE_FORK_TEST_META_TAGS)
-def test_merge_fork_random_duplicate_attestations(spec, phases, state):
-    randomize_state(spec, state, rng=Random(1111))
-    # Note: `run_fork_test` empties `current_epoch_attestations`
-    state.previous_epoch_attestations = state.previous_epoch_attestations + state.previous_epoch_attestations
-    yield from run_fork_test(phases[MERGE], state)
-
-
-@with_phases(phases=[ALTAIR], other_phases=[MERGE])
-@spec_test
-@with_state
-@with_meta_tags(MERGE_FORK_TEST_META_TAGS)
-def test_merge_fork_random_mismatched_attestations(spec, phases, state):
-    # Create a random state
-    randomize_state(spec, state, rng=Random(2222))
-
-    # Now make two copies
-    state_0 = state.copy()
-    state_1 = state.copy()
-
-    # Randomize attestation participation of both
-    randomize_attestation_participation(spec, state_0, rng=Random(3333))
-    randomize_attestation_participation(spec, state_1, rng=Random(4444))
-
-    # Note: `run_fork_test` empties `current_epoch_attestations`
-    # Use pending attestations from both random states in a single state for testing
-    state_0.previous_epoch_attestations = state_0.previous_epoch_attestations + state_1.previous_epoch_attestations
-    yield from run_fork_test(phases[MERGE], state_0)
 
 
 @with_phases(phases=[ALTAIR], other_phases=[MERGE])

--- a/tests/core/pyspec/eth2spec/test/merge/fork/test_merge_fork_random.py
+++ b/tests/core/pyspec/eth2spec/test/merge/fork/test_merge_fork_random.py
@@ -9,7 +9,7 @@ from eth2spec.test.context import (
 )
 from eth2spec.test.utils import with_meta_tags
 from eth2spec.test.helpers.constants import (
-    PHASE0, MERGE,
+    ALTAIR, MERGE,
     MINIMAL,
 )
 from eth2spec.test.helpers.merge.fork import (
@@ -22,7 +22,7 @@ from eth2spec.test.helpers.random import (
 )
 
 
-@with_phases(phases=[PHASE0], other_phases=[MERGE])
+@with_phases(phases=[ALTAIR], other_phases=[MERGE])
 @spec_test
 @with_state
 @with_meta_tags(MERGE_FORK_TEST_META_TAGS)
@@ -31,7 +31,7 @@ def test_merge_fork_random_0(spec, phases, state):
     yield from run_fork_test(phases[MERGE], state)
 
 
-@with_phases(phases=[PHASE0], other_phases=[MERGE])
+@with_phases(phases=[ALTAIR], other_phases=[MERGE])
 @spec_test
 @with_state
 @with_meta_tags(MERGE_FORK_TEST_META_TAGS)
@@ -40,7 +40,7 @@ def test_merge_fork_random_1(spec, phases, state):
     yield from run_fork_test(phases[MERGE], state)
 
 
-@with_phases(phases=[PHASE0], other_phases=[MERGE])
+@with_phases(phases=[ALTAIR], other_phases=[MERGE])
 @spec_test
 @with_state
 @with_meta_tags(MERGE_FORK_TEST_META_TAGS)
@@ -49,7 +49,7 @@ def test_merge_fork_random_2(spec, phases, state):
     yield from run_fork_test(phases[MERGE], state)
 
 
-@with_phases(phases=[PHASE0], other_phases=[MERGE])
+@with_phases(phases=[ALTAIR], other_phases=[MERGE])
 @spec_test
 @with_state
 @with_meta_tags(MERGE_FORK_TEST_META_TAGS)
@@ -58,7 +58,7 @@ def test_merge_fork_random_3(spec, phases, state):
     yield from run_fork_test(phases[MERGE], state)
 
 
-@with_phases(phases=[PHASE0], other_phases=[MERGE])
+@with_phases(phases=[ALTAIR], other_phases=[MERGE])
 @spec_test
 @with_state
 @with_meta_tags(MERGE_FORK_TEST_META_TAGS)
@@ -69,7 +69,7 @@ def test_merge_fork_random_duplicate_attestations(spec, phases, state):
     yield from run_fork_test(phases[MERGE], state)
 
 
-@with_phases(phases=[PHASE0], other_phases=[MERGE])
+@with_phases(phases=[ALTAIR], other_phases=[MERGE])
 @spec_test
 @with_state
 @with_meta_tags(MERGE_FORK_TEST_META_TAGS)
@@ -91,7 +91,7 @@ def test_merge_fork_random_mismatched_attestations(spec, phases, state):
     yield from run_fork_test(phases[MERGE], state_0)
 
 
-@with_phases(phases=[PHASE0], other_phases=[MERGE])
+@with_phases(phases=[ALTAIR], other_phases=[MERGE])
 @spec_test
 @with_custom_state(balances_fn=low_balances, threshold_fn=lambda spec: spec.config.EJECTION_BALANCE)
 @with_meta_tags(MERGE_FORK_TEST_META_TAGS)
@@ -100,7 +100,7 @@ def test_merge_fork_random_low_balances(spec, phases, state):
     yield from run_fork_test(phases[MERGE], state)
 
 
-@with_phases(phases=[PHASE0], other_phases=[MERGE])
+@with_phases(phases=[ALTAIR], other_phases=[MERGE])
 @spec_test
 @with_custom_state(balances_fn=misc_balances, threshold_fn=lambda spec: spec.config.EJECTION_BALANCE)
 @with_meta_tags(MERGE_FORK_TEST_META_TAGS)
@@ -109,7 +109,7 @@ def test_merge_fork_random_misc_balances(spec, phases, state):
     yield from run_fork_test(phases[MERGE], state)
 
 
-@with_phases(phases=[PHASE0], other_phases=[MERGE])
+@with_phases(phases=[ALTAIR], other_phases=[MERGE])
 @with_presets([MINIMAL],
               reason="mainnet config leads to larger validator set than limit of public/private keys pre-generated")
 @spec_test


### PR DESCRIPTION
No functional changes to the Merge itself, but extending the Altair specification now that it is in beta and looking stable.

- Update Merge Beacon doc
  - Update type definitions to full (fixes linting error for `state.slot` type, also does not mix common types of different modules)
  - Update extended processing functions to call Altair
- Update Merge genesis state creation
- Update validator and other doc references to previous forks
- Update test utils to handle sequence
- Update `helpers/constants.py`
- Update fork tests to start with Altair state when forking to Merge
- Update `setup.py` to generate code
- Update sharding beacon doc for consistency
