### PR TITLE
Rename the `eth2_*` functions to `eth_*`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ def floorlog2(x: int) -> uint64:
 
 
 OPTIMIZED_BLS_AGGREGATE_PUBKEYS = '''
-def eth2_aggregate_pubkeys(pubkeys: Sequence[BLSPubkey]) -> BLSPubkey:
+def eth_aggregate_pubkeys(pubkeys: Sequence[BLSPubkey]) -> BLSPubkey:
     return bls.AggregatePKs(pubkeys)
 '''
 
@@ -480,8 +480,8 @@ def get_generalized_index(ssz_class: Any, *path: Sequence[PyUnion[int, SSZVariab
 
     @classmethod
     def implement_optimizations(cls, functions: Dict[str, str]) -> Dict[str, str]:
-        if "eth2_aggregate_pubkeys" in functions:
-            functions["eth2_aggregate_pubkeys"] = OPTIMIZED_BLS_AGGREGATE_PUBKEYS.strip()
+        if "eth_aggregate_pubkeys" in functions:
+            functions["eth_aggregate_pubkeys"] = OPTIMIZED_BLS_AGGREGATE_PUBKEYS.strip()
         return super().implement_optimizations(functions)
 
 #

--- a/specs/altair/beacon-chain.md
+++ b/specs/altair/beacon-chain.md
@@ -287,7 +287,7 @@ def get_next_sync_committee(state: BeaconState) -> SyncCommittee:
     """
     indices = get_next_sync_committee_indices(state)
     pubkeys = [state.validators[index].pubkey for index in indices]
-    aggregate_pubkey = eth2_aggregate_pubkeys(pubkeys)
+    aggregate_pubkey = eth_aggregate_pubkeys(pubkeys)
     return SyncCommittee(pubkeys=pubkeys, aggregate_pubkey=aggregate_pubkey)
 ```
 
@@ -544,7 +544,7 @@ def process_sync_aggregate(state: BeaconState, sync_aggregate: SyncAggregate) ->
     previous_slot = max(state.slot, Slot(1)) - Slot(1)
     domain = get_domain(state, DOMAIN_SYNC_COMMITTEE, compute_epoch_at_slot(previous_slot))
     signing_root = compute_signing_root(get_block_root_at_slot(state, previous_slot), domain)
-    assert eth2_fast_aggregate_verify(participant_pubkeys, signing_root, sync_aggregate.sync_committee_signature)
+    assert eth_fast_aggregate_verify(participant_pubkeys, signing_root, sync_aggregate.sync_committee_signature)
 
     # Compute participant and proposer rewards
     total_active_increments = get_total_active_balance(state) // EFFECTIVE_BALANCE_INCREMENT

--- a/specs/altair/bls.md
+++ b/specs/altair/bls.md
@@ -9,8 +9,8 @@
 - [Introduction](#introduction)
 - [Constants](#constants)
 - [Extensions](#extensions)
-  - [`eth2_aggregate_pubkeys`](#eth2_aggregate_pubkeys)
-  - [`eth2_fast_aggregate_verify`](#eth2_fast_aggregate_verify)
+  - [`eth_aggregate_pubkeys`](#eth_aggregate_pubkeys)
+  - [`eth_fast_aggregate_verify`](#eth_fast_aggregate_verify)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- /TOC -->
@@ -29,14 +29,14 @@ Knowledge of the [phase 0 specification](../phase0/beacon-chain.md) is assumed, 
 
 ## Extensions
 
-### `eth2_aggregate_pubkeys`
+### `eth_aggregate_pubkeys`
 
 An additional function `AggregatePKs` is defined to extend the
 [IETF BLS signature draft standard v4](https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-04)
 spec referenced in the phase 0 document.
 
 ```python
-def eth2_aggregate_pubkeys(pubkeys: Sequence[BLSPubkey]) -> BLSPubkey:
+def eth_aggregate_pubkeys(pubkeys: Sequence[BLSPubkey]) -> BLSPubkey:
     """
     Return the aggregate public key for the public keys in ``pubkeys``.
 
@@ -52,10 +52,10 @@ def eth2_aggregate_pubkeys(pubkeys: Sequence[BLSPubkey]) -> BLSPubkey:
     return result
 ```
 
-### `eth2_fast_aggregate_verify`
+### `eth_fast_aggregate_verify`
 
 ```python
-def eth2_fast_aggregate_verify(pubkeys: Sequence[BLSPubkey], message: Bytes32, signature: BLSSignature) -> bool:
+def eth_fast_aggregate_verify(pubkeys: Sequence[BLSPubkey], message: Bytes32, signature: BLSSignature) -> bool:
     """
     Wrapper to ``bls.FastAggregateVerify`` accepting the ``G2_POINT_AT_INFINITY`` signature when ``pubkeys`` is empty.
     """


### PR DESCRIPTION
Reasons:
- More concise
- Once Eth1+Eth2 merged, using `eth2` may be confusing.