### PR TITLE
Extend base_fee_per_gas type to uint256

### DIFF
--- a/specs/merge/beacon-chain.md
+++ b/specs/merge/beacon-chain.md
@@ -65,7 +65,7 @@ This patch adds transaction execution to the beacon chain as part of the Merge f
 | `BYTES_PER_LOGS_BLOOM` | `uint64(2**8)` (= 256) |
 | `GAS_LIMIT_DENOMINATOR` | `uint64(2**10)` (= 1,024) |
 | `MIN_GAS_LIMIT` | `uint64(5000)` (= 5,000) |
-| `BASE_FEE_MAX_CHANGE_DENOMINATOR` | `uint64(2**3)` (= 8) |
+| `BASE_FEE_MAX_CHANGE_DENOMINATOR` | `uint256(2**3)` (= 8) |
 | `ELASTICITY_MULTIPLIER` | `uint64(2**1)` (= 2) |
 
 ## Configuration
@@ -77,7 +77,7 @@ This patch adds transaction execution to the beacon chain as part of the Merge f
 | Name | Value |
 | - | - |
 | `GENESIS_GAS_LIMIT` | `uint64(30000000)` (= 30,000,000) |
-| `GENESIS_BASE_FEE_PER_GAS` | `uint64(1000000000)` (= 1,000,000,000) |
+| `GENESIS_BASE_FEE_PER_GAS` | `uint256(1000000000)` (= 1,000,000,000) |
 
 ## Containers
 
@@ -160,7 +160,7 @@ class ExecutionPayload(Container):
     gas_limit: uint64
     gas_used: uint64
     timestamp: uint64
-    base_fee_per_gas: uint64  # base fee introduced in EIP-1559
+    base_fee_per_gas: uint256  # base fee introduced in EIP-1559
     # Extra payload fields
     block_hash: Hash32  # Hash of execution block
     transactions: List[Transaction, MAX_TRANSACTIONS_PER_PAYLOAD]
@@ -181,7 +181,7 @@ class ExecutionPayloadHeader(Container):
     gas_limit: uint64
     gas_used: uint64
     timestamp: uint64
-    base_fee_per_gas: uint64
+    base_fee_per_gas: uint256
     # Extra payload fields
     block_hash: Hash32  # Hash of execution block
     transactions_root: Root
@@ -286,10 +286,10 @@ def is_valid_gas_limit(payload: ExecutionPayload, parent: ExecutionPayloadHeader
 #### `compute_base_fee_per_gas`
 
 ```python
-def compute_base_fee_per_gas(payload: ExecutionPayload, parent: ExecutionPayloadHeader) -> uint64:
-    parent_gas_target = parent.gas_limit // ELASTICITY_MULTIPLIER
+def compute_base_fee_per_gas(payload: ExecutionPayload, parent: ExecutionPayloadHeader) -> uint256:
+    parent_gas_target = uint256(parent.gas_limit // ELASTICITY_MULTIPLIER)
     parent_base_fee_per_gas = parent.base_fee_per_gas
-    parent_gas_used = payload.gas_used
+    parent_gas_used = uint256(payload.gas_used)
 
     if parent_gas_used == parent_gas_target:
         return parent_base_fee_per_gas

--- a/tests/core/pyspec/eth2spec/test/helpers/execution_payload.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/execution_payload.py
@@ -20,7 +20,7 @@ def build_empty_execution_payload(spec, state, randao_mix=None):
         gas_limit=latest.gas_limit,  # retain same limit
         gas_used=0,  # empty block, 0 gas
         timestamp=timestamp,
-        base_fee_per_gas=spec.uint64(0),
+        base_fee_per_gas=spec.uint256(0),
         block_hash=spec.Hash32(),
         transactions=empty_txs,
     )


### PR DESCRIPTION
As it's been well spotted by @protolambda `base_fee_per_gas: uint64` is prone to overflow. Suppose `base_fee_per_gas = 32 Gwei`, miners will need to produce full blocks for ~150 in a row to overflow this value and eventually brick the Merge.

Thus, data structures, constants and arithmetics is update to use extended `uint256` type for `base_fee_per_gas`.

**UPD**
This attack requires `924,730 ETH` to be burned which is of the very high cost taking current ETH price. If the starting point of `base_fee_per_gas = 1024 Gwei` then the cost drops to `81,947 ETH`.