### PR TITLE
Change base_fee_per_gas type to Bytes32

### DIFF
--- a/specs/merge/beacon-chain.md
+++ b/specs/merge/beacon-chain.md
@@ -74,7 +74,7 @@ This patch adds transaction execution to the beacon chain as part of the Merge f
 | Name | Value |
 | - | - |
 | `GENESIS_GAS_LIMIT` | `uint64(30000000)` (= 30,000,000) |
-| `GENESIS_BASE_FEE_PER_GAS` | `Bytes32('0x000000000000000000000000000000000000000000000000000000003b9aca00')` (= 1,000,000,000) |
+| `GENESIS_BASE_FEE_PER_GAS` | `Bytes32('0x00ca9a3b00000000000000000000000000000000000000000000000000000000')` (= 1,000,000,000) |
 
 ## Containers
 
@@ -144,6 +144,8 @@ class BeaconState(Container):
 
 #### `ExecutionPayload`
 
+*Note*: The `base_fee_per_gas` field is serialized in little-endian.
+
 ```python
 class ExecutionPayload(Container):
     # Execution block header fields
@@ -157,7 +159,7 @@ class ExecutionPayload(Container):
     gas_limit: uint64
     gas_used: uint64
     timestamp: uint64
-    base_fee_per_gas: Bytes32  # base fee introduced in EIP-1559
+    base_fee_per_gas: Bytes32  # base fee introduced in EIP-1559, little-endian serialized
     # Extra payload fields
     block_hash: Hash32  # Hash of execution block
     transactions: List[Transaction, MAX_TRANSACTIONS_PER_PAYLOAD]

--- a/tests/core/pyspec/eth2spec/test/helpers/execution_payload.py
+++ b/tests/core/pyspec/eth2spec/test/helpers/execution_payload.py
@@ -20,11 +20,10 @@ def build_empty_execution_payload(spec, state, randao_mix=None):
         gas_limit=latest.gas_limit,  # retain same limit
         gas_used=0,  # empty block, 0 gas
         timestamp=timestamp,
-        base_fee_per_gas=spec.uint64(0),
+        base_fee_per_gas=latest.base_fee_per_gas,  # retain same base_fee
         block_hash=spec.Hash32(),
         transactions=empty_txs,
     )
-    payload.base_fee_per_gas = spec.compute_base_fee_per_gas(payload, latest)
     # TODO: real RLP + block hash logic would be nice, requires RLP and keccak256 dependency however.
     payload.block_hash = spec.Hash32(spec.hash(payload.hash_tree_root() + b"FAKE RLP HASH"))
 


### PR DESCRIPTION
A solution alternative to https://github.com/ethereum/eth2.0-specs/pull/2548

What's done:
- `base_fee_per_gas` type changed to `Bytes32`
- `base_fee_per_gas` validation and related computations are removed from the beacon chain
