### PR TITLE
Allow same-slot attestations to affect the fork choice

### DIFF
--- a/specs/phase0/fork-choice.md
+++ b/specs/phase0/fork-choice.md
@@ -283,9 +283,8 @@ def validate_on_attestation(store: Store, attestation: Attestation) -> None:
     target_slot = compute_start_slot_at_epoch(target.epoch)
     assert target.root == get_ancestor(store, attestation.data.beacon_block_root, target_slot)
 
-    # Attestations can only affect the fork choice of subsequent slots.
-    # Delay consideration in the fork choice until their slot is in the past.
-    assert get_current_slot(store) >= attestation.data.slot + 1
+    # Attestations can only affect the fork choice of the current and subsequent slots.
+    assert get_current_slot(store) >= attestation.data.slot
 ```
 
 ##### `store_target_checkpoint_state`

--- a/tests/core/pyspec/eth2spec/test/phase0/unittests/fork_choice/test_on_attestation.py
+++ b/tests/core/pyspec/eth2spec/test/phase0/unittests/fork_choice/test_on_attestation.py
@@ -308,7 +308,7 @@ def test_on_attestation_same_slot(spec, state):
     spec.on_block(store, signed_block)
 
     attestation = get_valid_attestation(spec, state, slot=block.slot, signed=True)
-    run_on_attestation(spec, state, store, attestation, False)
+    run_on_attestation(spec, state, store, attestation, True)
 
 
 @with_all_phases


### PR DESCRIPTION
## Problem
The fork choice rule does not consider attestations from the same slot. Apart from the fact that some attacks may benefit from this, it's unclear why the fork choice rule should not consider same-slot attestations. 

An attacker may strategically release attestations from previous slots in such a way that it could tip over honest attestors from the current slot to vote for a different head of the chain. There may be scenarios where this only works because the fork choice is disregarding attestations from the current slot.

## Proposed solution
Allow attestations from the current slot to be considered by the fork choice.

---
**EDIT:** Read some counterarguments to this PR [in a comment below](https://github.com/ethereum/eth2.0-specs/pull/2534#issuecomment-891736737). Summary: While in optimistic scenarios this PR intuitively makes sense, it seems that in adversarial conditions there may be strong reasons to not consider same-slot attestations. 

---
Special thanks to @adiasg and @barnabemonnot for discussions/help. 